### PR TITLE
Add additional metrics for parked persistent subscription messages

### DIFF
--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionMessageParkerTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionMessageParkerTests.cs
@@ -215,8 +215,10 @@ public class PersistentSubscriptionMessageParkerTests {
 
 		[Test]
 		public async Task should_have_one_parked_message() {
-			_messageParker.BeginParkMessage(CreateResolvedEvent(0, 0), "testing", ParkReason.None, (_, __) => {
+			_messageParker.BeginParkMessage(CreateResolvedEvent(0, 0), "testing", ParkReason.ClientNak, (_, __) => {
 				Assert.AreEqual(1, _messageParker.ParkedMessageCount);
+				Assert.AreEqual(1, _messageParker.ParkedDueToClientNak);
+				Assert.AreEqual(0, _messageParker.ParkedDueToMaxRetries);
 				Assert.AreEqual(EventTimeStamps[0], _messageParker.GetOldestParkedMessage);
 				_done.TrySetResult(true);
 			});
@@ -239,8 +241,8 @@ public class PersistentSubscriptionMessageParkerTests {
 
 			_parked = new TaskCompletionSource<bool>();
 			_messageParker = new PersistentSubscriptionMessageParker(_streamId, _ioDispatcher);
-			_messageParker.BeginParkMessage(CreateResolvedEvent(0, 0), "testing", ParkReason.None, (_, __) => {
-				_messageParker.BeginParkMessage(CreateResolvedEvent(1, 100), "testing", ParkReason.None, (_, __) => {
+			_messageParker.BeginParkMessage(CreateResolvedEvent(0, 0), "testing", ParkReason.MaxRetries, (_, __) => {
+				_messageParker.BeginParkMessage(CreateResolvedEvent(1, 100), "testing", ParkReason.MaxRetries, (_, __) => {
 					_parked.SetResult(true);
 				});
 			});
@@ -251,6 +253,8 @@ public class PersistentSubscriptionMessageParkerTests {
 			await _parked.Task;
 			_messageParker.BeginMarkParkedMessagesReprocessed(2, null, true, () => {
 				Assert.Zero(_messageParker.ParkedMessageCount);
+				Assert.AreEqual(0, _messageParker.ParkedDueToClientNak);
+				Assert.AreEqual(2, _messageParker.ParkedDueToMaxRetries);
 				Assert.Null(_messageParker.GetOldestParkedMessage);
 				_done.TrySetResult(true);
 			});
@@ -273,8 +277,8 @@ public class PersistentSubscriptionMessageParkerTests {
 
 			_replayParked = new TaskCompletionSource<bool>();
 			_messageParker = new PersistentSubscriptionMessageParker(_streamId, _ioDispatcher);
-			_messageParker.BeginParkMessage(CreateResolvedEvent(0, 0), "testing", ParkReason.None, (_, __) => {
-				_messageParker.BeginParkMessage(CreateResolvedEvent(1, 100), "testing", ParkReason.None, (_, __) => {
+			_messageParker.BeginParkMessage(CreateResolvedEvent(0, 0), "testing", ParkReason.ClientNak, (_, __) => {
+				_messageParker.BeginParkMessage(CreateResolvedEvent(1, 100), "testing", ParkReason.ClientNak, (_, __) => {
 					_messageParker.BeginMarkParkedMessagesReprocessed(2, null, true, () => {
 						_replayParked.SetResult(true);
 					});
@@ -286,8 +290,10 @@ public class PersistentSubscriptionMessageParkerTests {
 		public async Task should_have_one_parked_message() {
 			await _replayParked.Task;
 			_timeProvider.AddToUtcTime(new TimeSpan(0, 0, 1, 0));
-			_messageParker.BeginParkMessage(CreateResolvedEvent(2, 200), "testing", ParkReason.None, (_, __) => {
+			_messageParker.BeginParkMessage(CreateResolvedEvent(2, 200), "testing", ParkReason.MaxRetries, (_, __) => {
 				Assert.AreEqual(1, _messageParker.ParkedMessageCount);
+				Assert.AreEqual(2, _messageParker.ParkedDueToClientNak);
+				Assert.AreEqual(1, _messageParker.ParkedDueToMaxRetries);
 				Assert.AreEqual(EventTimeStamps[2], _messageParker.GetOldestParkedMessage);
 				_done.TrySetResult(true);
 			});

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionMessageParkerTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionMessageParkerTests.cs
@@ -215,7 +215,7 @@ public class PersistentSubscriptionMessageParkerTests {
 
 		[Test]
 		public async Task should_have_one_parked_message() {
-			_messageParker.BeginParkMessage(CreateResolvedEvent(0, 0), "testing", (_, __) => {
+			_messageParker.BeginParkMessage(CreateResolvedEvent(0, 0), "testing", ParkReason.None, (_, __) => {
 				Assert.AreEqual(1, _messageParker.ParkedMessageCount);
 				Assert.AreEqual(EventTimeStamps[0], _messageParker.GetOldestParkedMessage);
 				_done.TrySetResult(true);
@@ -239,8 +239,8 @@ public class PersistentSubscriptionMessageParkerTests {
 
 			_parked = new TaskCompletionSource<bool>();
 			_messageParker = new PersistentSubscriptionMessageParker(_streamId, _ioDispatcher);
-			_messageParker.BeginParkMessage(CreateResolvedEvent(0, 0), "testing", (_, __) => {
-				_messageParker.BeginParkMessage(CreateResolvedEvent(1, 100), "testing", (_, __) => {
+			_messageParker.BeginParkMessage(CreateResolvedEvent(0, 0), "testing", ParkReason.None, (_, __) => {
+				_messageParker.BeginParkMessage(CreateResolvedEvent(1, 100), "testing", ParkReason.None, (_, __) => {
 					_parked.SetResult(true);
 				});
 			});
@@ -273,8 +273,8 @@ public class PersistentSubscriptionMessageParkerTests {
 
 			_replayParked = new TaskCompletionSource<bool>();
 			_messageParker = new PersistentSubscriptionMessageParker(_streamId, _ioDispatcher);
-			_messageParker.BeginParkMessage(CreateResolvedEvent(0, 0), "testing", (_, __) => {
-				_messageParker.BeginParkMessage(CreateResolvedEvent(1, 100), "testing", (_, __) => {
+			_messageParker.BeginParkMessage(CreateResolvedEvent(0, 0), "testing", ParkReason.None, (_, __) => {
+				_messageParker.BeginParkMessage(CreateResolvedEvent(1, 100), "testing", ParkReason.None, (_, __) => {
 					_messageParker.BeginMarkParkedMessagesReprocessed(2, null, true, () => {
 						_replayParked.SetResult(true);
 					});
@@ -286,7 +286,7 @@ public class PersistentSubscriptionMessageParkerTests {
 		public async Task should_have_one_parked_message() {
 			await _replayParked.Task;
 			_timeProvider.AddToUtcTime(new TimeSpan(0, 0, 1, 0));
-			_messageParker.BeginParkMessage(CreateResolvedEvent(2, 200), "testing", (_, __) => {
+			_messageParker.BeginParkMessage(CreateResolvedEvent(2, 200), "testing", ParkReason.None, (_, __) => {
 				Assert.AreEqual(1, _messageParker.ParkedMessageCount);
 				Assert.AreEqual(EventTimeStamps[2], _messageParker.GetOldestParkedMessage);
 				_done.TrySetResult(true);

--- a/src/EventStore.Core.XUnit.Tests/Metrics/PersistentSubscriptionMetricsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Metrics/PersistentSubscriptionMetricsTests.cs
@@ -2,6 +2,7 @@
 // Event Store Ltd licenses this file to you under the Event Store License v2 (see LICENSE.md).
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using System.Linq;
 using EventStore.Core.Messages;
@@ -36,6 +37,9 @@ public class PersistentSubscriptionMetricsTests {
 			NamedConsumerStrategy = "Round Robin",
 			OldestParkedMessage = 1007,
 			OutstandingMessagesCount = 2,
+			ParkedDueToClientNak = 2001,
+			ParkedDueToMaxRetries = 2002,
+			ParkedMessageReplays = 2003,
 			ParkedMessageCount = 1003,
 			ReadBatchSize = 20,
 			ReadBufferCount = 0,
@@ -68,6 +72,9 @@ public class PersistentSubscriptionMetricsTests {
 			NamedConsumerStrategy = "Round Robin",
 			OldestParkedMessage = 1008,
 			OutstandingMessagesCount = 2,
+			ParkedDueToClientNak = 2004,
+			ParkedDueToMaxRetries = 2005,
+			ParkedMessageReplays = 2006,
 			ParkedMessageCount = 1004,
 			ReadBatchSize = 20,
 			ReadBufferCount = 0,
@@ -99,6 +106,52 @@ public class PersistentSubscriptionMetricsTests {
 		Assert.Collection(measurements,
 			AssertMeasurement("test", "testGroup", 1003),
 			AssertMeasurement("$all", "testGroup", 1004));
+	}
+
+	[Fact]
+	public void ObserveParkMessageRequests() {
+		var measurements = _sut.ObserveParkMessageRequests();
+		Assert.Collection(measurements,
+			actual => {
+				Assert.Equal(2001, actual.Value);
+				Assert.Collection(
+					actual.Tags.ToArray(),
+					AssertTag("event_stream_id", "test"),
+					AssertTag("group_name", "testGroup"),
+					AssertTag("reason", "client-nak"));
+			},
+			actual => {
+				Assert.Equal(2002, actual.Value);
+				Assert.Collection(
+					actual.Tags.ToArray(),
+					AssertTag("event_stream_id", "test"),
+					AssertTag("group_name", "testGroup"),
+					AssertTag("reason", "max-retries"));
+			},
+			actual => {
+				Assert.Equal(2004, actual.Value);
+				Assert.Collection(
+					actual.Tags.ToArray(),
+					AssertTag("event_stream_id", "$all"),
+					AssertTag("group_name", "testGroup"),
+					AssertTag("reason", "client-nak"));
+			},
+			actual => {
+				Assert.Equal(2005, actual.Value);
+				Assert.Collection(
+					actual.Tags.ToArray(),
+					AssertTag("event_stream_id", "$all"),
+					AssertTag("group_name", "testGroup"),
+					AssertTag("reason", "max-retries"));
+			});
+	}
+
+	[Fact]
+	public void ObserveParkedMessageReplays() {
+		var measurements = _sut.ObserveParkedMessageReplays();
+		Assert.Collection(measurements,
+			AssertMeasurement("test", "testGroup", 2003),
+			AssertMeasurement("$all", "testGroup", 2006));
 	}
 
 	[Fact]
@@ -162,14 +215,13 @@ public class PersistentSubscriptionMetricsTests {
 			Assert.Equal(expectedValue, actualMeasurement.Value);
 			Assert.Collection(
 				actualMeasurement.Tags.ToArray(),
-				tag => {
-					Assert.Equal("event_stream_id", tag.Key);
-					Assert.Equal(sourceName, tag.Value);
-				},
-				tag => {
-					Assert.Equal("group_name", tag.Key);
-					Assert.Equal(groupName, tag.Value);
-				}
-			);
+				AssertTag("event_stream_id", sourceName),
+				AssertTag("group_name", groupName));
+		};
+
+	static Action<KeyValuePair<string, object>> AssertTag(string key, object value) =>
+		actualTag => {
+			Assert.Equal(key, actualTag.Key);
+			Assert.Equal(value, actualTag.Value);
 		};
 }

--- a/src/EventStore.Core/Messages/MonitoringMessage.cs
+++ b/src/EventStore.Core/Messages/MonitoringMessage.cs
@@ -132,6 +132,9 @@ public static partial class MonitoringMessage {
 		public string NamedConsumerStrategy { get; set; }
 		public int MaxSubscriberCount { get; set; }
 		public long ParkedMessageCount { get; set; }
+		public long ParkedDueToClientNak { get; set; }
+		public long ParkedDueToMaxRetries { get; set; }
+		public long ParkedMessageReplays { get; set; }
 		public long OldestParkedMessage { get; set; }
 	}
 

--- a/src/EventStore.Core/Metrics/PersistentSubscriptionTracker.cs
+++ b/src/EventStore.Core/Metrics/PersistentSubscriptionTracker.cs
@@ -29,6 +29,28 @@ public class PersistentSubscriptionTracker : IPersistentSubscriptionTracker {
 				new("group_name", x.GroupName)
 			]));
 
+	public IEnumerable<Measurement<long>> ObserveParkMessageRequests() =>
+		_currentStats.SelectMany<MonitoringMessage.PersistentSubscriptionInfo, Measurement<long>>(
+			x => [
+				new Measurement<long>(x.ParkedDueToClientNak, [
+					new("event_stream_id", x.EventSource),
+					new("group_name", x.GroupName),
+					new ("reason", "client-nak"),
+				]),
+				new Measurement<long>(x.ParkedDueToMaxRetries, [
+					new("event_stream_id", x.EventSource),
+					new("group_name", x.GroupName),
+					new ("reason", "max-retries"),
+				])
+			]);
+
+	public IEnumerable<Measurement<long>> ObserveParkedMessageReplays() =>
+		_currentStats.Select(x =>
+			new Measurement<long>(x.ParkedMessageReplays, [
+				new("event_stream_id", x.EventSource),
+				new("group_name", x.GroupName)
+			]));
+
 	public IEnumerable<Measurement<long>> ObserveInFlightMessages() =>
 		_currentStats.Select(x =>
 			new Measurement<long>(x.TotalInFlightMessages, [

--- a/src/EventStore.Core/Metrics/PersistentSubscriptionTracker.cs
+++ b/src/EventStore.Core/Metrics/PersistentSubscriptionTracker.cs
@@ -35,13 +35,13 @@ public class PersistentSubscriptionTracker : IPersistentSubscriptionTracker {
 				new Measurement<long>(x.ParkedDueToClientNak, [
 					new("event_stream_id", x.EventSource),
 					new("group_name", x.GroupName),
-					new ("reason", "client-nak"),
+					new("reason", "client-nak"),
 				]),
 				new Measurement<long>(x.ParkedDueToMaxRetries, [
 					new("event_stream_id", x.EventSource),
 					new("group_name", x.GroupName),
-					new ("reason", "max-retries"),
-				])
+					new("reason", "max-retries"),
+				]),
 			]);
 
 	public IEnumerable<Measurement<long>> ObserveParkedMessageReplays() =>

--- a/src/EventStore.Core/MetricsBootstrapper.cs
+++ b/src/EventStore.Core/MetricsBootstrapper.cs
@@ -172,6 +172,8 @@ public static class MetricsBootstrapper {
 
 			coreMeter.CreateObservableUpDownCounter("eventstore-persistent-sub-connections", tracker.ObserveConnectionsCount);
 			coreMeter.CreateObservableUpDownCounter("eventstore-persistent-sub-parked-messages", tracker.ObserveParkedMessages);
+			coreMeter.CreateObservableUpDownCounter("eventstore-persistent-sub-park-message-requests", tracker.ObserveParkMessageRequests);
+			coreMeter.CreateObservableUpDownCounter("eventstore-persistent-sub-parked-message-replays", tracker.ObserveParkedMessageReplays);
 			coreMeter.CreateObservableUpDownCounter("eventstore-persistent-sub-in-flight-messages", tracker.ObserveInFlightMessages);
 			coreMeter.CreateObservableUpDownCounter("eventstore-persistent-sub-oldest-parked-message-seconds", tracker.ObserveOldestParkedMessage);
 

--- a/src/EventStore.Core/MetricsBootstrapper.cs
+++ b/src/EventStore.Core/MetricsBootstrapper.cs
@@ -172,14 +172,14 @@ public static class MetricsBootstrapper {
 
 			coreMeter.CreateObservableUpDownCounter("eventstore-persistent-sub-connections", tracker.ObserveConnectionsCount);
 			coreMeter.CreateObservableUpDownCounter("eventstore-persistent-sub-parked-messages", tracker.ObserveParkedMessages);
-			coreMeter.CreateObservableUpDownCounter("eventstore-persistent-sub-park-message-requests", tracker.ObserveParkMessageRequests);
-			coreMeter.CreateObservableUpDownCounter("eventstore-persistent-sub-parked-message-replays", tracker.ObserveParkedMessageReplays);
 			coreMeter.CreateObservableUpDownCounter("eventstore-persistent-sub-in-flight-messages", tracker.ObserveInFlightMessages);
 			coreMeter.CreateObservableUpDownCounter("eventstore-persistent-sub-oldest-parked-message-seconds", tracker.ObserveOldestParkedMessage);
 
 			coreMeter.CreateObservableCounter("eventstore-persistent-sub-items-processed", tracker.ObserveItemsProcessed);
 			coreMeter.CreateObservableCounter("eventstore-persistent-sub-last-known-event-number", tracker.ObserveLastKnownEvent);
 			coreMeter.CreateObservableCounter("eventstore-persistent-sub-last-known-event-commit-position", tracker.ObserveLastKnownEventCommitPosition);
+			coreMeter.CreateObservableCounter("eventstore-persistent-sub-park-message-requests", tracker.ObserveParkMessageRequests);
+			coreMeter.CreateObservableCounter("eventstore-persistent-sub-parked-message-replays", tracker.ObserveParkedMessageReplays);
 			coreMeter.CreateObservableCounter("eventstore-persistent-sub-checkpointed-event-number", tracker.ObserveLastCheckpointedEvent);
 			coreMeter.CreateObservableCounter("eventstore-persistent-sub-checkpointed-event-commit-position", tracker.ObserveLastCheckpointedEventCommitPosition);
 		}

--- a/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionMessageParker.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionMessageParker.cs
@@ -21,6 +21,7 @@ public interface IPersistentSubscriptionMessageParker {
 }
 
 public enum ParkReason {
+	None = 0,
 	ClientNak,
 	MaxRetries,
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionMessageParker.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionMessageParker.cs
@@ -8,11 +8,19 @@ using EventStore.Core.Messages;
 namespace EventStore.Core.Services.PersistentSubscription;
 
 public interface IPersistentSubscriptionMessageParker {
-	void BeginParkMessage(ResolvedEvent ev, string reason, Action<ResolvedEvent, OperationResult> completed);
+	void BeginParkMessage(ResolvedEvent ev, string reason, ParkReason parkReason, Action<ResolvedEvent, OperationResult> completed);
 	void BeginReadEndSequence(Action<long?> completed);
 	void BeginMarkParkedMessagesReprocessed(long sequence, DateTime? oldestParkedMessageTimestamp, bool updateOldestParkedMessage);
 	void BeginDelete(Action<IPersistentSubscriptionMessageParker> completed);
 	long ParkedMessageCount { get; }
 	public void BeginLoadStats(Action completed);
 	DateTime? GetOldestParkedMessage { get; }
+	long ParkedDueToClientNak { get; }
+	long ParkedDueToMaxRetries { get; }
+	long ParkedMessageReplays { get; }
+}
+
+public enum ParkReason {
+	ClientNak,
+	MaxRetries,
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using EventStore.Common.Utils;
 using EventStore.Core.Data;
 using EventStore.Core.Helpers;
@@ -19,6 +20,10 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 	private long _lastTruncateBefore = -1;
 	private long _lastParkedEventNumber = -1;
 	private DateTime? _oldestParkedMessage;
+	private long _parkedDueToClientNak;
+	private long _parkedDueToMaxRetries;
+	private long _parkedMessageReplays;
+
 	public long ParkedMessageCount {
 		get {
 			return _lastParkedEventNumber == -1 ? 0 :
@@ -26,6 +31,10 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 				_lastParkedEventNumber - _lastTruncateBefore + 1;
 		}
 	}
+
+	public long ParkedDueToClientNak => Interlocked.Read(ref _parkedDueToClientNak);
+	public long ParkedDueToMaxRetries => Interlocked.Read(ref _parkedDueToMaxRetries);
+	public long ParkedMessageReplays => Interlocked.Read(ref _parkedMessageReplays);
 
 	private static readonly ILogger Log = Serilog.Log.ForContext<PersistentSubscriptionMessageParker>();
 
@@ -65,8 +74,20 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 		completed?.Invoke(ev, msg.Result);
 	}
 
-	public void BeginParkMessage(ResolvedEvent ev, string reason,
+	public void BeginParkMessage(ResolvedEvent ev, string reason, ParkReason parkReason,
 		Action<ResolvedEvent, OperationResult> completed) {
+
+		switch (parkReason) {
+			case ParkReason.MaxRetries:
+				Interlocked.Increment(ref _parkedDueToMaxRetries);
+				break;
+			case ParkReason.ClientNak:
+				Interlocked.Increment(ref _parkedDueToClientNak);
+				break;
+			default:
+				throw new ArgumentOutOfRangeException(nameof(parkReason));
+		}
+
 		var metadata = new ParkedMessageMetadata { Added = DateTime.Now, Reason = reason, SubscriptionEventNumber = ev.OriginalEventNumber };
 
 		string data = GetLinkToFor(ev);
@@ -106,6 +127,8 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 	}
 
 	public void BeginReadEndSequence(Action<long?> completed) {
+		Interlocked.Increment(ref _parkedMessageReplays);
+
 		_ioDispatcher.ReadBackward(ParkedStreamId,
 			long.MaxValue,
 			1,

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -1141,9 +1141,10 @@ public class PersistentSubscriptionService<TStreamId> :
 	public void Handle(ClientMessage.ReplayParkedMessages message) {
 		PersistentSubscription subscription;
 		var key = BuildSubscriptionGroupKey(message.EventStreamId, message.GroupName);
-		Log.Debug("Replaying parked messages for persistent subscription {subscriptionKey} {to}",
+		Log.Debug("Replaying parked messages for persistent subscription {subscriptionKey} {to}. Requested by {user}",
 			key,
-			message.StopAt.HasValue ? $" (To: '{message.StopAt.ToString()}')" : " (All)");
+			message.StopAt.HasValue ? $" (To: '{message.StopAt.ToString()}')" : " (All)",
+			message.User?.Identity?.Name);
 
 		if (message.StopAt.HasValue && message.StopAt.Value < 0) {
 			message.Envelope.ReplyWith(new ClientMessage.ReplayMessagesReceived(message.CorrelationId,

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
@@ -117,6 +117,9 @@ public class PersistentSubscriptionStats {
 			NamedConsumerStrategy = _settings.ConsumerStrategy.Name,
 			MaxSubscriberCount = _settings.MaxSubscriberCount,
 			ParkedMessageCount = parkedMessageCount,
+			ParkedDueToClientNak = _settings.MessageParker.ParkedDueToClientNak,
+			ParkedDueToMaxRetries = _settings.MessageParker.ParkedDueToMaxRetries,
+			ParkedMessageReplays = _settings.MessageParker.ParkedMessageReplays,
 			OldestParkedMessage = oldestParkedMessage
 		};
 	}


### PR DESCRIPTION
Added: Additional metrics for parked persistent subscription messages

This PR adds two persistent subscription metrics to count the number of parked message requests and replays. The requests are subdivided into two reason categories: `client-nak`, `max-retries`

```
# TYPE eventstore_persistent_sub_park_message_requests gauge
eventstore_persistent_sub_park_message_requests{event_stream_id="test",group_name="test",reason="client-nak"} 0 1747226271196
eventstore_persistent_sub_park_message_requests{event_stream_id="test",group_name="test",reason="max-retries"} 0 1747226271196

# TYPE eventstore_persistent_sub_parked_message_replays gauge
eventstore_persistent_sub_parked_message_replays{event_stream_id="test",group_name="test"} 1 1747226271196
```
