### PR TITLE
Update http.md to correct path to HTTP_Connector tutorial

### DIFF
--- a/docs/server/features/connectors/sinks/http.md
+++ b/docs/server/features/connectors/sinks/http.md
@@ -136,4 +136,4 @@ https://api.example.com/TestEvent
 
 ### Tutorial
 
-[Learn how to configure and use a connector using the HTTP Sink in KurrentDB through a tutorial.](/tutorials/http.md)
+[Learn how to configure and use a connector using the HTTP Sink in KurrentDB through a tutorial.](/tutorials/HTTP_Connector.md)


### PR DESCRIPTION
Updated file path based on current 404 when trying to find HTTP tutorial