### PR TITLE
Projections Testing  Allow testing the Result as well as State 

### DIFF
--- a/src/KurrentDB.Projections.Core.Javascript.Tests/KurrentDB.Projections.Core.Javascript.Tests.csproj
+++ b/src/KurrentDB.Projections.Core.Javascript.Tests/KurrentDB.Projections.Core.Javascript.Tests.csproj
@@ -4,21 +4,10 @@
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 	<ItemGroup>
-		<None Remove="Specs\account-balancer.js" />
-		<None Remove="Specs\account-closer.js" />
-		<None Remove="Specs\by-category-spec.json" />
-		<None Remove="Specs\by-category.js" />
-		<None Remove="Specs\event-data.js" />
-		<None Remove="Specs\event-data-spec.json" />
+		<None Remove="Specs\*" />
 	</ItemGroup>
 	<ItemGroup>
-		<EmbeddedResource Include="Specs\account-balancer.js" />
-		<EmbeddedResource Include="Specs\account-closer.js" />
-		<EmbeddedResource Include="Specs\by-category-spec.json" />
-		<EmbeddedResource Include="Specs\by-category.js" />
-		<EmbeddedResource Include="Specs\event-data.js" />
-		<EmbeddedResource Include="Specs\event-data-spec.json" />
-		<EmbeddedResource Include="Specs\account-spec.json" />
+		<EmbeddedResource Include="Specs\*" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />

--- a/src/KurrentDB.Projections.Core.Javascript.Tests/Specs/state_with_null_result-spec.json
+++ b/src/KurrentDB.Projections.Core.Javascript.Tests/Specs/state_with_null_result-spec.json
@@ -1,0 +1,32 @@
+{
+	"projection": "state_with_null_result",
+	"input": [
+		{
+			"streamId": "with_null",
+			"events": [
+				{"eventType": "with_null","data": {}, "metadata":  {},"initializedPartitions": [ "" ], "states": [{"partition": "","state": {"d":[0]    }, "result": null }]},
+				{"eventType": "with_null","data": {}, "metadata":  {}, 								 "states": [{"partition": "","state": {"d":[0,1]  }, "result": null }]},
+				{"eventType": "with_null","data": {}, "metadata":  {}, 								 "states": [{"partition": "","state": {"d":[0,1,2]}, "result": null }]}
+			]
+		}
+	],
+	"output": {
+		"config": {
+			"categories": [],
+			"allStreams": true,
+			"events": ["with_null"] ,
+			"partitioned": false,
+			"definesStateTransform": true,
+			"handlesDeletedNotifications": false,
+			"producesResults": true,
+			"definesFold": true,
+			"resultStreamName": "",
+			"partitionResultStreamNamePattern": null,
+			"$includeLinks": false,
+			"reorderEvents": false,
+			"processingLag": 0,
+			"biState": false
+		}
+	}
+}
+

--- a/src/KurrentDB.Projections.Core.Javascript.Tests/Specs/state_with_null_result.js
+++ b/src/KurrentDB.Projections.Core.Javascript.Tests/Specs/state_with_null_result.js
@@ -1,0 +1,6 @@
+﻿fromAll()
+	.when({
+		$init: function () {return {d: []}},
+		with_null: function (s, e) {s.d[e.sequenceNumber]=e.sequenceNumber},
+	})
+	.transformBy(function (state) {return null;});

--- a/src/KurrentDB.Projections.Core.Javascript.Tests/Specs/with_result-spec.json
+++ b/src/KurrentDB.Projections.Core.Javascript.Tests/Specs/with_result-spec.json
@@ -1,0 +1,32 @@
+{
+	"projection": "with_result",
+	"input": [
+		{
+			"streamId": "with_result",
+			"events": [
+				{"eventType": "tested","data": {}, "metadata":  {},"initializedPartitions": [ "" ], "states": [{"partition": "","state": {"count":1 }, "result": { "Total":1} }]},
+				{"eventType": "tested","data": {}, "metadata":  {}, 								 "states": [{"partition": "","state": {"count":2 }, "result": { "Total":2} }]},
+				{"eventType": "tested","data": {}, "metadata":  {}, 								 "states": [{"partition": "","state": {"count":3 }, "result": { "Total":3} }]}
+			]
+		}
+	],
+	"output": {
+		"config": {
+			"categories": [],
+			"allStreams": true,
+			"events": ["tested"] ,
+			"partitioned": false,
+			"definesStateTransform": true,
+			"handlesDeletedNotifications": false,
+			"producesResults": true,
+			"definesFold": true,
+			"resultStreamName": "",
+			"partitionResultStreamNamePattern": null,
+			"$includeLinks": false,
+			"reorderEvents": false,
+			"processingLag": 0,
+			"biState": false
+		}
+	}
+}
+

--- a/src/KurrentDB.Projections.Core.Javascript.Tests/Specs/with_result.js
+++ b/src/KurrentDB.Projections.Core.Javascript.Tests/Specs/with_result.js
@@ -1,0 +1,6 @@
+﻿fromAll()
+	.when({
+		$init: function () {return {count:0}},
+		tested: function (s, e) {s.count++},
+	})
+	.transformBy(function (state) {return {Total: state.count}})


### PR DESCRIPTION
* Allow testing the Result as well as State. Ensure that the behavior of
`.transformBy(function (state) {return null;});`
is tested to keep it this way.
As this cuts the checkpoint size in 2 when the Result is not used by consumers.