### PR TITLE
Rearrange release notes settings

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -9,9 +9,6 @@ changelog:
     - title: Fixed
       labels:
         - bug
-    - title: Changed
-      labels:
-        - "*"
     - title: Deprecated
       labels:
         - deprecated
@@ -21,3 +18,6 @@ changelog:
     - title: Documentation
       labels:
         - documentation
+    - title: Changed
+      labels:
+        - "*"


### PR DESCRIPTION
So that deprecated and documentation labels are correctly applied.