### PR TITLE
Add additional metrics for parked persistent subscription messages (ported from #5062)

### DIFF
--- a/src/KurrentDB.Core/Messages/MonitoringMessage.cs
+++ b/src/KurrentDB.Core/Messages/MonitoringMessage.cs
@@ -132,6 +132,9 @@ public static partial class MonitoringMessage {
 		public string NamedConsumerStrategy { get; set; }
 		public int MaxSubscriberCount { get; set; }
 		public long ParkedMessageCount { get; set; }
+		public long ParkedDueToClientNak { get; set; }
+		public long ParkedDueToMaxRetries { get; set; }
+		public long ParkedMessageReplays { get; set; }
 		public long OldestParkedMessage { get; set; }
 	}
 

--- a/src/KurrentDB.Core/Metrics/PersistentSubscriptionTracker.cs
+++ b/src/KurrentDB.Core/Metrics/PersistentSubscriptionTracker.cs
@@ -29,6 +29,28 @@ public class PersistentSubscriptionTracker : IPersistentSubscriptionTracker {
 				new("group_name", x.GroupName)
 			]));
 
+	public IEnumerable<Measurement<long>> ObserveParkMessageRequests() =>
+		_currentStats.SelectMany<MonitoringMessage.PersistentSubscriptionInfo, Measurement<long>>(
+			x => [
+				new Measurement<long>(x.ParkedDueToClientNak, [
+					new("event_stream_id", x.EventSource),
+					new("group_name", x.GroupName),
+					new("reason", "client-nak"),
+				]),
+				new Measurement<long>(x.ParkedDueToMaxRetries, [
+					new("event_stream_id", x.EventSource),
+					new("group_name", x.GroupName),
+					new("reason", "max-retries"),
+				]),
+			]);
+
+	public IEnumerable<Measurement<long>> ObserveParkedMessageReplays() =>
+		_currentStats.Select(x =>
+			new Measurement<long>(x.ParkedMessageReplays, [
+				new("event_stream_id", x.EventSource),
+				new("group_name", x.GroupName)
+			]));
+
 	public IEnumerable<Measurement<long>> ObserveInFlightMessages() =>
 		_currentStats.Select(x =>
 			new Measurement<long>(x.TotalInFlightMessages, [

--- a/src/KurrentDB.Core/MetricsBootstrapper.cs
+++ b/src/KurrentDB.Core/MetricsBootstrapper.cs
@@ -179,6 +179,8 @@ public static class MetricsBootstrapper {
 			// these only go up, but are not strictly counters; should not have `_total` appended
 			coreMeter.CreateObservableUpDownCounter($"{serviceName}-persistent-sub-last-known-event-number", tracker.ObserveLastKnownEvent);
 			coreMeter.CreateObservableUpDownCounter($"{serviceName}-persistent-sub-last-known-event-commit-position", tracker.ObserveLastKnownEventCommitPosition);
+			coreMeter.CreateObservableUpDownCounter($"{serviceName}-persistent-sub-park-message-requests", tracker.ObserveParkMessageRequests);
+			coreMeter.CreateObservableUpDownCounter($"{serviceName}-persistent-sub-parked-message-replays", tracker.ObserveParkedMessageReplays);
 			coreMeter.CreateObservableUpDownCounter($"{serviceName}-persistent-sub-checkpointed-event-number", tracker.ObserveLastCheckpointedEvent);
 			coreMeter.CreateObservableUpDownCounter($"{serviceName}-persistent-sub-checkpointed-event-commit-position", tracker.ObserveLastCheckpointedEventCommitPosition);
 

--- a/src/KurrentDB.Core/Services/PersistentSubscription/IPersistentSubscriptionMessageParker.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/IPersistentSubscriptionMessageParker.cs
@@ -8,11 +8,20 @@ using KurrentDB.Core.Messages;
 namespace KurrentDB.Core.Services.PersistentSubscription;
 
 public interface IPersistentSubscriptionMessageParker {
-	void BeginParkMessage(ResolvedEvent ev, string reason, Action<ResolvedEvent, OperationResult> completed);
+	void BeginParkMessage(ResolvedEvent ev, string reason, ParkReason parkReason, Action<ResolvedEvent, OperationResult> completed);
 	void BeginReadEndSequence(Action<long?> completed);
 	void BeginMarkParkedMessagesReprocessed(long sequence, DateTime? oldestParkedMessageTimestamp, bool updateOldestParkedMessage);
 	void BeginDelete(Action<IPersistentSubscriptionMessageParker> completed);
 	long ParkedMessageCount { get; }
 	public void BeginLoadStats(Action completed);
 	DateTime? GetOldestParkedMessage { get; }
+	long ParkedDueToClientNak { get; }
+	long ParkedDueToMaxRetries { get; }
+	long ParkedMessageReplays { get; }
+}
+
+public enum ParkReason {
+	None = 0,
+	ClientNak,
+	MaxRetries,
 }

--- a/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -1116,9 +1116,10 @@ public class PersistentSubscriptionService<TStreamId> :
 	public void Handle(ClientMessage.ReplayParkedMessages message) {
 		PersistentSubscription subscription;
 		var key = BuildSubscriptionGroupKey(message.EventStreamId, message.GroupName);
-		Log.Debug("Replaying parked messages for persistent subscription {subscriptionKey} {to}",
+		Log.Debug("Replaying parked messages for persistent subscription {subscriptionKey} {to}. Requested by {user}",
 			key,
-			message.StopAt.HasValue ? $" (To: '{message.StopAt.ToString()}')" : " (All)");
+			message.StopAt.HasValue ? $" (To: '{message.StopAt.ToString()}')" : " (All)",
+			message.User?.Identity?.Name);
 
 		if (message.StopAt.HasValue && message.StopAt.Value < 0) {
 			message.Envelope.ReplyWith(new ClientMessage.ReplayMessagesReceived(message.CorrelationId,

--- a/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
+++ b/src/KurrentDB.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
@@ -117,6 +117,9 @@ public class PersistentSubscriptionStats {
 			NamedConsumerStrategy = _settings.ConsumerStrategy.Name,
 			MaxSubscriberCount = _settings.MaxSubscriberCount,
 			ParkedMessageCount = parkedMessageCount,
+			ParkedDueToClientNak = _settings.MessageParker.ParkedDueToClientNak,
+			ParkedDueToMaxRetries = _settings.MessageParker.ParkedDueToMaxRetries,
+			ParkedMessageReplays = _settings.MessageParker.ParkedMessageReplays,
 			OldestParkedMessage = oldestParkedMessage
 		};
 	}


### PR DESCRIPTION
Added: Additional metrics for parked persistent subscription messages

Ported from https://github.com/kurrent-io/KurrentDB/pull/5062

This PR adds two persistent subscription metrics to count the number of parked message requests and replays. The requests are subdivided into two reason categories: client-nak, max-retries

```
# TYPE kurrentdb_persistent_sub_park_message_requests gauge
kurrentdb_persistent_sub_park_message_requests{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",event_stream_id="test",group_name="test",reason="client-nak"} 0 1747290696031
kurrentdb_persistent_sub_park_message_requests{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",event_stream_id="test",group_name="test",reason="max-retries"} 4 1747290696031

# TYPE kurrentdb_persistent_sub_parked_message_replays gauge
kurrentdb_persistent_sub_parked_message_replays{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",event_stream_id="test",group_name="test"} 3 1747290696031
```