### PR TITLE
Add checkpoint to `caughtup` and fellbehind` messages (#5013)

### DIFF
--- a/proto.lock
+++ b/proto.lock
@@ -5326,10 +5326,44 @@
             ],
             "messages": [
               {
-                "name": "CaughtUp"
+                "name": "CaughtUp",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "timestamp",
+                    "type": "google.protobuf.Timestamp"
+                  },
+                  {
+                    "id": 2,
+                    "name": "stream_revision",
+                    "type": "int64"
+                  },
+                  {
+                    "id": 3,
+                    "name": "position",
+                    "type": "Position"
+                  }
+                ]
               },
               {
-                "name": "FellBehind"
+                "name": "FellBehind",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "timestamp",
+                    "type": "google.protobuf.Timestamp"
+                  },
+                  {
+                    "id": 2,
+                    "name": "stream_revision",
+                    "type": "int64"
+                  },
+                  {
+                    "id": 3,
+                    "name": "position",
+                    "type": "Position"
+                  }
+                ]
               },
               {
                 "name": "ReadEvent",
@@ -5420,6 +5454,26 @@
               },
               {
                 "name": "Checkpoint",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "commit_position",
+                    "type": "uint64"
+                  },
+                  {
+                    "id": 2,
+                    "name": "prepare_position",
+                    "type": "uint64"
+                  },
+                  {
+                    "id": 3,
+                    "name": "timestamp",
+                    "type": "google.protobuf.Timestamp"
+                  }
+                ]
+              },
+              {
+                "name": "Position",
                 "fields": [
                   {
                     "id": 1,

--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.AllSubscription.CombinationTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.AllSubscription.CombinationTests.cs
@@ -244,18 +244,26 @@ public partial class EnumeratorTests {
 						var evtTfPos = new TFPos(evtPos.CommitPosition, evtPos.PreparePosition);
 						Assert.AreEqual(evtTfPos, evt.EventPosition!.Value);
 						break;
-					case FellBehind:
+					case FellBehind x:
 						if (!shouldFallBehindThenCatchUp)
 							Assert.Fail("Subscription fell behind.");
 
+						Assert.True(DateTime.UtcNow - x.Wrapped.Timestamp < TimeSpan.FromSeconds(1));
+						Assert.NotNull(x.Wrapped.AllCheckpoint);
+						Assert.Null(x.Wrapped.StreamCheckpoint);
+
 						fellBehind = true;
 						break;
-					case CaughtUp:
+					case CaughtUp x:
 						if (!fellBehind)
 							Assert.Fail("Subscription caught up before falling behind");
 
 						if (!shouldFallBehindThenCatchUp)
 							Assert.Fail("Subscription fell behind then caught up.");
+
+						Assert.True(DateTime.UtcNow - x.Wrapped.Timestamp < TimeSpan.FromSeconds(1));
+						Assert.NotNull(x.Wrapped.AllCheckpoint);
+						Assert.Null(x.Wrapped.StreamCheckpoint);
 
 						caughtUp = true;
 						break;

--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.AllSubscription.Tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.AllSubscription.Tests.cs
@@ -54,7 +54,10 @@ public partial class EnumeratorTests {
 			Assert.AreEqual(_eventIds[0], ((Event)await sub.GetNext()).Id);
 			Assert.AreEqual(_eventIds[1], ((Event)await sub.GetNext()).Id);
 			Assert.AreEqual(_eventIds[2], ((Event)await sub.GetNext()).Id);
-			Assert.True(await sub.GetNext() is CaughtUp);
+			var caughtUp = AssertEx.IsType<CaughtUp>(await sub.GetNext());
+			Assert.True(DateTime.UtcNow - caughtUp.Wrapped.Timestamp < TimeSpan.FromSeconds(1));
+			Assert.AreEqual(new TFPos(350, 300), caughtUp.Wrapped.AllCheckpoint);
+			Assert.Null(caughtUp.Wrapped.StreamCheckpoint);
 		}
 	}
 
@@ -73,7 +76,10 @@ public partial class EnumeratorTests {
 			await using var sub = CreateAllSubscription(_publisher, Position.End);
 
 			Assert.True(await sub.GetNext() is SubscriptionConfirmation);
-			Assert.True(await sub.GetNext() is CaughtUp);
+			var caughtUp = AssertEx.IsType<CaughtUp>(await sub.GetNext());
+			Assert.True(DateTime.UtcNow - caughtUp.Wrapped.Timestamp < TimeSpan.FromSeconds(1));
+			Assert.AreEqual(new TFPos(350, 350), caughtUp.Wrapped.AllCheckpoint);
+			Assert.Null(caughtUp.Wrapped.StreamCheckpoint);
 		}
 	}
 
@@ -103,7 +109,10 @@ public partial class EnumeratorTests {
 			Assert.AreEqual(_eventIds[0], ((Event)await sub.GetNext()).Id);
 			Assert.AreEqual(_eventIds[1], ((Event)await sub.GetNext()).Id);
 			Assert.AreEqual(_eventIds[2], ((Event)await sub.GetNext()).Id);
-			Assert.True(await sub.GetNext() is CaughtUp);
+			var caughtUp = AssertEx.IsType<CaughtUp>(await sub.GetNext());
+			Assert.True(DateTime.UtcNow - caughtUp.Wrapped.Timestamp < TimeSpan.FromSeconds(1));
+			Assert.AreEqual(new TFPos(650, 600), caughtUp.Wrapped.AllCheckpoint);
+			Assert.Null(caughtUp.Wrapped.StreamCheckpoint);
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.CombinationTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.CombinationTests.cs
@@ -553,18 +553,26 @@ public partial class EnumeratorTests {
 
 						checkpointPosition = newCheckpointPosition;
 						break;
-					case FellBehind:
+					case FellBehind x:
 						if (!shouldFallBehindThenCatchUp)
 							Assert.Fail("Subscription fell behind.");
 
+						Assert.True(DateTime.UtcNow - x.Wrapped.Timestamp < TimeSpan.FromSeconds(1));
+						Assert.NotNull(x.Wrapped.AllCheckpoint);
+						Assert.Null(x.Wrapped.StreamCheckpoint);
+
 						fellBehind = true;
 						break;
-					case CaughtUp:
+					case CaughtUp x:
 						if (!fellBehind)
 							Assert.Fail("Subscription caught up before falling behind");
 
 						if (!shouldFallBehindThenCatchUp)
 							Assert.Fail("Subscription fell behind then caught up.");
+
+						Assert.True(DateTime.UtcNow - x.Wrapped.Timestamp < TimeSpan.FromSeconds(1));
+						Assert.NotNull(x.Wrapped.AllCheckpoint);
+						Assert.Null(x.Wrapped.StreamCheckpoint);
 
 						caughtUp = true;
 						break;
@@ -572,6 +580,8 @@ public partial class EnumeratorTests {
 						// we don't count checkpoints as part of the number of expected responses as it's
 						// not always straightforward to calculate how many checkpoints we will receive.
 						numResponsesExpected++;
+
+						Assert.True(DateTime.UtcNow - checkpoint.Wrapped.Timestamp < TimeSpan.FromSeconds(1));
 
 						// checkpoint must not move backwards
 						Assert.True(checkpoint.CheckpointPosition >= checkpointPosition);

--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.Tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.Tests.cs
@@ -60,9 +60,15 @@ public partial class EnumeratorTests {
 
 			Assert.True(await sub.GetNext() is SubscriptionConfirmation);
 			Assert.AreEqual(_eventIds[0], ((Event)await sub.GetNext()).Id);
-			var c = AssertEx.IsType<Checkpoint>(await sub.GetNext());
-			Assert.True(c.CheckpointPosition < Position.End);
-			Assert.True(await sub.GetNext() is CaughtUp);
+
+			var checkpoint = AssertEx.IsType<Checkpoint>(await sub.GetNext());
+			Assert.True(checkpoint.CheckpointPosition < Position.End);
+			Assert.True(DateTime.UtcNow - checkpoint.Wrapped.Timestamp < TimeSpan.FromSeconds(1));
+
+			var caughtUp = AssertEx.IsType<CaughtUp>(await sub.GetNext());
+			Assert.True(DateTime.UtcNow - caughtUp.Wrapped.Timestamp < TimeSpan.FromSeconds(1));
+			Assert.AreEqual(new TFPos(150, 100), caughtUp.Wrapped.AllCheckpoint);
+			Assert.Null(caughtUp.Wrapped.StreamCheckpoint);
 		}
 
 		[Test]
@@ -71,9 +77,15 @@ public partial class EnumeratorTests {
 				_publisher, null, EventFilter.EventType.Prefixes(false, "match-nothing"));
 
 			Assert.True(await sub.GetNext() is SubscriptionConfirmation);
+
 			var checkpoint = AssertEx.IsType<Checkpoint>(await sub.GetNext());
 			Assert.True(checkpoint.CheckpointPosition < Position.End);
-			Assert.True(await sub.GetNext() is CaughtUp);
+			Assert.True(DateTime.UtcNow - checkpoint.Wrapped.Timestamp < TimeSpan.FromSeconds(1));
+
+			var caughtUp = AssertEx.IsType<CaughtUp>(await sub.GetNext());
+			Assert.True(DateTime.UtcNow - caughtUp.Wrapped.Timestamp < TimeSpan.FromSeconds(1));
+			Assert.AreEqual(new TFPos(0, 0), caughtUp.Wrapped.AllCheckpoint);
+			Assert.Null(caughtUp.Wrapped.StreamCheckpoint);
 		}
 	}
 
@@ -93,7 +105,10 @@ public partial class EnumeratorTests {
 				_publisher, Position.End, EventFilter.EventType.Prefixes(false, "type1"));
 
 			Assert.True(await sub.GetNext() is SubscriptionConfirmation);
-			Assert.True(await sub.GetNext() is CaughtUp);
+			var caughtUp = AssertEx.IsType<CaughtUp>(await sub.GetNext());
+			Assert.True(DateTime.UtcNow - caughtUp.Wrapped.Timestamp < TimeSpan.FromSeconds(1));
+			Assert.AreEqual(new TFPos(400, 400), caughtUp.Wrapped.AllCheckpoint);
+			Assert.Null(caughtUp.Wrapped.StreamCheckpoint);
 		}
 	}
 
@@ -122,9 +137,15 @@ public partial class EnumeratorTests {
 
 			Assert.True(await sub.GetNext() is SubscriptionConfirmation);
 			Assert.AreEqual(_eventIds[0], ((Event)await sub.GetNext()).Id);
-			var c = AssertEx.IsType<Checkpoint>(await sub.GetNext());
-			Assert.True(c.CheckpointPosition < Position.End);
-			Assert.True(await sub.GetNext() is CaughtUp);
+
+			var checkpoint = AssertEx.IsType<Checkpoint>(await sub.GetNext());
+			Assert.True(checkpoint.CheckpointPosition < Position.End);
+			Assert.True(DateTime.UtcNow - checkpoint.Wrapped.Timestamp < TimeSpan.FromSeconds(1));
+
+			var caughtUp = AssertEx.IsType<CaughtUp>(await sub.GetNext());
+			Assert.True(DateTime.UtcNow - caughtUp.Wrapped.Timestamp < TimeSpan.FromSeconds(1));
+			Assert.AreEqual(new TFPos(450, 400), caughtUp.Wrapped.AllCheckpoint);
+			Assert.Null(caughtUp.Wrapped.StreamCheckpoint);
 		}
 
 		[Test]
@@ -135,9 +156,15 @@ public partial class EnumeratorTests {
 				EventFilter.EventType.Prefixes(false, "match-nothing"));
 
 			Assert.True(await sub.GetNext() is SubscriptionConfirmation);
+
 			var checkpoint = AssertEx.IsType<Checkpoint>(await sub.GetNext());
 			Assert.True(checkpoint.CheckpointPosition < Position.End);
-			Assert.True(await sub.GetNext() is CaughtUp);
+			Assert.True(DateTime.UtcNow - checkpoint.Wrapped.Timestamp < TimeSpan.FromSeconds(1));
+
+			var caughtUp = AssertEx.IsType<CaughtUp>(await sub.GetNext());
+			Assert.True(DateTime.UtcNow - caughtUp.Wrapped.Timestamp < TimeSpan.FromSeconds(1));
+			Assert.AreEqual(new TFPos(350, 300), caughtUp.Wrapped.AllCheckpoint);
+			Assert.Null(caughtUp.Wrapped.StreamCheckpoint);
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.StreamSubscription.CombinationTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.StreamSubscription.CombinationTests.cs
@@ -801,18 +801,26 @@ public partial class EnumeratorTests {
 					case Event evt:
 						Assert.AreEqual(nextEventNumber++, evt.EventNumber);
 						break;
-					case FellBehind:
+					case FellBehind x:
 						if (!shouldFallBehindThenCatchUp)
 							Assert.Fail("Subscription fell behind.");
 
+						Assert.True(DateTime.UtcNow - x.Wrapped.Timestamp < TimeSpan.FromSeconds(1));
+						Assert.Null(x.Wrapped.AllCheckpoint);
+						Assert.NotNull(x.Wrapped.StreamCheckpoint);
+
 						fellBehind = true;
 						break;
-					case CaughtUp:
+					case CaughtUp x:
 						if (!fellBehind)
 							Assert.Fail("Subscription caught up before falling behind");
 
 						if (!shouldFallBehindThenCatchUp)
 							Assert.Fail("Subscription fell behind then caught up.");
+
+						Assert.True(DateTime.UtcNow - x.Wrapped.Timestamp < TimeSpan.FromSeconds(1));
+						Assert.Null(x.Wrapped.AllCheckpoint);
+						Assert.NotNull(x.Wrapped.StreamCheckpoint);
 
 						caughtUp = true;
 						break;

--- a/src/EventStore.Core.XUnit.Tests/Services/Transport/Grpc/ResponseConverterTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Transport/Grpc/ResponseConverterTests.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using EventStore.Client.Streams;
+using EventStore.Core.Services.Transport.Grpc;
+using EventStore.Core.Services.Transport.Enumerators;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Services.Transport.Grpc;
+
+public class ResponseConverterTests {
+	static readonly DateTime TimeStamp = new(2025, 04, 17, 06, 30, 30, DateTimeKind.Utc);
+
+	[Fact]
+	public void can_convert_checkpoint_received() {
+		Assert.True(ResponseConverter.TryConvertReadResponse(
+			new ReadResponse.CheckpointReceived(
+				timestamp: TimeStamp,
+				commitPosition: 100,
+				preparePosition: 50),
+			uuidOption: null,
+			out var actual));
+
+		Assert.Equal(ReadResp.ContentOneofCase.Checkpoint, actual.ContentCase);
+
+		Assert.Equal(TimeStamp, actual.Checkpoint.Timestamp.ToDateTime());
+
+		Assert.Equal(100ul, actual.Checkpoint.CommitPosition);
+		Assert.Equal(50ul, actual.Checkpoint.PreparePosition);
+	}
+
+	[Fact]
+	public void subscription_caught_up_has_timestamp() {
+		Assert.True(ResponseConverter.TryConvertReadResponse(
+			new ReadResponse.SubscriptionCaughtUp(
+				timestamp: TimeStamp,
+				allCheckpoint: new Data.TFPos(100, 50)),
+			uuidOption: null,
+			out var actual));
+
+		Assert.Equal(ReadResp.ContentOneofCase.CaughtUp, actual.ContentCase);
+
+		Assert.Equal(TimeStamp, actual.CaughtUp.Timestamp.ToDateTime());
+	}
+
+	[Fact]
+	public void subscription_caught_up_supports_all_checkpoint() {
+		Assert.True(ResponseConverter.TryConvertReadResponse(
+			new ReadResponse.SubscriptionCaughtUp(
+				timestamp: TimeStamp,
+				allCheckpoint: new Data.TFPos(100, 50)),
+			uuidOption: null,
+			out var actual));
+
+		Assert.Equal(ReadResp.ContentOneofCase.CaughtUp, actual.ContentCase);
+
+		Assert.False(actual.CaughtUp.HasStreamRevision);
+
+		Assert.Equal(100ul, actual.CaughtUp.Position.CommitPosition);
+		Assert.Equal(50ul, actual.CaughtUp.Position.PreparePosition);
+	}
+
+	[Fact]
+	public void subscription_caught_up_supports_stream_checkpoint() {
+		Assert.True(ResponseConverter.TryConvertReadResponse(
+			new ReadResponse.SubscriptionCaughtUp(
+				timestamp: TimeStamp,
+				streamCheckpoint: 5),
+			uuidOption: null,
+			out var actual));
+
+		Assert.Equal(ReadResp.ContentOneofCase.CaughtUp, actual.ContentCase);
+
+		Assert.True(actual.CaughtUp.HasStreamRevision);
+		Assert.Equal(5, actual.CaughtUp.StreamRevision);
+
+		Assert.Null(actual.CaughtUp.Position);
+	}
+}

--- a/src/EventStore.Core/Data/TFPos.cs
+++ b/src/EventStore.Core/Data/TFPos.cs
@@ -6,7 +6,7 @@ using System.Diagnostics.Contracts;
 
 namespace EventStore.Core.Data;
 
-public struct TFPos : IEquatable<TFPos>, IComparable<TFPos> {
+public readonly struct TFPos : IEquatable<TFPos>, IComparable<TFPos> {
 	public static readonly TFPos Invalid = new TFPos(-1, -1);
 	public static readonly TFPos HeadOfTf = new TFPos(-1, -1);
 	public static readonly TFPos FirstRecordOfTf = new TFPos(0, 0);

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.cs
@@ -18,7 +18,7 @@ using Serilog;
 namespace EventStore.Core.Services.Transport.Enumerators;
 
 partial class Enumerator {
-	public class AllSubscriptionFiltered : IAsyncEnumerator<ReadResponse> {
+	public sealed class AllSubscriptionFiltered : IAsyncEnumerator<ReadResponse> {
 		private static readonly ILogger Log = Serilog.Log.ForContext<AllSubscriptionFiltered>();
 
 		private readonly IExpiryStrategy _expiryStrategy;
@@ -192,7 +192,11 @@ ReadLoop:
 				"Subscription {subscriptionId} to $all:{eventFilter} caught up at checkpoint {position}.",
 				_subscriptionId, _eventFilter, checkpoint);
 
-			await _channel.Writer.WriteAsync(new ReadResponse.SubscriptionCaughtUp(), ct);
+			await _channel.Writer.WriteAsync(
+				new ReadResponse.SubscriptionCaughtUp(
+					timestamp: DateTime.UtcNow,
+					allCheckpoint: checkpoint),
+				ct);
 		}
 
 		private async Task NotifyFellBehind(TFPos checkpoint, CancellationToken ct) {
@@ -200,7 +204,11 @@ ReadLoop:
 				"Subscription {subscriptionId} to $all:{eventFilter} fell behind at checkpoint {position}.",
 				_subscriptionId, _eventFilter, checkpoint);
 
-			await _channel.Writer.WriteAsync(new ReadResponse.SubscriptionFellBehind(), ct);
+			await _channel.Writer.WriteAsync(
+				new ReadResponse.SubscriptionFellBehind(
+					timestamp: DateTime.UtcNow,
+					allCheckpoint: checkpoint),
+				ct);
 		}
 
 		private async ValueTask<(TFPos, ulong)> GoLive(TFPos checkpoint, ulong sequenceNumber, CancellationToken ct) {
@@ -362,6 +370,7 @@ ReadLoop:
 			}
 			var checkpointPos = Position.FromInt64(checkpoint.CommitPosition, checkpoint.PreparePosition);
 			await _channel.Writer.WriteAsync(new ReadResponse.CheckpointReceived(
+				timestamp: DateTime.UtcNow,
 				commitPosition: checkpointPos.CommitPosition,
 				preparePosition: checkpointPos.PreparePosition), ct);
 		}

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.StreamSubscription.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.StreamSubscription.cs
@@ -26,7 +26,7 @@ static partial class Enumerator {
 		public abstract ReadResponse Current { get; }
 	}
 
-	public class StreamSubscription<TStreamId> : StreamSubscription {
+	public sealed class StreamSubscription<TStreamId> : StreamSubscription {
 		private readonly IExpiryStrategy _expiryStrategy;
 		private readonly Guid _subscriptionId;
 		private readonly IPublisher _bus;
@@ -176,7 +176,11 @@ ReadLoop:
 				"Subscription {subscriptionId} to {streamName} caught up at checkpoint {streamRevision:N0}.",
 				_subscriptionId, _streamName, checkpoint);
 
-			await _channel.Writer.WriteAsync(new ReadResponse.SubscriptionCaughtUp(), ct);
+			await _channel.Writer.WriteAsync(
+				new ReadResponse.SubscriptionCaughtUp(
+					timestamp: DateTime.UtcNow,
+					streamCheckpoint: checkpoint),
+				ct);
 		}
 
 		private async Task NotifyFellBehind(long checkpoint, CancellationToken ct) {
@@ -184,7 +188,11 @@ ReadLoop:
 				"Subscription {subscriptionId} to {streamName} fell behind at checkpoint {streamRevision:N0}.",
 				_subscriptionId, _streamName, checkpoint);
 
-			await _channel.Writer.WriteAsync(new ReadResponse.SubscriptionFellBehind(), ct);
+			await _channel.Writer.WriteAsync(
+				new ReadResponse.SubscriptionFellBehind(
+					timestamp: DateTime.UtcNow,
+					streamCheckpoint: checkpoint),
+				ct);
 		}
 
 		private async ValueTask<(long, ulong)> GoLive(long checkpoint, ulong sequenceNumber, CancellationToken ct) {

--- a/src/EventStore.Core/Services/Transport/Enumerators/ReadResponse.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/ReadResponse.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Event Store Ltd and/or licensed to Event Store Ltd under one or more agreements.
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
+using System;
 using EventStore.Core.Data;
 using EventStore.Core.Services.Transport.Common;
 
@@ -15,18 +16,50 @@ public abstract class ReadResponse {
 		}
 	}
 
-	public class SubscriptionCaughtUp : ReadResponse { }
+	public class SubscriptionCaughtUp : ReadResponse {
+		public readonly DateTime Timestamp;
 
-	public class SubscriptionFellBehind : ReadResponse { }
+		// Always populated for stream subscriptions
+		public readonly long? StreamCheckpoint;
 
-	public class CheckpointReceived : ReadResponse {
-		public readonly ulong CommitPosition;
-		public readonly ulong PreparePosition;
+		// Always populated for $all subscriptions
+		public readonly TFPos? AllCheckpoint;
 
-		public CheckpointReceived(ulong commitPosition, ulong preparePosition) {
-			CommitPosition = commitPosition;
-			PreparePosition = preparePosition;
+		public SubscriptionCaughtUp(DateTime timestamp, long streamCheckpoint) {
+			Timestamp = timestamp;
+			StreamCheckpoint = streamCheckpoint;
 		}
+
+		public SubscriptionCaughtUp(DateTime timestamp, TFPos allCheckpoint) {
+			Timestamp = timestamp;
+			AllCheckpoint = allCheckpoint;
+		}
+	}
+
+	public class SubscriptionFellBehind : ReadResponse {
+		public readonly DateTime Timestamp;
+
+		// Always populated for stream subscriptions
+		public readonly long? StreamCheckpoint;
+
+		// Always populated for $all subscriptions
+		public readonly TFPos? AllCheckpoint;
+
+		public SubscriptionFellBehind(DateTime timestamp, long streamCheckpoint) {
+			Timestamp = timestamp;
+			StreamCheckpoint = streamCheckpoint;
+		}
+
+		public SubscriptionFellBehind(DateTime timestamp, TFPos allCheckpoint) {
+			Timestamp = timestamp;
+			AllCheckpoint = allCheckpoint;
+		}
+	}
+
+	public class CheckpointReceived(DateTime timestamp, ulong commitPosition, ulong preparePosition) : ReadResponse {
+		public readonly DateTime Timestamp = timestamp;
+		public readonly ulong CommitPosition = commitPosition;
+		public readonly ulong PreparePosition = preparePosition;
 	}
 
 	public class StreamNotFound : ReadResponse {

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
@@ -18,6 +18,7 @@ using Google.Protobuf;
 using Grpc.Core;
 using CountOptionOneofCase = EventStore.Client.Streams.ReadReq.Types.Options.CountOptionOneofCase;
 using FilterOptionOneofCase = EventStore.Client.Streams.ReadReq.Types.Options.FilterOptionOneofCase;
+using Position = EventStore.Core.Services.Transport.Common.Position;
 using ReadDirection = EventStore.Client.Streams.ReadReq.Types.Options.Types.ReadDirection;
 using StreamOptionOneofCase = EventStore.Client.Streams.ReadReq.Types.Options.StreamOptionOneofCase;
 
@@ -78,13 +79,13 @@ internal partial class Streams<TStreamId> {
 				await using (enumerator) {
 					await using (context.CancellationToken.Register(DisposeEnumerator)) {
 						while (await enumerator.MoveNextAsync()) {
-							if (TryConvertReadResponse(enumerator.Current, uuidOption, out var readResponse))
+							if (ResponseConverter.TryConvertReadResponse(enumerator.Current, uuidOption, out var readResponse))
 								await responseStream.WriteAsync(readResponse);
 						}
 					}
 				}
 			} catch (ReadResponseException ex) {
-				ConvertReadResponseException(ex);
+				ResponseConverter.ConvertReadResponseException(ex);
 			}
 		} catch (Exception ex) {
 			duration.SetException(ex);
@@ -253,8 +254,10 @@ internal partial class Streams<TStreamId> {
 					: EventFilter.StreamName.Regex(isAllStream, filter.StreamIdentifier.Regex)),
 			_ => throw RpcExceptions.InvalidArgument(filter)
 		};
+}
 
-	private static bool TryConvertReadResponse(ReadResponse readResponse, ReadReq.Types.Options.Types.UUIDOption uuidOption, out ReadResp readResp) {
+public static class ResponseConverter {
+	public static bool TryConvertReadResponse(ReadResponse readResponse, ReadReq.Types.Options.Types.UUIDOption uuidOption, out ReadResp readResp) {
 		readResp = readResponse switch {
 			ReadResponse.EventReceived eventReceived => new ReadResp {
 				Event = ConvertToReadEvent(uuidOption, eventReceived.Event)
@@ -266,6 +269,7 @@ internal partial class Streams<TStreamId> {
 			},
 			ReadResponse.CheckpointReceived checkpointReceived => new ReadResp {
 				Checkpoint = new ReadResp.Types.Checkpoint {
+					Timestamp = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(checkpointReceived.Timestamp),
 					CommitPosition = checkpointReceived.CommitPosition,
 					PreparePosition = checkpointReceived.PreparePosition
 				}
@@ -275,9 +279,7 @@ internal partial class Streams<TStreamId> {
 					StreamIdentifier = streamNotFound.StreamName
 				}
 			},
-			ReadResponse.SubscriptionCaughtUp => new ReadResp {
-				CaughtUp = new ReadResp.Types.CaughtUp()
-			},
+			ReadResponse.SubscriptionCaughtUp caughtUp => Convert(caughtUp),
 			ReadResponse.SubscriptionFellBehind => null, // currently not sent to clients
 			ReadResponse.LastStreamPositionReceived lastStreamPositionReceived => new ReadResp {
 				LastStreamPosition = lastStreamPositionReceived.LastStreamPosition
@@ -291,7 +293,29 @@ internal partial class Streams<TStreamId> {
 		return readResp != null;
 	}
 
-	private static void ConvertReadResponseException(ReadResponseException readResponseEx) {
+	private static ReadResp Convert(ReadResponse.SubscriptionCaughtUp caughtUp) {
+		var response = new ReadResp {
+			CaughtUp = new ReadResp.Types.CaughtUp {
+				Timestamp = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(caughtUp.Timestamp),
+			},
+		};
+
+		if (caughtUp.StreamCheckpoint is { } streamCheckpoint && streamCheckpoint >= 0) {
+			response.CaughtUp.StreamRevision = streamCheckpoint;
+		}
+
+		if (caughtUp.AllCheckpoint is { } allCheckpoint && allCheckpoint != TFPos.HeadOfTf) {
+			var unsignedPosition = Position.FromInt64(allCheckpoint.CommitPosition, allCheckpoint.PreparePosition);
+			response.CaughtUp.Position = new() {
+				CommitPosition = unsignedPosition.CommitPosition,
+				PreparePosition = unsignedPosition.PreparePosition,
+			};
+		}
+
+		return response;
+	}
+
+	public static void ConvertReadResponseException(ReadResponseException readResponseEx) {
 		switch (readResponseEx) {
 			case ReadResponseException.NotHandled.ServerNotReady:
 				throw RpcExceptions.ServerNotReady();

--- a/src/Protos/Grpc/streams.proto
+++ b/src/Protos/Grpc/streams.proto
@@ -102,10 +102,38 @@ message ReadResp {
 		CaughtUp caught_up = 8;
 		FellBehind fell_behind = 9;
 	}
-	
-	message CaughtUp {}
 
-	message FellBehind {}
+	// The $all or stream subscription has caught up and become live.
+	message CaughtUp {
+		// Current time in the server when the subscription caught up
+		google.protobuf.Timestamp timestamp = 1;
+
+		// Checkpoint for resuming a stream subscription.
+		// For stream subscriptions it is populated unless the stream is empty.
+		// For $all subscriptions it is not populated.
+		optional int64 stream_revision = 2;
+
+		// Checkpoint for resuming a $all subscription.
+		// For stream subscriptions it is not populated.
+		// For $all subscriptions it is populated unless the database is empty.
+		optional Position position = 3;
+	}
+
+	// The $all or stream subscription has fallen back into catchup mode and is no longer live.
+	message FellBehind {
+		// Current time in the server when the subscription fell behind
+		google.protobuf.Timestamp timestamp = 1;
+
+		// Checkpoint for resuming a stream subscription.
+		// For stream subscriptions it is populated unless the stream is empty.
+		// For $all subscriptions it is not populated.
+		optional int64 stream_revision = 2;
+
+		// Checkpoint for resuming a $all subscription.
+		// For stream subscriptions it is not populated.
+		// For $all subscriptions it is populated unless the database is empty.
+		optional Position position = 3;
+	}
 
 	message ReadEvent {
 		RecordedEvent event = 1;
@@ -132,7 +160,16 @@ message ReadResp {
 	message Checkpoint {
 		uint64 commit_position = 1;
 		uint64 prepare_position = 2;
+
+		// Current time in the server when the checkpoint was reached
+		google.protobuf.Timestamp timestamp = 3;
 	}
+
+	message Position {
+		uint64 commit_position = 1;
+		uint64 prepare_position = 2;
+	}
+
 	message StreamNotFound {
 		event_store.client.StreamIdentifier stream_identifier = 1;
 	}


### PR DESCRIPTION
Cherry pick of #5013

Proto changes requested by & agreed with Devex team. Backwards compatible.

Conflicts:
- src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
- src/KurrentDB.Core/Services/Transport/Enumerators/ReadResponse.cs
