### PR TITLE
Add additional metrics for parked persistent subscription messages (ported from #5062) (#5068)

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Metrics/MetricsEndpointTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Metrics/MetricsEndpointTests.cs
@@ -1,11 +1,16 @@
 // Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using EventStore.Common.Configuration;
+using EventStore.Core.Bus;
 using EventStore.Core.Configuration.Sources;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.UserManagement;
 using EventStore.Core.Tests;
 using EventStore.Core.Tests.Helpers;
 using Microsoft.Extensions.Configuration;
@@ -29,6 +34,39 @@ public class MetricsEndpointTests : DirectoryPerTest<MetricsEndpointTests> {
 			Assert.Contains(expected, content);
 	}
 
+	private async static Task CreatePersistentSubscription(IPublisher publisher) {
+		var tcs = new TaskCompletionSource();
+		publisher.Publish(new ClientMessage.CreatePersistentSubscriptionToStream(
+			internalCorrId: Guid.NewGuid(),
+			correlationId: Guid.NewGuid(),
+			envelope: new CallbackEnvelope(msg => {
+				var completed = msg as ClientMessage.CreatePersistentSubscriptionToStreamCompleted;
+				Assert.NotNull(completed);
+				Assert.Equal(ClientMessage.CreatePersistentSubscriptionToStreamCompleted.
+					CreatePersistentSubscriptionToStreamResult.Success, completed.Result);
+				tcs.SetResult();
+			}),
+			eventStreamId: "stream",
+			groupName: "group",
+			resolveLinkTos: false,
+			startFrom: 0,
+			messageTimeoutMilliseconds: 1000,
+			recordStatistics: false,
+			maxRetryCount: 10,
+			bufferSize: 100,
+			liveBufferSize: 10,
+			readbatchSize: 10,
+			checkPointAfterMilliseconds: 1000,
+			minCheckPointCount: 10,
+			maxCheckPointCount: 10,
+			maxSubscriberCount: 10,
+			namedConsumerStrategy: "RoundRobin",
+			user: SystemAccounts.System));
+
+		await tcs.Task;
+		await Task.Delay(TimeSpan.FromSeconds(1));
+	}
+
 	async Task<string> Query(bool legacy) {
 		var configuration = new ConfigurationBuilder()
 			.AddSection($"{KurrentConfigurationKeys.Prefix}:Metrics", x => x
@@ -44,6 +82,9 @@ public class MetricsEndpointTests : DirectoryPerTest<MetricsEndpointTests> {
 			.Build();
 		await using var sut = new MiniNode<LogFormat.V2, string>(Fixture.Directory, configuration: configuration);
 		await sut.Start();
+
+		await CreatePersistentSubscription(sut.Node.MainQueue);
+
 		sut.HttpClient.DefaultRequestHeaders.Add(
 			"Accept",
 			"application/openmetrics-text;version=1.0.0,application/openmetrics-text;version=0.0.1;q=0.75,text/plain;version=0.0.4;q=0.5,*/*;q=0.1");
@@ -96,6 +137,15 @@ public class MetricsEndpointTests : DirectoryPerTest<MetricsEndpointTests> {
 		"# TYPE kurrentdb_sys_mem_bytes gauge",
 		"# TYPE kurrentdb_writer_flush_duration_max_seconds gauge",
 		"# TYPE kurrentdb_writer_flush_size_max gauge",
+		"# TYPE kurrentdb_persistent_sub_connections gauge",
+		"# TYPE kurrentdb_persistent_sub_parked_messages gauge",
+		"# TYPE kurrentdb_persistent_sub_in_flight_messages gauge",
+		"# TYPE kurrentdb_persistent_sub_oldest_parked_message_seconds gauge",
+		"# TYPE kurrentdb_persistent_sub_last_known_event_number gauge",
+		"# TYPE kurrentdb_persistent_sub_park_message_requests gauge",
+		"# TYPE kurrentdb_persistent_sub_parked_message_replays gauge",
+		"# TYPE kurrentdb_persistent_sub_checkpointed_event_number gauge",
+		"# TYPE kurrentdb_persistent_sub_items_processed counter",
 
 		"# UNIT kurrentdb_cache_resources_entries entries",
 		"# UNIT kurrentdb_disk_io_bytes bytes",
@@ -157,6 +207,15 @@ public class MetricsEndpointTests : DirectoryPerTest<MetricsEndpointTests> {
 		"kurrentdb_sys_mem_bytes{",
 		"kurrentdb_writer_flush_duration_max_seconds{",
 		"kurrentdb_writer_flush_size_max{",
+		"kurrentdb_persistent_sub_connections{",
+		"kurrentdb_persistent_sub_parked_messages{",
+		"kurrentdb_persistent_sub_in_flight_messages{",
+		"kurrentdb_persistent_sub_oldest_parked_message_seconds{",
+		"kurrentdb_persistent_sub_last_known_event_number{",
+		"kurrentdb_persistent_sub_park_message_requests{",
+		"kurrentdb_persistent_sub_parked_message_replays{",
+		"kurrentdb_persistent_sub_checkpointed_event_number{",
+		"kurrentdb_persistent_sub_items_processed_total{",
 	];
 
 	static IEnumerable<string> EventStoreMetrics => [
@@ -193,6 +252,15 @@ public class MetricsEndpointTests : DirectoryPerTest<MetricsEndpointTests> {
 		"# TYPE eventstore_sys_mem_bytes gauge",
 		"# TYPE eventstore_writer_flush_duration_max_seconds gauge",
 		"# TYPE eventstore_writer_flush_size_max gauge",
+		"# TYPE eventstore_persistent_sub_connections gauge",
+		"# TYPE eventstore_persistent_sub_parked_messages gauge",
+		"# TYPE eventstore_persistent_sub_in_flight_messages gauge",
+		"# TYPE eventstore_persistent_sub_oldest_parked_message_seconds gauge",
+		"# TYPE eventstore_persistent_sub_last_known_event_number gauge",
+		"# TYPE eventstore_persistent_sub_park_message_requests gauge",
+		"# TYPE eventstore_persistent_sub_parked_message_replays gauge",
+		"# TYPE eventstore_persistent_sub_checkpointed_event_number gauge",
+		"# TYPE eventstore_persistent_sub_items_processed counter",
 
 		"eventstore_cache_hits_misses{",
 		"eventstore_cache_resources_entries{",
@@ -229,5 +297,14 @@ public class MetricsEndpointTests : DirectoryPerTest<MetricsEndpointTests> {
 		"eventstore_sys_mem_bytes{",
 		"eventstore_writer_flush_duration_max_seconds{",
 		"eventstore_writer_flush_size_max{",
+		"eventstore_persistent_sub_connections{",
+		"eventstore_persistent_sub_parked_messages{",
+		"eventstore_persistent_sub_in_flight_messages{",
+		"eventstore_persistent_sub_oldest_parked_message_seconds{",
+		"eventstore_persistent_sub_last_known_event_number{",
+		"eventstore_persistent_sub_park_message_requests{",
+		"eventstore_persistent_sub_parked_message_replays{",
+		"eventstore_persistent_sub_checkpointed_event_number{",
+		"eventstore_persistent_sub_items_processed{",
 	];
 }

--- a/src/EventStore.Core.XUnit.Tests/Metrics/PersistentSubscriptionMetricsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Metrics/PersistentSubscriptionMetricsTests.cs
@@ -2,6 +2,7 @@
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using System.Linq;
 using EventStore.Core.Messages;
@@ -36,6 +37,9 @@ public class PersistentSubscriptionMetricsTests {
 			NamedConsumerStrategy = "Round Robin",
 			OldestParkedMessage = 1007,
 			OutstandingMessagesCount = 2,
+			ParkedDueToClientNak = 2001,
+			ParkedDueToMaxRetries = 2002,
+			ParkedMessageReplays = 2003,
 			ParkedMessageCount = 1003,
 			ReadBatchSize = 20,
 			ReadBufferCount = 0,
@@ -68,6 +72,9 @@ public class PersistentSubscriptionMetricsTests {
 			NamedConsumerStrategy = "Round Robin",
 			OldestParkedMessage = 1008,
 			OutstandingMessagesCount = 2,
+			ParkedDueToClientNak = 2004,
+			ParkedDueToMaxRetries = 2005,
+			ParkedMessageReplays = 2006,
 			ParkedMessageCount = 1004,
 			ReadBatchSize = 20,
 			ReadBufferCount = 0,
@@ -99,6 +106,52 @@ public class PersistentSubscriptionMetricsTests {
 		Assert.Collection(measurements,
 			AssertMeasurement("test", "testGroup", 1003),
 			AssertMeasurement("$all", "testGroup", 1004));
+	}
+
+	[Fact]
+	public void ObserveParkMessageRequests() {
+		var measurements = _sut.ObserveParkMessageRequests();
+		Assert.Collection(measurements,
+			actual => {
+				Assert.Equal(2001, actual.Value);
+				Assert.Collection(
+					actual.Tags.ToArray(),
+					AssertTag("event_stream_id", "test"),
+					AssertTag("group_name", "testGroup"),
+					AssertTag("reason", "client-nak"));
+			},
+			actual => {
+				Assert.Equal(2002, actual.Value);
+				Assert.Collection(
+					actual.Tags.ToArray(),
+					AssertTag("event_stream_id", "test"),
+					AssertTag("group_name", "testGroup"),
+					AssertTag("reason", "max-retries"));
+			},
+			actual => {
+				Assert.Equal(2004, actual.Value);
+				Assert.Collection(
+					actual.Tags.ToArray(),
+					AssertTag("event_stream_id", "$all"),
+					AssertTag("group_name", "testGroup"),
+					AssertTag("reason", "client-nak"));
+			},
+			actual => {
+				Assert.Equal(2005, actual.Value);
+				Assert.Collection(
+					actual.Tags.ToArray(),
+					AssertTag("event_stream_id", "$all"),
+					AssertTag("group_name", "testGroup"),
+					AssertTag("reason", "max-retries"));
+			});
+	}
+
+	[Fact]
+	public void ObserveParkedMessageReplays() {
+		var measurements = _sut.ObserveParkedMessageReplays();
+		Assert.Collection(measurements,
+			AssertMeasurement("test", "testGroup", 2003),
+			AssertMeasurement("$all", "testGroup", 2006));
 	}
 
 	[Fact]
@@ -162,14 +215,13 @@ public class PersistentSubscriptionMetricsTests {
 			Assert.Equal(expectedValue, actualMeasurement.Value);
 			Assert.Collection(
 				actualMeasurement.Tags.ToArray(),
-				tag => {
-					Assert.Equal("event_stream_id", tag.Key);
-					Assert.Equal(sourceName, tag.Value);
-				},
-				tag => {
-					Assert.Equal("group_name", tag.Key);
-					Assert.Equal(groupName, tag.Value);
-				}
-			);
+				AssertTag("event_stream_id", sourceName),
+				AssertTag("group_name", groupName));
+		};
+
+	static Action<KeyValuePair<string, object>> AssertTag(string key, object value) =>
+		actualTag => {
+			Assert.Equal(key, actualTag.Key);
+			Assert.Equal(value, actualTag.Value);
 		};
 }

--- a/src/EventStore.Core/Messages/MonitoringMessage.cs
+++ b/src/EventStore.Core/Messages/MonitoringMessage.cs
@@ -132,6 +132,9 @@ public static partial class MonitoringMessage {
 		public string NamedConsumerStrategy { get; set; }
 		public int MaxSubscriberCount { get; set; }
 		public long ParkedMessageCount { get; set; }
+		public long ParkedDueToClientNak { get; set; }
+		public long ParkedDueToMaxRetries { get; set; }
+		public long ParkedMessageReplays { get; set; }
 		public long OldestParkedMessage { get; set; }
 	}
 

--- a/src/EventStore.Core/Metrics/PersistentSubscriptionTracker.cs
+++ b/src/EventStore.Core/Metrics/PersistentSubscriptionTracker.cs
@@ -29,6 +29,28 @@ public class PersistentSubscriptionTracker : IPersistentSubscriptionTracker {
 				new("group_name", x.GroupName)
 			]));
 
+	public IEnumerable<Measurement<long>> ObserveParkMessageRequests() =>
+		_currentStats.SelectMany<MonitoringMessage.PersistentSubscriptionInfo, Measurement<long>>(
+			x => [
+				new Measurement<long>(x.ParkedDueToClientNak, [
+					new("event_stream_id", x.EventSource),
+					new("group_name", x.GroupName),
+					new("reason", "client-nak"),
+				]),
+				new Measurement<long>(x.ParkedDueToMaxRetries, [
+					new("event_stream_id", x.EventSource),
+					new("group_name", x.GroupName),
+					new("reason", "max-retries"),
+				]),
+			]);
+
+	public IEnumerable<Measurement<long>> ObserveParkedMessageReplays() =>
+		_currentStats.Select(x =>
+			new Measurement<long>(x.ParkedMessageReplays, [
+				new("event_stream_id", x.EventSource),
+				new("group_name", x.GroupName)
+			]));
+
 	public IEnumerable<Measurement<long>> ObserveInFlightMessages() =>
 		_currentStats.Select(x =>
 			new Measurement<long>(x.TotalInFlightMessages, [

--- a/src/EventStore.Core/MetricsBootstrapper.cs
+++ b/src/EventStore.Core/MetricsBootstrapper.cs
@@ -179,6 +179,8 @@ public static class MetricsBootstrapper {
 			// these only go up, but are not strictly counters; should not have `_total` appended
 			coreMeter.CreateObservableUpDownCounter($"{serviceName}-persistent-sub-last-known-event-number", tracker.ObserveLastKnownEvent);
 			coreMeter.CreateObservableUpDownCounter($"{serviceName}-persistent-sub-last-known-event-commit-position", tracker.ObserveLastKnownEventCommitPosition);
+			coreMeter.CreateObservableUpDownCounter($"{serviceName}-persistent-sub-park-message-requests", tracker.ObserveParkMessageRequests);
+			coreMeter.CreateObservableUpDownCounter($"{serviceName}-persistent-sub-parked-message-replays", tracker.ObserveParkedMessageReplays);
 			coreMeter.CreateObservableUpDownCounter($"{serviceName}-persistent-sub-checkpointed-event-number", tracker.ObserveLastCheckpointedEvent);
 			coreMeter.CreateObservableUpDownCounter($"{serviceName}-persistent-sub-checkpointed-event-commit-position", tracker.ObserveLastCheckpointedEventCommitPosition);
 

--- a/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionMessageParker.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionMessageParker.cs
@@ -8,11 +8,20 @@ using EventStore.Core.Messages;
 namespace EventStore.Core.Services.PersistentSubscription;
 
 public interface IPersistentSubscriptionMessageParker {
-	void BeginParkMessage(ResolvedEvent ev, string reason, Action<ResolvedEvent, OperationResult> completed);
+	void BeginParkMessage(ResolvedEvent ev, string reason, ParkReason parkReason, Action<ResolvedEvent, OperationResult> completed);
 	void BeginReadEndSequence(Action<long?> completed);
 	void BeginMarkParkedMessagesReprocessed(long sequence, DateTime? oldestParkedMessageTimestamp, bool updateOldestParkedMessage);
 	void BeginDelete(Action<IPersistentSubscriptionMessageParker> completed);
 	long ParkedMessageCount { get; }
 	public void BeginLoadStats(Action completed);
 	DateTime? GetOldestParkedMessage { get; }
+	long ParkedDueToClientNak { get; }
+	long ParkedDueToMaxRetries { get; }
+	long ParkedMessageReplays { get; }
+}
+
+public enum ParkReason {
+	None = 0,
+	ClientNak,
+	MaxRetries,
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using EventStore.Common.Utils;
 using EventStore.Core.Data;
 using EventStore.Core.Helpers;
@@ -19,6 +20,10 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 	private long _lastTruncateBefore = -1;
 	private long _lastParkedEventNumber = -1;
 	private DateTime? _oldestParkedMessage;
+	private long _parkedDueToClientNak;
+	private long _parkedDueToMaxRetries;
+	private long _parkedMessageReplays;
+
 	public long ParkedMessageCount {
 		get {
 			return _lastParkedEventNumber == -1 ? 0 :
@@ -26,6 +31,10 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 				_lastParkedEventNumber - _lastTruncateBefore + 1;
 		}
 	}
+
+	public long ParkedDueToClientNak => Interlocked.Read(ref _parkedDueToClientNak);
+	public long ParkedDueToMaxRetries => Interlocked.Read(ref _parkedDueToMaxRetries);
+	public long ParkedMessageReplays => Interlocked.Read(ref _parkedMessageReplays);
 
 	private static readonly ILogger Log = Serilog.Log.ForContext<PersistentSubscriptionMessageParker>();
 
@@ -65,8 +74,19 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 		completed?.Invoke(ev, msg.Result);
 	}
 
-	public void BeginParkMessage(ResolvedEvent ev, string reason,
+	public void BeginParkMessage(ResolvedEvent ev, string reason, ParkReason parkReason,
 		Action<ResolvedEvent, OperationResult> completed) {
+		switch (parkReason) {
+			case ParkReason.MaxRetries:
+				Interlocked.Increment(ref _parkedDueToMaxRetries);
+				break;
+			case ParkReason.ClientNak:
+				Interlocked.Increment(ref _parkedDueToClientNak);
+				break;
+			default:
+				throw new ArgumentOutOfRangeException(nameof(parkReason));
+		}
+
 		var metadata = new ParkedMessageMetadata { Added = DateTime.Now, Reason = reason, SubscriptionEventNumber = ev.OriginalEventNumber };
 
 		string data = GetLinkToFor(ev);
@@ -106,6 +126,8 @@ public class PersistentSubscriptionMessageParker : IPersistentSubscriptionMessag
 	}
 
 	public void BeginReadEndSequence(Action<long?> completed) {
+		Interlocked.Increment(ref _parkedMessageReplays);
+
 		_ioDispatcher.ReadBackward(ParkedStreamId,
 			long.MaxValue,
 			1,

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -1145,9 +1145,10 @@ public class PersistentSubscriptionService<TStreamId> :
 	public void Handle(ClientMessage.ReplayParkedMessages message) {
 		PersistentSubscription subscription;
 		var key = BuildSubscriptionGroupKey(message.EventStreamId, message.GroupName);
-		Log.Debug("Replaying parked messages for persistent subscription {subscriptionKey} {to}",
+		Log.Debug("Replaying parked messages for persistent subscription {subscriptionKey} {to}. Requested by {user}",
 			key,
-			message.StopAt.HasValue ? $" (To: '{message.StopAt.ToString()}')" : " (All)");
+			message.StopAt.HasValue ? $" (To: '{message.StopAt.ToString()}')" : " (All)",
+			message.User?.Identity?.Name);
 
 		if (message.StopAt.HasValue && message.StopAt.Value < 0) {
 			message.Envelope.ReplyWith(new ClientMessage.ReplayMessagesReceived(message.CorrelationId,

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
@@ -117,6 +117,9 @@ public class PersistentSubscriptionStats {
 			NamedConsumerStrategy = _settings.ConsumerStrategy.Name,
 			MaxSubscriberCount = _settings.MaxSubscriberCount,
 			ParkedMessageCount = parkedMessageCount,
+			ParkedDueToClientNak = _settings.MessageParker.ParkedDueToClientNak,
+			ParkedDueToMaxRetries = _settings.MessageParker.ParkedDueToMaxRetries,
+			ParkedMessageReplays = _settings.MessageParker.ParkedMessageReplays,
 			OldestParkedMessage = oldestParkedMessage
 		};
 	}


### PR DESCRIPTION


* Add additional metrics for parked persistent subscription messages eventstore_persistent_sub_park_message_requests
eventstore_persistent_sub_parked_message_replays

# Conflicts: in using statements only