### PR TITLE
[KDB-773] Metrics do not report faulted system projection correctly

### DIFF
--- a/src/KurrentDB.Projections.Core.Tests/Services/projection_metrics/A_Projection.cs
+++ b/src/KurrentDB.Projections.Core.Tests/Services/projection_metrics/A_Projection.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using KurrentDB.Core.Data;
+using KurrentDB.Core.Tests;
+using KurrentDB.Projections.Core.Messages;
+using KurrentDB.Projections.Core.Metrics;
+using KurrentDB.Projections.Core.Tests.Services.projections_manager.continuous;
+using NUnit.Framework;
+
+namespace KurrentDB.Projections.Core.Tests.Services.projection_metrics;
+
+public class A_Projection {
+	public class Base<TLogFormat, TStreamId> : a_new_posted_projection.Base<TLogFormat, TStreamId> {
+		private bool noStatsYet = true;
+
+		protected IEnumerable<Measurement<long>> ObservedStatus() {
+			// for some reason, if GetStatistics is called multiple times, then the stats are duplicated;
+			if (noStatsYet) {
+				_manager.Handle(
+					new ProjectionManagementMessage.Command.GetStatistics(_bus, null, _projectionName, false));
+				var s = _consumer.HandledMessages.OfType<ProjectionManagementMessage.Statistics>();
+				_projectionMetricTracker.OnNewStats(s.Single().Projections);
+				noStatsYet = false;
+			}
+
+			return _projectionMetricTracker.ObserveStatus();
+		}
+
+		protected int ObservedRunning() {
+			// for some reason, if GetStatistics is called multiple times, then the stats are duplicated;
+			if (noStatsYet) {
+				_manager.Handle(
+					new ProjectionManagementMessage.Command.GetStatistics(_bus, null, _projectionName, false));
+				var s = _consumer.HandledMessages.OfType<ProjectionManagementMessage.Statistics>();
+				_projectionMetricTracker.OnNewStats(s.Single().Projections);
+				noStatsYet = false;
+			}
+
+			return (int)_projectionMetricTracker.ObserveRunning().Single().Value;
+		}
+
+		protected int ValueOf(IEnumerable<Measurement<long>> measurements, KeyValuePair<string, object> status)
+			=> (int)measurements.ToArray().Single(m => m.Tags.ToArray().Any(t => Equals(t, status))).Value;
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+	public class Stopping<TLogFormat, TStreamId> : Base<TLogFormat, TStreamId> {
+		[Test]
+		public void Has_Correct_Status() {
+			Assert.AreEqual(0, ValueOf(ObservedStatus(), ProjectionTracker.StatusRunning), "Status Running");
+			Assert.AreEqual(0, ValueOf(ObservedStatus(), ProjectionTracker.StatusFaulted), "Status Faulted");
+			Assert.AreEqual(1, ValueOf(ObservedStatus(), ProjectionTracker.StatusStopped), "Status Stopped");
+		}
+
+		[Test]
+		public void Has_Correct_Running() {
+			Assert.AreEqual(0, ObservedRunning(), "Observed  Running");
+		}
+
+		protected override IEnumerable<WhenStep> When() {
+			foreach (var m in base.When()) yield return m;
+			yield return
+				new ProjectionManagementMessage.Command.Disable(
+					_bus,
+					_projectionName,
+					ProjectionManagementMessage.RunAs.System
+				);
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+	public class Faulted<TLogFormat, TStreamId> : Base<TLogFormat, TStreamId> {
+
+		[Test]
+		public void Has_Correct_Status() {
+			Assert.AreEqual(0, ValueOf(ObservedStatus(), ProjectionTracker.StatusRunning), "Status Running");
+			Assert.AreEqual(1, ValueOf(ObservedStatus(), ProjectionTracker.StatusFaulted), "Status Faulted");
+			Assert.AreEqual(0, ValueOf(ObservedStatus(), ProjectionTracker.StatusStopped), "Status Stopped");
+		}
+
+		[Test]
+		public void Has_Correct_Running() {
+			Assert.AreEqual(0, ObservedRunning(), "Observed  Running");
+		}
+
+		protected override IEnumerable<WhenStep> When() {
+			foreach (var m in base.When()) yield return m;
+			var readerAssignedMessage = _consumer.HandledMessages
+				.OfType<EventReaderSubscriptionMessage.ReaderAssignedReader>()
+				.LastOrDefault();
+			Assert.IsNotNull(readerAssignedMessage);
+			var reader = readerAssignedMessage.ReaderId;
+
+			yield return
+				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+					reader, new TFPos(100, 50), new TFPos(100, 50), "stream", 1, "stream", 1, false, Guid.NewGuid(),
+					"fail", false, new byte[0], new byte[0], 100, 33.3f);
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+	public class Running<TLogFormat, TStreamId> : Base<TLogFormat, TStreamId> {
+
+		[Test]
+		public void Has_Correct_Status() {
+			Assert.AreEqual(1, ValueOf(ObservedStatus(), ProjectionTracker.StatusRunning), "Status Running");
+			Assert.AreEqual(0, ValueOf(ObservedStatus(), ProjectionTracker.StatusFaulted), "Status Faulted");
+			Assert.AreEqual(0, ValueOf(ObservedStatus(), ProjectionTracker.StatusStopped), "Status Stopped");
+		}
+
+		[Test]
+		public void Has_Correct_Running() {
+			Assert.AreEqual(1, ObservedRunning(), "Observed  Running");
+		}
+
+		protected override IEnumerable<WhenStep> When() {
+			foreach (var m in base.When())
+				yield return m;
+			var readerAssignedMessage =
+				_consumer.HandledMessages.OfType<EventReaderSubscriptionMessage.ReaderAssignedReader>()
+					.LastOrDefault();
+			Assert.IsNotNull(readerAssignedMessage);
+			var reader = readerAssignedMessage.ReaderId;
+
+			yield return
+				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+					reader, new TFPos(100, 50), new TFPos(100, 50), "stream", 1, "stream", 1, false,
+					Guid.NewGuid(), "type", false, new byte[0], new byte[0], 100, 33.3f);
+		}
+	}
+}

--- a/src/KurrentDB.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
+++ b/src/KurrentDB.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
@@ -61,6 +61,7 @@ public abstract class TestFixtureWithProjectionCoreAndManagementServices<TLogFor
 	private bool _initializeSystemProjections;
 	protected Tuple<SynchronousScheduler, IPublisher, SynchronousScheduler, Guid>[] _processingQueues;
 	private ProjectionCoreCoordinator _coordinator;
+	protected readonly ProjectionTracker _projectionMetricTracker= new();
 
 	protected override void Given1() {
 		base.Given1();
@@ -87,6 +88,7 @@ public abstract class TestFixtureWithProjectionCoreAndManagementServices<TLogFor
 		_processingQueues = GivenProcessingQueues();
 		var queues = _processingQueues.ToDictionary(v => v.Item4, v => v.Item1.As<IPublisher>());
 		_managerMessageDispatcher = new ProjectionManagerMessageDispatcher(queues);
+
 		_manager = new ProjectionManager(
 			GetInputQueue(),
 			GetInputQueue(),
@@ -95,7 +97,7 @@ public abstract class TestFixtureWithProjectionCoreAndManagementServices<TLogFor
 			ProjectionType.All,
 			_ioDispatcher,
 			TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
-			IProjectionTracker.NoOp,
+			_projectionMetricTracker,
 			_initializeSystemProjections);
 
 		_coordinator = new ProjectionCoreCoordinator(

--- a/src/KurrentDB.Projections.Core.XUnit.Tests/Metrics/ProjectionMetricsTests.cs
+++ b/src/KurrentDB.Projections.Core.XUnit.Tests/Metrics/ProjectionMetricsTests.cs
@@ -5,7 +5,6 @@ using System.Diagnostics.Metrics;
 using KurrentDB.Projections.Core.Metrics;
 using KurrentDB.Projections.Core.Services;
 using KurrentDB.Projections.Core.Services.Management;
-using KurrentDB.Projections.Core.Services.Processing;
 using Xunit;
 
 namespace KurrentDB.Projections.Core.XUnit.Tests.Metrics;
@@ -14,28 +13,28 @@ public class ProjectionMetricsTests {
 	private readonly ProjectionTracker _sut = new();
 
 	public ProjectionMetricsTests() {
-		_sut.OnNewStats([Stat("TestProjection", ProjectionMode.Continuous, CoreProjection.State.Running)]);
+		_sut.OnNewStats([Stat("TestProjection", ProjectionMode.Continuous, ManagedProjectionState.Running)]);
 	}
 
 	[Fact]
 	public void ObserveEventsProcessed() {
 		var measurements = _sut.ObserveEventsProcessed();
 		var measurement = Assert.Single(measurements);
-		AssertMeasurement(50L, ("projection", "TestProjection"))(measurement);
+		AssertMeasurement(50L, new KeyValuePair<string, object>("projection", "TestProjection"))(measurement);
 	}
 
 	[Fact]
 	public void ObserveRunning() {
 		var measurements = _sut.ObserveRunning();
 		var measurement = Assert.Single(measurements);
-		AssertMeasurement(1L, ("projection", "TestProjection"))(measurement);
+		AssertMeasurement(1L, new KeyValuePair<string, object>("projection", "TestProjection"))(measurement);
 	}
 
 	[Fact]
 	public void ObserveProgress() {
 		var measurements = _sut.ObserveProgress();
 		var measurement = Assert.Single(measurements);
-		AssertMeasurement(0.75f, ("projection", "TestProjection"))(measurement);
+		AssertMeasurement(0.75f, new KeyValuePair<string, object>("projection", "TestProjection"))(measurement);
 	}
 
 
@@ -44,61 +43,69 @@ public class ProjectionMetricsTests {
 	public void ObservedStatuses(StatusCombination combo) {
 		_sut.OnNewStats([Stat(combo.Projection, ProjectionMode.Continuous, combo.WhenObservedStateIs)]);
 		var measurements = _sut.ObserveStatus();
+		var prj = new KeyValuePair<string, object>("projection", combo.Projection);
 		Assert.Collection(measurements,
-			AssertMeasurement(combo.ThenRunningIs, ("projection", combo.Projection), ("status", "Running")),
-			AssertMeasurement(combo.ThenFaultedIs, ("projection", combo.Projection), ("status", "Faulted")),
-			AssertMeasurement(combo.ThenStoppedIs, ("projection", combo.Projection), ("status", "Stopped"))
+			AssertMeasurement(combo.ThenRunningIs, prj, ProjectionTracker.StatusRunning),
+			AssertMeasurement(combo.ThenFaultedIs, prj, ProjectionTracker.StatusFaulted),
+			AssertMeasurement(combo.ThenStoppedIs, prj, ProjectionTracker.StatusStopped)
 		);
 	}
 
 
 
-	static Action<Measurement<T>> AssertMeasurement<T>(
-		T expectedValue, params (string, string?)[] tags) where T : struct =>
+	static Action<Measurement<T>> AssertMeasurement<T>(T expectedValue, params KeyValuePair<string, object>[] tags)
+		where T : struct =>
 
 		actualMeasurement => {
 			Assert.Equal(expectedValue, actualMeasurement.Value);
 			if (actualMeasurement.Tags == null) return;
-			Assert.Equal(
-				tags,
-				actualMeasurement.Tags.ToArray().Select(tag => (tag.Key, tag.Value as string)));
+			var actualTags = actualMeasurement.Tags.ToArray();
+			Assert.Equal(tags, actualTags!, (a, b) => a.Key == b.Key && a.Value.Equals(b.Value));
 		};
 
 
-	public record StatusCombination (string Projection, CoreProjection.State WhenObservedStateIs, long ThenRunningIs, long ThenFaultedIs, long ThenStoppedIs);
+	public record StatusCombination(
+		string Projection,
+		ManagedProjectionState WhenObservedStateIs,
+		long ThenRunningIs,
+		long ThenFaultedIs,
+		long ThenStoppedIs);
 
 	public static IEnumerable<object[]> AllStatuses() {
 
-		foreach (var state in Enum.GetValues<CoreProjection.State>()) {
+		foreach (var state in Enum.GetValues<ManagedProjectionState>()) {
 			var projectionName = $"Test-{state}";
 			switch (state) {
-				case CoreProjection.State.Running:
-					yield return [new StatusCombination(projectionName,state, 1, 0, 0)];
-					continue;
-				case CoreProjection.State.Faulted:
-					yield return [new StatusCombination(projectionName,state, 0, 1, 0)];
-					continue;
-				case CoreProjection.State.Stopped:
-					yield return [new StatusCombination(projectionName, state, 0, 0, 1)];
-					continue;
-
-				case CoreProjection.State.Initial:
-				case CoreProjection.State.LoadStateRequested:
-				case CoreProjection.State.StateLoaded:
-				case CoreProjection.State.Subscribed:
-				case CoreProjection.State.Stopping:
-				case CoreProjection.State.FaultedStopping:
-				case CoreProjection.State.CompletingPhase:
-				case CoreProjection.State.PhaseCompleted:
-				case CoreProjection.State.Suspended:
-				default:
+				case ManagedProjectionState.Creating:
+				case ManagedProjectionState.Loading:
+				case ManagedProjectionState.Loaded:
+				case ManagedProjectionState.Preparing:
+				case ManagedProjectionState.Prepared:
+				case ManagedProjectionState.Starting:
+				case ManagedProjectionState.LoadingStopped:
+				case ManagedProjectionState.Stopping:
+				case ManagedProjectionState.Completed:
+				case ManagedProjectionState.Aborted:
+				case ManagedProjectionState.Deleting:
+				case ManagedProjectionState.Aborting:
 					yield return [new StatusCombination(projectionName, state, 0, 0, 0)];
 					break;
+				case ManagedProjectionState.Running:
+					yield return [new StatusCombination(projectionName, state, 1, 0, 0)];
+					break;
+				case ManagedProjectionState.Stopped:
+					yield return [new StatusCombination(projectionName, state, 0, 0, 1)];
+					break;
+				case ManagedProjectionState.Faulted:
+					yield return [new StatusCombination(projectionName, state, 0, 1, 0)];
+					break;
+				default:
+					throw new ArgumentOutOfRangeException();
 			}
 		}
 	}
 
-	static ProjectionStatistics Stat(string name, ProjectionMode mode, CoreProjection.State state) =>
+	private static ProjectionStatistics Stat(string name, ProjectionMode mode, ManagedProjectionState state) =>
 		new() {
 			Name = name,
 			ProjectionId = 1234,
@@ -109,5 +116,4 @@ public class ProjectionMetricsTests {
 			Progress = 75,
 			EventsProcessedAfterRestart = 50,
 		};
-
 }

--- a/src/KurrentDB.Projections.Core/Metrics/ProjectionTracker.cs
+++ b/src/KurrentDB.Projections.Core/Metrics/ProjectionTracker.cs
@@ -41,7 +41,7 @@ public class ProjectionTracker : IProjectionTracker {
 
 	public IEnumerable<Measurement<long>> ObserveRunning() =>
 		_currentStats.Select(x => {
-			var projectionRunning = x.Status.Equals("running", StringComparison.CurrentCultureIgnoreCase)
+			var projectionRunning = x.Status.StartsWith("running", StringComparison.CurrentCultureIgnoreCase)
 				? 1
 				: 0;
 
@@ -52,36 +52,38 @@ public class ProjectionTracker : IProjectionTracker {
 		});
 
 	public IEnumerable<Measurement<long>> ObserveStatus() {
+
 		foreach (var statistics in _currentStats) {
 			var projectionRunning = 0;
 			var projectionFaulted = 0;
 			var projectionStopped = 0;
-
+			// the status in the statistics can be a compound string  passed e.g. "faulted (enabled)"
 			switch (statistics.Status.ToLower()) {
-				case "running":
+				case var s when s.StartsWith("running", StringComparison.CurrentCultureIgnoreCase):
 					projectionRunning = 1;
 					break;
-				case "stopped":
+				case var s when s.StartsWith("stopped", StringComparison.CurrentCultureIgnoreCase):
 					projectionStopped = 1;
 					break;
-				case "faulted":
+				case var s when s.StartsWith("faulted", StringComparison.CurrentCultureIgnoreCase):
 					projectionFaulted = 1;
 					break;
+
 			}
 
 			yield return new(projectionRunning, [
 				new("projection", statistics.Name),
-				new("status", "Running"),
+				StatusRunning
 			]);
 
 			yield return new(projectionFaulted, [
 				new("projection", statistics.Name),
-				new("status", "Faulted"),
+				StatusFaulted
 			]);
 
 			yield return new(projectionStopped, [
 				new("projection", statistics.Name),
-				new("status", "Stopped"),
+				StatusStopped
 			]);
 		}
 	}

--- a/src/KurrentDB.Projections.Core/Metrics/ProjectionTracker.cs
+++ b/src/KurrentDB.Projections.Core/Metrics/ProjectionTracker.cs
@@ -10,6 +10,13 @@ using KurrentDB.Projections.Core.Services;
 namespace KurrentDB.Projections.Core.Metrics;
 
 public class ProjectionTracker : IProjectionTracker {
+
+	public const string Projection = "projection";
+	public static KeyValuePair<string, object> StatusRunning = new("status", "Running");
+	public static KeyValuePair<string, object> StatusFaulted = new("status", "Faulted");
+	public static KeyValuePair<string, object> StatusStopped = new("status", "Stopped");
+
+
 	private ProjectionStatistics[] _currentStats = [];
 
 	public void OnNewStats(ProjectionStatistics[] newStats) {

--- a/src/KurrentDB.Projections.Core/Services/Processing/CoreProjection.cs
+++ b/src/KurrentDB.Projections.Core/Services/Processing/CoreProjection.cs
@@ -25,7 +25,7 @@ public class CoreProjection : IDisposable,
 	IHandle<CoreProjectionManagementMessage.GetState>,
 	IHandle<CoreProjectionManagementMessage.GetResult> {
 	[Flags]
-	public enum State : uint {
+	private enum State : uint {
 		Initial = 0x80000000,
 		LoadStateRequested = 0x2,
 		StateLoaded = 0x4,

--- a/src/KurrentDB.Projections.Core/Services/Processing/CoreProjection.cs
+++ b/src/KurrentDB.Projections.Core/Services/Processing/CoreProjection.cs
@@ -25,7 +25,7 @@ public class CoreProjection : IDisposable,
 	IHandle<CoreProjectionManagementMessage.GetState>,
 	IHandle<CoreProjectionManagementMessage.GetResult> {
 	[Flags]
-	private enum State : uint {
+	public enum State : uint {
 		Initial = 0x80000000,
 		LoadStateRequested = 0x2,
 		StateLoaded = 0x4,


### PR DESCRIPTION
Fixes #5003 the Faulted reported metrics when a projection is in a faulted state is not set 
(also potentially other compound statistics status)

Tests: 
* expanded metrics tests to all projection statuses used by the statisics 
* added end-2-end tests to check all statuses from projection statistics to metrics
  * for some reason 
    * if `GetStatistics` is called multiple times then the stats are duplicated
    *  calling `OnNewStats` needs to be done manually in the test suite


    
  