### PR TITLE
[KDB-764] Use [] rather than null to represent all events being for one single stream

### DIFF
--- a/src/KurrentDB.Core.Tests/Services/IndexCommitter/with_index_committer_service.cs
+++ b/src/KurrentDB.Core.Tests/Services/IndexCommitter/with_index_committer_service.cs
@@ -107,7 +107,7 @@ public class FakeIndexCommitter<TStreamId> : IIndexCommitter<TStreamId> {
 		return new(0L);
 	}
 
-	public ValueTask Commit(IReadOnlyList<IPrepareLogRecord<TStreamId>> committedPrepares, int numStreams, LowAllocReadOnlyMemory<int>? eventStreamIndexes, bool isTfEof, bool cacheLastEventNumber, CancellationToken token) {
+	public ValueTask Commit(IReadOnlyList<IPrepareLogRecord<TStreamId>> committedPrepares, int numStreams, LowAllocReadOnlyMemory<int> eventStreamIndexes, bool isTfEof, bool cacheLastEventNumber, CancellationToken token) {
 		foreach (var prepare in committedPrepares) {
 			CommittedPrepares.Enqueue(prepare);
 		}

--- a/src/KurrentDB.Core.Tests/Services/Storage/FakeIndexWriter.cs
+++ b/src/KurrentDB.Core.Tests/Services/Storage/FakeIndexWriter.cs
@@ -40,7 +40,7 @@ public class FakeIndexWriter<TStreamId> : IIndexWriter<TStreamId> {
 	public ValueTask PreCommit(CommitLogRecord commit, CancellationToken token)
 		=> token.IsCancellationRequested ? ValueTask.FromCanceled(token) : ValueTask.CompletedTask;
 
-	public void PreCommit(ReadOnlySpan<IPrepareLogRecord<TStreamId>> commitedPrepares, LowAllocReadOnlyMemory<int>? eventStreamIndexes) { }
+	public void PreCommit(ReadOnlySpan<IPrepareLogRecord<TStreamId>> commitedPrepares, LowAllocReadOnlyMemory<int> eventStreamIndexes) { }
 
 	public void UpdateTransactionInfo(long transactionId, long logPosition, TransactionInfo<TStreamId> transactionInfo) { }
 

--- a/src/KurrentDB.Core.XUnit.Tests/Services/Transport/Grpc/MSARequestConverterTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Services/Transport/Grpc/MSARequestConverterTests.cs
@@ -71,7 +71,7 @@ public class MSARequestConverterTests {
 		Assert.True(output.RequireLeader);
 
 		Assert.Equal(["stream-a", "stream-b"], output.EventStreamIds.Span);
-		Assert.Equal([0, 1], output.EventStreamIndexes!.Value.Span);
+		Assert.Equal([0, 1], output.EventStreamIndexes.Span);
 		Assert.Equal([-2, -2], output.ExpectedVersions.Span);
 
 		Assert.Equal(2, output.Events.Length);

--- a/src/KurrentDB.Core.XUnit.Tests/Services/Transport/Grpc/MultiStreamAppendServiceTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Services/Transport/Grpc/MultiStreamAppendServiceTests.cs
@@ -97,7 +97,7 @@ public class MultiStreamAppendServiceTests {
 			var writeEvents = Assert.IsType<ClientMessage.WriteEvents>(message);
 			Assert.Equal(["stream-a", "stream-b"], writeEvents.EventStreamIds.Span);
 			Assert.Equal([1, -2], writeEvents.ExpectedVersions.Span);
-			Assert.Equal([0, 1, 1], writeEvents.EventStreamIndexes!.Value.Span);
+			Assert.Equal([0, 1, 1], writeEvents.EventStreamIndexes.Span);
 			Assert.Equal(3, writeEvents.Events.Length);
 
 			var proposedEvent2 = writeEvents.Events.Span[0];

--- a/src/KurrentDB.Core.XUnit.Tests/TransactionLog/MultiStreamWrites/MultiStreamWritesTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/TransactionLog/MultiStreamWrites/MultiStreamWritesTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using KurrentDB.Common.Utils;
 using KurrentDB.Core.Data;
 using KurrentDB.Core.Messages;
 using KurrentDB.Core.Messaging;

--- a/src/KurrentDB.Core.XUnit.Tests/TransactionLog/MultiStreamWrites/MultiStreamWritesTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/TransactionLog/MultiStreamWrites/MultiStreamWritesTests.cs
@@ -70,7 +70,7 @@ public class MultiStreamWritesTests(MiniNodeFixture<MultiStreamWritesTests> fixt
 			eventStreamIds: [A],
 			expectedVersions: [ExpectedVersion.Any],
 			events: [NewEvent, NewEvent, NewEvent],
-			eventStreamIndexes: null);
+			eventStreamIndexes: []);
 
 		Assert.Equal(OperationResult.Success, completed.Result);
 		Assert.Equal([0], completed.FirstEventNumbers.ToArray());
@@ -87,7 +87,7 @@ public class MultiStreamWritesTests(MiniNodeFixture<MultiStreamWritesTests> fixt
 			eventStreamIds: [A],
 			expectedVersions: [ExpectedVersion.Any],
 			events: [],
-			eventStreamIndexes: null);
+			eventStreamIndexes: []);
 
 		Assert.Equal(OperationResult.Success, completed.Result);
 		Assert.Equal([0], completed.FirstEventNumbers.ToArray());
@@ -98,7 +98,7 @@ public class MultiStreamWritesTests(MiniNodeFixture<MultiStreamWritesTests> fixt
 			eventStreamIds: [A],
 			expectedVersions: [ExpectedVersion.Any],
 			events: [NewEvent, NewEvent, NewEvent],
-			eventStreamIndexes: null);
+			eventStreamIndexes: []);
 
 		Assert.Equal(OperationResult.Success, completed.Result);
 
@@ -107,7 +107,7 @@ public class MultiStreamWritesTests(MiniNodeFixture<MultiStreamWritesTests> fixt
 			eventStreamIds: [A],
 			expectedVersions: [ExpectedVersion.Any],
 			events: [],
-			eventStreamIndexes: null);
+			eventStreamIndexes: []);
 
 		Assert.Equal(OperationResult.Success, completed.Result);
 		Assert.Equal([3], completed.FirstEventNumbers.ToArray());
@@ -411,7 +411,7 @@ public class MultiStreamWritesTests(MiniNodeFixture<MultiStreamWritesTests> fixt
 			eventStreamIds: [A],
 			expectedVersions: [ExpectedVersion.NoStream],
 			events: [eventA0, NewEvent],
-			eventStreamIndexes: null);
+			eventStreamIndexes: []);
 
 		Assert.Equal(OperationResult.WrongExpectedVersion, completed.Result);
 		// for backwards compatibility, the arrays are populated when there is a single stream
