### PR TITLE
[KDB-775] Handle write request responses where deleted stream is unspecified

### DIFF
--- a/src/KurrentDB.Core.XUnit.Tests/Services/Transport/Grpc/MSAResponseConverterTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Services/Transport/Grpc/MSAResponseConverterTests.cs
@@ -110,8 +110,10 @@ public class MSAResponseConverterTests {
 			});
 	}
 
-	[Fact]
-	public void converts_when_stream_is_deleted() {
+	[Theory]
+	[InlineData(false)]
+	[InlineData(true)]
+	public void converts_when_stream_is_deleted(bool isStreamKnown) {
 		// given
 		var requests = new AppendStreamRequest[] {
 			new() { Stream = "stream-at-index-0" },
@@ -124,8 +126,8 @@ public class MSAResponseConverterTests {
 			correlationId: Guid.NewGuid(),
 			result: OperationResult.StreamDeleted,
 			message: "the details",
-			failureStreamIndexes: new[] { 1 },
-			failureCurrentVersions: new long[] { 11 });
+			failureStreamIndexes: isStreamKnown ? [1] : [],
+			failureCurrentVersions: isStreamKnown ? [11] : []);
 
 		// when
 		var result = _sut.ConvertToMSAResponse(requests, input);
@@ -134,7 +136,7 @@ public class MSAResponseConverterTests {
 		Assert.Collection(
 			result.Failure.Output,
 			x => {
-				Assert.Equal("stream-at-index-1", x.Stream);
+				Assert.Equal(isStreamKnown ? "stream-at-index-1" : "<unknown>", x.Stream);
 				Assert.Equal(AppendStreamFailure.ErrorOneofCase.StreamDeleted, x.ErrorCase);
 			});
 	}

--- a/src/KurrentDB.Core/Services/Transport/Grpc/MSAResponseConverter.cs
+++ b/src/KurrentDB.Core/Services/Transport/Grpc/MSAResponseConverter.cs
@@ -93,7 +93,9 @@ public class MSAResponseConverter {
 					Failure = new() {
 						Output = {
 							new AppendStreamFailure {
-								Stream = appendStreamRequests[completed.FailureStreamIndexes.Span[0]].Stream,
+								Stream = completed.FailureStreamIndexes.Span is [var streamIndex, ..]
+									? appendStreamRequests[streamIndex].Stream
+									: "<unknown>",
 								StreamDeleted = StreamDeletedError,
 							},
 						},


### PR DESCRIPTION
The core ought to populate this, but we shouldn't rely on it