### PR TITLE
Add Seq to Serilog and upgraded logging packages

### DIFF
--- a/src/EventStore.BufferManagement/EventStore.BufferManagement.csproj
+++ b/src/EventStore.BufferManagement/EventStore.BufferManagement.csproj
@@ -3,6 +3,6 @@
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 	</PropertyGroup>
 	<ItemGroup>
-	  <PackageReference Include="Serilog" Version="4.0.1" />
+	  <PackageReference Include="Serilog" Version="4.1.0" />
 	</ItemGroup>
 </Project>

--- a/src/EventStore.Common/EventStore.Common.csproj
+++ b/src/EventStore.Common/EventStore.Common.csproj
@@ -17,15 +17,18 @@
 		<PackageReference Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 
-		<PackageReference Include="Serilog" Version="4.0.1" />
+		<PackageReference Include="Serilog" Version="4.1.0" />
+		<PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
 		<PackageReference Include="Serilog.Enrichers.Process" Version="3.0.0" />
 		<PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
 		<PackageReference Include="Serilog.Expressions" Version="5.0.0" />
 		<PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
-		<PackageReference Include="Serilog.Settings.Configuration" Version="8.0.2" />
-		<PackageReference Include="Serilog.Sinks.Async" Version="2.0.0" />
+		<PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
+		<PackageReference Include="Serilog.Settings.Configuration" Version="8.0.4" />
+		<PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
 		<PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+		<PackageReference Include="Serilog.Sinks.Seq" Version="8.0.0" />
 
 		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/src/EventStore.Core/Log/EventStoreLoggerConfiguration.cs
+++ b/src/EventStore.Core/Log/EventStoreLoggerConfiguration.cs
@@ -37,7 +37,7 @@ public class EventStoreLoggerConfiguration {
 	private static readonly SerilogEventListener EventListener;
 
 	private static int Initialized;
-	private static LoggingLevelSwitch _defaultLogLevelSwitch;
+	private static LoggingLevelSwitch _defaultLogLevelSwitch = new(LogEventLevel.Debug);
 	private static object _defaultLogLevelSwitchLock = new object();
 
 	private readonly string _logsDirectory;
@@ -207,6 +207,7 @@ public class EventStoreLoggerConfiguration {
 			.Enrich.WithProperty(Constants.SourceContextPropertyName, "EventStore")
 			.Enrich.WithProcessId()
 			.Enrich.WithThreadId()
+            .Enrich.WithMachineName()
 			.Enrich.FromLogContext();
 
 

--- a/src/EventStore.Licensing/EventStore.Licensing.csproj
+++ b/src/EventStore.Licensing/EventStore.Licensing.csproj
@@ -12,7 +12,7 @@
 	<ItemGroup>
 		<PackageReference Include="EventStore.Plugins" Version="24.10.6" />
 		<PackageReference Include="RestSharp" Version="112.0.0" />
-		<PackageReference Include="Serilog" Version="4.0.1" />
+		<PackageReference Include="Serilog" Version="4.1.0" />
 	</ItemGroup>
 
 </Project>

--- a/src/EventStore.SystemRuntime/EventStore.SystemRuntime.csproj
+++ b/src/EventStore.SystemRuntime/EventStore.SystemRuntime.csproj
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
-	  <PackageReference Include="Serilog" Version="4.0.1" />
+	  <PackageReference Include="Serilog" Version="4.1.0" />
 	  <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="8.0.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
Changed: Upgraded Serilog to version 4.1.0 across various projects. 
Changed: Added MachineName enricher and updated additional Serilog dependencies in EventStore.Common.
Changed: Initialized LoggingLevelSwitch with Debug level in EventStoreLoggerConfiguration to avoid exception when log level is not Default.