### PR TITLE
[KDB-773] Metrics do not report faulted system projection correctly

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/projection_metrics/A_Projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_metrics/A_Projection.cs
@@ -1,0 +1,139 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using EventStore.Core.Data;
+using EventStore.Core.Tests;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Metrics;
+using EventStore.Projections.Core.Tests.Services.projections_manager.continuous;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.projection_metrics;
+
+public class A_Projection {
+	public class Base<TLogFormat, TStreamId> : a_new_posted_projection.Base<TLogFormat, TStreamId> {
+		private bool noStatsYet = true;
+
+		protected IEnumerable<Measurement<long>> ObservedStatus() {
+			// for some reason, if GetStatistics is called multiple times, then the stats are duplicated;
+			if (noStatsYet) {
+				_manager.Handle(
+					new ProjectionManagementMessage.Command.GetStatistics(_bus, null, _projectionName, false));
+				var s = _consumer.HandledMessages.OfType<ProjectionManagementMessage.Statistics>();
+				_projectionMetricTracker.OnNewStats(s.Single().Projections);
+				noStatsYet = false;
+			}
+
+			return _projectionMetricTracker.ObserveStatus();
+		}
+
+		protected int ObservedRunning() {
+			// for some reason, if GetStatistics is called multiple times, then the stats are duplicated;
+			if (noStatsYet) {
+				_manager.Handle(
+					new ProjectionManagementMessage.Command.GetStatistics(_bus, null, _projectionName, false));
+				var s = _consumer.HandledMessages.OfType<ProjectionManagementMessage.Statistics>();
+				_projectionMetricTracker.OnNewStats(s.Single().Projections);
+				noStatsYet = false;
+			}
+
+			return (int)_projectionMetricTracker.ObserveRunning().Single().Value;
+		}
+
+		protected int ValueOf(IEnumerable<Measurement<long>> measurements, KeyValuePair<string, object> status)
+			=> (int)measurements.ToArray().Single(m => m.Tags.ToArray().Any(t => Equals(t, status))).Value;
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+	public class Stopping<TLogFormat, TStreamId> : Base<TLogFormat, TStreamId> {
+		[Test]
+		public void Has_Correct_Status() {
+			Assert.AreEqual(0, ValueOf(ObservedStatus(), ProjectionTracker.StatusRunning), "Status Running");
+			Assert.AreEqual(0, ValueOf(ObservedStatus(), ProjectionTracker.StatusFaulted), "Status Faulted");
+			Assert.AreEqual(1, ValueOf(ObservedStatus(), ProjectionTracker.StatusStopped), "Status Stopped");
+		}
+
+		[Test]
+		public void Has_Correct_Running() {
+			Assert.AreEqual(0, ObservedRunning(), "Observed  Running");
+		}
+
+		protected override IEnumerable<WhenStep> When() {
+			foreach (var m in base.When()) yield return m;
+			yield return
+				new ProjectionManagementMessage.Command.Disable(
+					_bus,
+					_projectionName,
+					ProjectionManagementMessage.RunAs.System
+				);
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+	public class Faulted<TLogFormat, TStreamId> : Base<TLogFormat, TStreamId> {
+
+		[Test]
+		public void Has_Correct_Status() {
+			Assert.AreEqual(0, ValueOf(ObservedStatus(), ProjectionTracker.StatusRunning), "Status Running");
+			Assert.AreEqual(1, ValueOf(ObservedStatus(), ProjectionTracker.StatusFaulted), "Status Faulted");
+			Assert.AreEqual(0, ValueOf(ObservedStatus(), ProjectionTracker.StatusStopped), "Status Stopped");
+		}
+
+		[Test]
+		public void Has_Correct_Running() {
+			Assert.AreEqual(0, ObservedRunning(), "Observed  Running");
+		}
+
+		protected override IEnumerable<WhenStep> When() {
+			foreach (var m in base.When()) yield return m;
+			var readerAssignedMessage = _consumer.HandledMessages
+				.OfType<EventReaderSubscriptionMessage.ReaderAssignedReader>()
+				.LastOrDefault();
+			Assert.IsNotNull(readerAssignedMessage);
+			var reader = readerAssignedMessage.ReaderId;
+
+			yield return
+				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+					reader, new TFPos(100, 50), new TFPos(100, 50), "stream", 1, "stream", 1, false, Guid.NewGuid(),
+					"fail", false, new byte[0], new byte[0], 100, 33.3f);
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+	public class Running<TLogFormat, TStreamId> : Base<TLogFormat, TStreamId> {
+
+		[Test]
+		public void Has_Correct_Status() {
+			Assert.AreEqual(1, ValueOf(ObservedStatus(), ProjectionTracker.StatusRunning), "Status Running");
+			Assert.AreEqual(0, ValueOf(ObservedStatus(), ProjectionTracker.StatusFaulted), "Status Faulted");
+			Assert.AreEqual(0, ValueOf(ObservedStatus(), ProjectionTracker.StatusStopped), "Status Stopped");
+		}
+
+		[Test]
+		public void Has_Correct_Running() {
+			Assert.AreEqual(1, ObservedRunning(), "Observed  Running");
+		}
+
+		protected override IEnumerable<WhenStep> When() {
+			foreach (var m in base.When())
+				yield return m;
+			var readerAssignedMessage =
+				_consumer.HandledMessages.OfType<EventReaderSubscriptionMessage.ReaderAssignedReader>()
+					.LastOrDefault();
+			Assert.IsNotNull(readerAssignedMessage);
+			var reader = readerAssignedMessage.ReaderId;
+
+			yield return
+				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+					reader, new TFPos(100, 50), new TFPos(100, 50), "stream", 1, "stream", 1, false,
+					Guid.NewGuid(), "type", false, new byte[0], new byte[0], 100, 33.3f);
+		}
+	}
+}

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
@@ -60,6 +60,7 @@ public abstract class TestFixtureWithProjectionCoreAndManagementServices<TLogFor
 	private bool _initializeSystemProjections;
 	protected Tuple<SynchronousScheduler, IPublisher, SynchronousScheduler, Guid>[] _processingQueues;
 	private ProjectionCoreCoordinator _coordinator;
+	protected readonly ProjectionTracker _projectionMetricTracker= new();
 
 	protected override void Given1() {
 		base.Given1();
@@ -86,6 +87,7 @@ public abstract class TestFixtureWithProjectionCoreAndManagementServices<TLogFor
 		_processingQueues = GivenProcessingQueues();
 		var queues = _processingQueues.ToDictionary(v => v.Item4, v => v.Item1.As<IPublisher>());
 		_managerMessageDispatcher = new ProjectionManagerMessageDispatcher(queues);
+
 		_manager = new ProjectionManager(
 			GetInputQueue(),
 			GetInputQueue(),
@@ -94,7 +96,7 @@ public abstract class TestFixtureWithProjectionCoreAndManagementServices<TLogFor
 			ProjectionType.All,
 			_ioDispatcher,
 			TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
-			IProjectionTracker.NoOp,
+			_projectionMetricTracker,
 			_initializeSystemProjections);
 
 		_coordinator = new ProjectionCoreCoordinator(

--- a/src/EventStore.Projections.Core.XUnit.Tests/Metrics/ProjectionMetricsTests.cs
+++ b/src/EventStore.Projections.Core.XUnit.Tests/Metrics/ProjectionMetricsTests.cs
@@ -10,62 +10,110 @@ using Xunit;
 namespace EventStore.Projections.Core.XUnit.Tests.Metrics;
 
 public class ProjectionMetricsTests {
-	readonly ProjectionTracker _sut = new();
+	private readonly ProjectionTracker _sut = new();
 
 	public ProjectionMetricsTests() {
-		_sut.OnNewStats([new() {
-			Name = "TestProjection",
-			ProjectionId = 1234,
-			Epoch = -1,
-			Version = -1,
-			Mode = ProjectionMode.Continuous,
-			Status = "Running",
-			LeaderStatus = ManagedProjectionState.Running,
-			Progress = 75,
-			EventsProcessedAfterRestart = 50,
-		}]);
+		_sut.OnNewStats([Stat("TestProjection", ProjectionMode.Continuous, ManagedProjectionState.Running)]);
 	}
 
 	[Fact]
 	public void ObserveEventsProcessed() {
 		var measurements = _sut.ObserveEventsProcessed();
 		var measurement = Assert.Single(measurements);
-		AssertMeasurement(50L, ("projection", "TestProjection"))(measurement);
+		AssertMeasurement(50L, new KeyValuePair<string, object>("projection", "TestProjection"))(measurement);
 	}
 
 	[Fact]
 	public void ObserveRunning() {
 		var measurements = _sut.ObserveRunning();
 		var measurement = Assert.Single(measurements);
-		AssertMeasurement(1L, ("projection", "TestProjection"))(measurement);
+		AssertMeasurement(1L, new KeyValuePair<string, object>("projection", "TestProjection"))(measurement);
 	}
 
 	[Fact]
 	public void ObserveProgress() {
 		var measurements = _sut.ObserveProgress();
 		var measurement = Assert.Single(measurements);
-		AssertMeasurement(0.75f, ("projection", "TestProjection"))(measurement);
+		AssertMeasurement(0.75f, new KeyValuePair<string, object>("projection", "TestProjection"))(measurement);
 	}
 
-	[Fact]
-	public void ObserveStatus() {
+
+	[Theory]
+	[MemberData(nameof(AllStatuses))]
+	public void ObservedStatuses(StatusCombination combo) {
+		_sut.OnNewStats([Stat(combo.Projection, ProjectionMode.Continuous, combo.WhenObservedStateIs)]);
 		var measurements = _sut.ObserveStatus();
+		var prj = new KeyValuePair<string, object>("projection", combo.Projection);
 		Assert.Collection(measurements,
-			AssertMeasurement(1L, ("projection", "TestProjection"), ("status", "Running")),
-			AssertMeasurement(0L, ("projection", "TestProjection"), ("status", "Faulted")),
-			AssertMeasurement(0L, ("projection", "TestProjection"), ("status", "Stopped")));
+			AssertMeasurement(combo.ThenRunningIs, prj, ProjectionTracker.StatusRunning),
+			AssertMeasurement(combo.ThenFaultedIs, prj, ProjectionTracker.StatusFaulted),
+			AssertMeasurement(combo.ThenStoppedIs, prj, ProjectionTracker.StatusStopped)
+		);
 	}
 
-	static Action<Measurement<T>> AssertMeasurement<T>(
-		T expectedValue, params (string, string?)[] tags) where T : struct =>
+
+
+	static Action<Measurement<T>> AssertMeasurement<T>(T expectedValue, params KeyValuePair<string, object>[] tags)
+		where T : struct =>
 
 		actualMeasurement => {
 			Assert.Equal(expectedValue, actualMeasurement.Value);
-			if (actualMeasurement.Tags == null)
-				return;
+			if (actualMeasurement.Tags == null) return;
+			var actualTags = actualMeasurement.Tags.ToArray();
+			Assert.Equal(tags, actualTags!, (a, b) => a.Key == b.Key && a.Value.Equals(b.Value));
+		};
 
-			Assert.Equal(
-				tags,
-				actualMeasurement.Tags.ToArray().Select(tag => (tag.Key, tag.Value as string)));
+
+	public record StatusCombination(
+		string Projection,
+		ManagedProjectionState WhenObservedStateIs,
+		long ThenRunningIs,
+		long ThenFaultedIs,
+		long ThenStoppedIs);
+
+	public static IEnumerable<object[]> AllStatuses() {
+
+		foreach (var state in Enum.GetValues<ManagedProjectionState>()) {
+			var projectionName = $"Test-{state}";
+			switch (state) {
+				case ManagedProjectionState.Creating:
+				case ManagedProjectionState.Loading:
+				case ManagedProjectionState.Loaded:
+				case ManagedProjectionState.Preparing:
+				case ManagedProjectionState.Prepared:
+				case ManagedProjectionState.Starting:
+				case ManagedProjectionState.LoadingStopped:
+				case ManagedProjectionState.Stopping:
+				case ManagedProjectionState.Completed:
+				case ManagedProjectionState.Aborted:
+				case ManagedProjectionState.Deleting:
+				case ManagedProjectionState.Aborting:
+					yield return [new StatusCombination(projectionName, state, 0, 0, 0)];
+					break;
+				case ManagedProjectionState.Running:
+					yield return [new StatusCombination(projectionName, state, 1, 0, 0)];
+					break;
+				case ManagedProjectionState.Stopped:
+					yield return [new StatusCombination(projectionName, state, 0, 0, 1)];
+					break;
+				case ManagedProjectionState.Faulted:
+					yield return [new StatusCombination(projectionName, state, 0, 1, 0)];
+					break;
+				default:
+					throw new ArgumentOutOfRangeException();
+			}
+		}
+	}
+
+	private static ProjectionStatistics Stat(string name, ProjectionMode mode, ManagedProjectionState state) =>
+		new() {
+			Name = name,
+			ProjectionId = 1234,
+			Epoch = -1,
+			Version = -1,
+			Mode = mode,
+			Status = state.ToString(),
+			Progress = 75,
+			EventsProcessedAfterRestart = 50,
 		};
 }

--- a/src/EventStore.Projections.Core/Metrics/ProjectionTracker.cs
+++ b/src/EventStore.Projections.Core/Metrics/ProjectionTracker.cs
@@ -10,6 +10,13 @@ using EventStore.Projections.Core.Services;
 namespace EventStore.Projections.Core.Metrics;
 
 public class ProjectionTracker : IProjectionTracker {
+
+	public const string Projection = "projection";
+	public static KeyValuePair<string, object> StatusRunning = new("status", "Running");
+	public static KeyValuePair<string, object> StatusFaulted = new("status", "Faulted");
+	public static KeyValuePair<string, object> StatusStopped = new("status", "Stopped");
+
+
 	private ProjectionStatistics[] _currentStats = [];
 
 	public void OnNewStats(ProjectionStatistics[] newStats) {
@@ -34,7 +41,7 @@ public class ProjectionTracker : IProjectionTracker {
 
 	public IEnumerable<Measurement<long>> ObserveRunning() =>
 		_currentStats.Select(x => {
-			var projectionRunning = x.Status.Equals("running", StringComparison.CurrentCultureIgnoreCase)
+			var projectionRunning = x.Status.StartsWith("running", StringComparison.CurrentCultureIgnoreCase)
 				? 1
 				: 0;
 
@@ -45,36 +52,38 @@ public class ProjectionTracker : IProjectionTracker {
 		});
 
 	public IEnumerable<Measurement<long>> ObserveStatus() {
+
 		foreach (var statistics in _currentStats) {
 			var projectionRunning = 0;
 			var projectionFaulted = 0;
 			var projectionStopped = 0;
-
+			// the status in the statistics can be a compound string  passed e.g. "faulted (enabled)"
 			switch (statistics.Status.ToLower()) {
-				case "running":
+				case var s when s.StartsWith("running", StringComparison.CurrentCultureIgnoreCase):
 					projectionRunning = 1;
 					break;
-				case "stopped":
+				case var s when s.StartsWith("stopped", StringComparison.CurrentCultureIgnoreCase):
 					projectionStopped = 1;
 					break;
-				case "faulted":
+				case var s when s.StartsWith("faulted", StringComparison.CurrentCultureIgnoreCase):
 					projectionFaulted = 1;
 					break;
+
 			}
 
 			yield return new(projectionRunning, [
 				new("projection", statistics.Name),
-				new("status", "Running"),
+				StatusRunning
 			]);
 
 			yield return new(projectionFaulted, [
 				new("projection", statistics.Name),
-				new("status", "Faulted"),
+				StatusFaulted
 			]);
 
 			yield return new(projectionStopped, [
 				new("projection", statistics.Name),
-				new("status", "Stopped"),
+				StatusStopped
 			]);
 		}
 	}


### PR DESCRIPTION
Cherry-picks #5012 

* expanded metrics tests to all projection statuses
* added end-2-end tests to check all statuses from projection statistics to metrics

* Fixes the Faulted reported metrics (and potentially other compound statistics status)