### PR TITLE
[DB-9-8] Implement writes, events and bytes metrics.

### DIFF
--- a/src/EventStore.Core.Tests/Services/RequestManagement/Service/RequestManagerServiceSpecification.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/Service/RequestManagerServiceSpecification.cs
@@ -45,7 +45,8 @@ namespace EventStore.Core.Tests.Services.RequestManagement.Service {
 				Dispatcher,
 				TimeSpan.FromSeconds(2),
 				TimeSpan.FromSeconds(2),
-				explicitTransactionsSupported: true);
+				explicitTransactionsSupported: true,
+				new WritesTracker.NoOp());
 			Dispatcher.Subscribe<ClientMessage.WriteEvents>(Service);
 			Dispatcher.Subscribe<StorageMessage.PrepareAck>(Service);
 			Dispatcher.Subscribe<StorageMessage.InvalidTransaction>(Service);
@@ -68,7 +69,7 @@ namespace EventStore.Core.Tests.Services.RequestManagement.Service {
 			Publisher.Messages.Clear();
 
 			Dispatcher.Publish(When());
-			
+
 		}
 
 
@@ -91,10 +92,10 @@ namespace EventStore.Core.Tests.Services.RequestManagement.Service {
 				LogPosition += 100;
 			}
 			Dispatcher.Publish(new StorageMessage.CommitIndexed(
-									message.CorrelationId, 
-									LogPosition, 
+									message.CorrelationId,
+									LogPosition,
 									transactionPosition,
-									0, 
+									0,
 									message.Events.Length));
 		}
 

--- a/src/EventStore.Core.XUnit.Tests/Services/VNode/WritesTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/VNode/WritesTrackerTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Metrics;
+using EventStore.Core.Services.RequestManager;
+using EventStore.Core.Services.UserManagement;
+using EventStore.Core.XUnit.Tests.Metrics;
+using Xunit;
+
+namespace EventStore.Core.TransactionLog.Services.VNode;
+
+public class WritesTrackerTests : IDisposable {
+	private readonly TestMeterListener<long> _listener;
+	private readonly WritesTracker _sut;
+	private readonly CounterMetric _writtenBytes;
+	private readonly CounterMetric _writtenEvents;
+	private readonly CounterMetric _writes;
+
+	public WritesTrackerTests() {
+		var meter = new Meter($"{typeof(WritesTrackerTests)}");
+		_listener = new TestMeterListener<long>(meter);
+		_writes = new CounterMetric(meter, "eventstore", "writes");
+		_writtenBytes = new CounterMetric(meter, "eventstore", "bytes");
+		_writtenEvents = new CounterMetric(meter, "eventstore", "events");
+
+		_sut = new WritesTracker(new CounterSubMetric(_writtenBytes, []), new CounterSubMetric(_writtenEvents, []),
+			new CounterSubMetric(_writes, []));
+	}
+
+	public void Dispose() {
+		_listener?.Dispose();
+	}
+
+	[Fact]
+	public void can_track() {
+		var data = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7 };
+		var metadata = new byte[] { 0, 1, 2 };
+		var events = new List<Event> {
+			new(Guid.NewGuid(), "foobar", false, data, metadata),
+			new(Guid.NewGuid(), "foobar", false, data, metadata),
+			new(Guid.NewGuid(), "foobar", false, data, metadata)
+		};
+
+		var message = new ClientMessage.WriteEvents(Guid.NewGuid(), Guid.NewGuid(), new CallbackEnvelope(_ => { }),
+			true, "toto", 42, events.ToArray(), SystemAccounts.System);
+
+		_sut.OnWrite(message);
+		AssertMeasurements(writes: 1, events: 3, bytes: (data.Length + metadata.Length) * 3);
+	}
+
+	private void AssertMeasurements(long writes, long events, long bytes) {
+		_listener.Observe();
+		var writesMeasurements = _listener.RetrieveMeasurements("eventstore-writes");
+		var eventsMeasurements = _listener.RetrieveMeasurements("eventstore-events");
+		var bytesMeasurements = _listener.RetrieveMeasurements("eventstore-bytes");
+
+		Assert.Equal(writes, writesMeasurements[0].Value);
+		Assert.Equal(events, eventsMeasurements[0].Value);
+		Assert.Equal(bytes, bytesMeasurements[0].Value);
+	}
+}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1091,7 +1091,8 @@ namespace EventStore.Core {
 				_mainQueue,
 				TimeSpan.FromMilliseconds(options.Database.PrepareTimeoutMs),
 				TimeSpan.FromMilliseconds(options.Database.CommitTimeoutMs),
-				logFormat.SupportsExplicitTransactions);
+				logFormat.SupportsExplicitTransactions,
+				trackers.WritesTracker);
 
 			_mainBus.Subscribe<SystemMessage.SystemInit>(requestManagement);
 			_mainBus.Subscribe<SystemMessage.StateChangeMessage>(requestManagement);

--- a/src/EventStore.Core/Services/RequestManager/WritesTracker.cs
+++ b/src/EventStore.Core/Services/RequestManager/WritesTracker.cs
@@ -1,0 +1,35 @@
+﻿using System.Linq;
+using EventStore.Core.Messages;
+using EventStore.Core.Metrics;
+using EventStore.Core.Services.Storage;
+
+namespace EventStore.Core.Services.RequestManager;
+
+public class WritesTracker : IWritesTracker {
+	private readonly CounterSubMetric _writtenBytes;
+	private readonly CounterSubMetric _writtenEvents;
+	private readonly CounterSubMetric _writes;
+
+	public WritesTracker(
+		CounterSubMetric writtenBytes,
+		CounterSubMetric writtenEvents,
+		CounterSubMetric writes) {
+
+		_writtenBytes = writtenBytes;
+		_writtenEvents = writtenEvents;
+		_writes = writes;
+	}
+
+	public void OnWrite(ClientMessage.WriteEvents msg) {
+		_writes.Add(1);
+		_writtenEvents.Add(msg.Events.Length);
+
+		var count = msg.Events.Sum(@event => @event.Data.Length + @event.Metadata.Length);
+		_writtenBytes.Add(count);
+	}
+
+	public class NoOp : IWritesTracker {
+		public void OnWrite(ClientMessage.WriteEvents msg) {
+		}
+	}
+}

--- a/src/EventStore.Core/Services/Storage/IWritesTracker.cs
+++ b/src/EventStore.Core/Services/Storage/IWritesTracker.cs
@@ -1,0 +1,7 @@
+﻿using EventStore.Core.Messages;
+
+namespace EventStore.Core.Services.Storage;
+
+public interface IWritesTracker {
+	void OnWrite(ClientMessage.WriteEvents msg);
+}


### PR DESCRIPTION
Added: Implement writes, events and bytes metrics.

A better commit message would be that PR is tracking how many append stream commands, events and bytes the current leader of the cluster is dealing with.