@@ -527,12 +527,12 @@ public class MultiStreamWritesTests(MiniNodeFixture<MultiStreamWritesTests> fixt
 			events: [NewEvent, NewEvent],
 			eventStreamIndexes: [0, 0]));
 
-		// not all streams being written to (with eventStreamIndexes: null)
+		// not all streams being written to (with eventStreamIndexes: [])
 		await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await WriteEvents(
 			eventStreamIds: [A, B],
 			expectedVersions: [ExpectedVersion.Any, ExpectedVersion.Any],
 			events: [NewEvent, NewEvent],
-			eventStreamIndexes: null)); // equivalent to [0, 0]
+			eventStreamIndexes: [])); // equivalent to [0, 0]
 
 		// empty write to multiple streams
 		await Assert.ThrowsAsync<ArgumentException>(async () => await WriteEvents(
@@ -541,12 +541,12 @@ public class MultiStreamWritesTests(MiniNodeFixture<MultiStreamWritesTests> fixt
 			events: [],
 			eventStreamIndexes: []));
 
-		// empty write to multiple streams (with eventStreamIndexes: null)
+		// empty write to multiple streams (with eventStreamIndexes: [])
 		await Assert.ThrowsAsync<ArgumentException>(async () => await WriteEvents(
 			eventStreamIds: [A, B],
 			expectedVersions: [ExpectedVersion.Any, ExpectedVersion.Any],
 			events: [],
-			eventStreamIndexes: null)); // equivalent to []
+			eventStreamIndexes: [])); // equivalent to []
 	}
 
 	[Fact]
@@ -605,7 +605,7 @@ public class MultiStreamWritesTests(MiniNodeFixture<MultiStreamWritesTests> fixt
 			eventStreamIds,
 			expectedVersions,
 			events,
-			eventStreamIndexes is null ? (LowAllocReadOnlyMemory<int>?)null : eventStreamIndexes,
+			eventStreamIndexes: eventStreamIndexes,
 			user: SystemAccounts.System);
 
 		fixture.MiniNode.Node.MainQueue.Publish(writeEventsMsg);

