### PR TITLE
[KDB-764] Add LowAllocReadOnlyMemory<T>

### DIFF
--- a/src/KurrentDB.Common.Tests/Utils/LowAllocReadOnlyMemoryTests.cs
+++ b/src/KurrentDB.Common.Tests/Utils/LowAllocReadOnlyMemoryTests.cs
@@ -13,14 +13,14 @@ public class LowAllocReadOnlyMemoryTests {
 		Assert.Throws<InvalidOperationException>(() => sut.Single);
 		Assert.Equal(Array.Empty<int>(), sut.Span);
 
-		foreach (var x in sut) {
+		foreach (var _ in sut) {
 			Assert.Fail();
 		}
 	}
 
 	[Fact]
 	public void single_works() {
-		var expected = new int[] { 5 };
+		var expected = new[] { 5 };
 		var sut = new LowAllocReadOnlyMemory<int>(5);
 		Assert.Equal(1, sut.Length);
 		Assert.Equal(5, sut.Single);
@@ -67,7 +67,7 @@ public class LowAllocReadOnlyMemoryTests {
 		Assert.Equal(2, sut.Single);
 
 		sut = [3, 4, 5];
-		var expected = new int[] { 3, 4, 5 };
+		var expected = new[] { 3, 4, 5 };
 		Assert.Equal(expected, sut.Span);
 	}
 }

--- a/src/KurrentDB.Common.Tests/Utils/LowAllocReadOnlyMemoryTests.cs
+++ b/src/KurrentDB.Common.Tests/Utils/LowAllocReadOnlyMemoryTests.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using KurrentDB.Common.Utils;
+
+namespace KurrentDB.Common.Tests.Utils;
+
+public class LowAllocReadOnlyMemoryTests {
+	[Fact]
+	public void empty_works() {
+		var sut = LowAllocReadOnlyMemory<int>.Empty;
+		Assert.Equal(0, sut.Length);
+		Assert.Throws<InvalidOperationException>(() => sut.Single);
+		Assert.Equal(Array.Empty<int>(), sut.Span);
+
+		foreach (var x in sut) {
+			Assert.Fail();
+		}
+	}
+
+	[Fact]
+	public void single_works() {
+		var expected = new int[] { 5 };
+		var sut = new LowAllocReadOnlyMemory<int>(5);
+		Assert.Equal(1, sut.Length);
+		Assert.Equal(5, sut.Single);
+		Assert.Equal(expected, sut.Span);
+
+		var foreachOutput = new List<int>();
+		foreach (var x in sut) {
+			foreachOutput.Add(x);
+		}
+		Assert.Equal(expected, foreachOutput);
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(1)]
+	[InlineData(2)]
+	[InlineData(3)]
+	public void multiple_works(int length) {
+		var expected = Enumerable.Range(0, length).ToArray();
+		var sut = new LowAllocReadOnlyMemory<int>(expected);
+		Assert.Equal(expected.Length, sut.Length);
+
+		if (length is 1) {
+			Assert.Equal(0, sut.Single);
+		} else {
+			Assert.Throws<InvalidOperationException>(() => sut.Single);
+		}
+
+		Assert.Equal(expected, sut.Span);
+
+		var foreachOutput = new List<int>();
+		foreach (var x in sut) {
+			foreachOutput.Add(x);
+		}
+		Assert.Equal(expected, foreachOutput);
+	}
+
+	[Fact]
+	public void collection_expression_works() {
+		LowAllocReadOnlyMemory<int> sut = [];
+		Assert.Equal(0, sut.Length);
+
+		sut = [2];
+		Assert.Equal(2, sut.Single);
+
+		sut = [3, 4, 5];
+		var expected = new int[] { 3, 4, 5 };
+		Assert.Equal(expected, sut.Span);
+	}
+}

--- a/src/KurrentDB.Common/Utils/LowAllocReadOnlyMemory.cs
+++ b/src/KurrentDB.Common/Utils/LowAllocReadOnlyMemory.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace KurrentDB.Common.Utils;
+
+// Similar to ReadOnlyMemory<T>.
+// Unlike ReadOnlyMemory<T>, this not require allocation of a backing array when containing 1 element.
+// Useful when 0 or 1 elements is the common case.
+[CollectionBuilder(typeof(LowAllocReadOnlyMemoryBuilder), nameof(LowAllocReadOnlyMemoryBuilder.Create))]
+public readonly struct LowAllocReadOnlyMemory<T> {
+	private readonly bool _isSingle;
+	// todo: consider union
+	private readonly T _singleItem;
+	private readonly ReadOnlyMemory<T> _items; // for 0 or >1 items
+
+	/// <summary>
+	/// Construct from single item.
+	/// </summary>
+	public LowAllocReadOnlyMemory(T singleItem) {
+		_isSingle = true;
+		_singleItem = singleItem;
+	}
+
+	/// <summary>
+	/// Construct from ReadOnlyMemory.
+	/// Does not capture the ReadOnlyMemory if it is only a single item. Allows the memory to be released earlier.
+	/// </summary>
+	public LowAllocReadOnlyMemory(ReadOnlyMemory<T> items) {
+		if (items.Span is [var singleItem]) {
+			_isSingle = true;
+			_singleItem = singleItem;
+		} else {
+			_isSingle = false;
+			_items = items;
+		}
+	}
+
+	public static implicit operator LowAllocReadOnlyMemory<T>(T[] array) => new(items: array);
+
+	public static LowAllocReadOnlyMemory<T> Empty => default;
+
+	public int Length => _isSingle
+		? 1
+		: _items.Length;
+
+	public T Single => _isSingle
+		? _singleItem
+		: throw new InvalidOperationException($"Cannot get single item for collection of length {Length}");
+
+	public ReadOnlySpan<T> Span => _isSingle
+		? MemoryMarshal.CreateReadOnlySpan(in _singleItem, 1)
+		: _items.Span;
+
+	public ReadOnlySpan<T>.Enumerator GetEnumerator() => Span.GetEnumerator();
+
+	public T[] ToArray() => Span.ToArray();
+}
+
+// For collection expressions. Allocates a backing array if necessary.
+public static class LowAllocReadOnlyMemoryBuilder {
+	public static LowAllocReadOnlyMemory<T> Create<T>(ReadOnlySpan<T> items) =>
+		items is [var singleItem]
+			? new(singleItem: singleItem)
+			: new(items: items.ToArray());
+}


### PR DESCRIPTION
Similar to ReadOnlyMemory<T> but has special handling to avoid allocation when there is 1 element in the collection. Useful when 0 or 1 elements are the common case.