### PR TITLE
[KDB-781] Upgrade Qodana to 2024.3

### DIFF
--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -22,6 +22,6 @@ jobs:
           fetch-depth: 0  # a full history is required for pull request analysis
           submodules: recursive
       - name: 'Qodana Scan'
-        uses: JetBrains/qodana-action@v2024.1
+        uses: JetBrains/qodana-action@v2024.3
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,6 +1,6 @@
 version: "1.0"
 
-linter: jetbrains/qodana-dotnet:2024.1
+linter: jetbrains/qodana-dotnet:2024.3
 
 dotnet:
   solution: src/KurrentDB.sln


### PR DESCRIPTION
Seems necessary to avoid these report upload errors that we've started getting:

e.g. https://github.com/kurrent-io/KurrentDB/actions/runs/14518579250/job/40733598864?pr=5014 

```
Failed publishing analysis results to qodana cloud
org.jetbrains.qodana.publisher.PublisherException: Can't read response, perhaps you are using wrong url? (make sure you use api url e.g. https://api.qodana.cloud, not https://qodana.cloud)
	at org.jetbrains.qodana.publisher.PublisherException$Companion.from4XX(PublisherException.kt:28)
	at org.jetbrains.qodana.publisher.CloudClient.handleFailure(CloudClient.kt:76)
	at org.jetbrains.qodana.publisher.CloudClient.startUpload(CloudClient.kt:39)
	at org.jetbrains.qodana.publisher.CloudClient$startUpload$1.invokeSuspend(CloudClient.kt)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
	at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:115)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:103)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:584)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:793)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:697)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:684)
```