--- a/src/KurrentDB.Core/Services/RequestManager/Managers/WriteEvents.cs
+++ b/src/KurrentDB.Core/Services/RequestManager/Managers/WriteEvents.cs
@@ -15,7 +15,7 @@ public class WriteEvents : RequestManagerBase {
 	private readonly LowAllocReadOnlyMemory<string> _streamIds;
 	private readonly LowAllocReadOnlyMemory<long> _expectedVersions;
 	private readonly LowAllocReadOnlyMemory<Event> _events;
-	private readonly LowAllocReadOnlyMemory<int>? _eventStreamIndexes;
+	private readonly LowAllocReadOnlyMemory<int> _eventStreamIndexes;
 	private readonly CancellationToken _cancellationToken;
 
 	public WriteEvents(IPublisher publisher,
@@ -26,7 +26,7 @@ public class WriteEvents : RequestManagerBase {
 		LowAllocReadOnlyMemory<string> streamIds,
 		LowAllocReadOnlyMemory<long> expectedVersions,
 		LowAllocReadOnlyMemory<Event> events,
-		LowAllocReadOnlyMemory<int>? eventStreamIndexes,
+		LowAllocReadOnlyMemory<int> eventStreamIndexes,
 		CommitSource commitSource,
 		CancellationToken cancellationToken = default)
 		: base(
@@ -66,7 +66,7 @@ public class WriteEvents : RequestManagerBase {
 			streamIds: new(streamId),
 			expectedVersions: new(expectedVersion),
 			events: events,
-			eventStreamIndexes: null,
+			eventStreamIndexes: [],
 			commitSource: commitSource,
 			cancellationToken: cancellationToken);
 	}

--- a/src/KurrentDB.Core/Services/Storage/ImplicitTransaction.cs
+++ b/src/KurrentDB.Core/Services/Storage/ImplicitTransaction.cs
@@ -19,9 +19,9 @@ public class ImplicitTransaction<TStreamId> {
 	public long? Position { get; private set; }
 	public LowAllocReadOnlyMemory<long> GetFirstEventNumbers() => _firstEventNumbers.ToLowAllocReadOnlyMemory();
 	public LowAllocReadOnlyMemory<long> GetLastEventNumbers() => _lastEventNumbers.ToLowAllocReadOnlyMemory();
-	public LowAllocReadOnlyMemory<int>? GetEventStreamIndexes() {
+	public LowAllocReadOnlyMemory<int> GetEventStreamIndexes() {
 		if (CurrentStreamIndex == 1)
-			return null;
+			return [];
 
 		return _eventStreamIndexes.ToLowAllocReadOnlyMemory();
 	}

--- a/src/KurrentDB.Core/Services/Storage/StorageChaser.cs
+++ b/src/KurrentDB.Core/Services/Storage/StorageChaser.cs
@@ -232,7 +232,7 @@ public class StorageChaser<TStreamId> : StorageChaser, IMonitoredQueue,
 		if (lastEventNumber is EventNumber.Invalid)
 			lastEventNumber = record.FirstEventNumber - 1;
 		_leaderBus.Publish(new StorageMessage.CommitAck(record.CorrelationId, record.LogPosition,
-			record.TransactionPosition, new(firstEventNumber), new(lastEventNumber), null));
+			record.TransactionPosition, new(firstEventNumber), new(lastEventNumber), []));
 	}
 
 	private ValueTask ProcessSystemRecord(ISystemLogRecord record, CancellationToken token) {

--- a/src/KurrentDB.Core/Services/Storage/StorageWriterService.cs
+++ b/src/KurrentDB.Core/Services/Storage/StorageWriterService.cs
@@ -310,8 +310,8 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 
 				var numEventIds = 0;
 				for (int eventIndex = 0; eventIndex < msg.Events.Length; eventIndex++) {
-					var eventStreamIndex = msg.EventStreamIndexes.HasValue ?
-						msg.EventStreamIndexes.Value.Span[eventIndex] : 0;
+					var eventStreamIndex = msg.EventStreamIndexes.Length is not 0 ?
+						msg.EventStreamIndexes.Span[eventIndex] : 0;
 					if (eventStreamIndex == streamIndex) {
 						eventIds[numEventIds++] = msg.Events.Span[eventIndex].EventId;
 					}
@@ -343,7 +343,7 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 				var transactionPosition = logPosition;
 				for (int i = 0; i < msg.Events.Length; ++i) {
 					var evnt = msg.Events.Span[i];
-					var streamIndex = msg.EventStreamIndexes.HasValue ? msg.EventStreamIndexes.Value.Span[i] : 0;
+					var streamIndex = msg.EventStreamIndexes.Length is not 0 ? msg.EventStreamIndexes.Span[i] : 0;
 
 					var flags = PrepareFlags.Data | PrepareFlags.IsCommitted;
 					if (i == 0)


### PR DESCRIPTION
This simplifies the semantics a bit and avoids the risk of a null array being accidentally converted to an empty ReadOnlyMemory<>? when it should have stayed null e.g. this cast is no longer required in the MultiStreamWritesTests: `eventStreamIndexes is null ? (LowAllocReadOnlyMemory<int>?)null : eventStreamIndexes`