### PR TITLE
Improve projection error if the type handling a native projection cannot be found (#5083)

### DIFF
--- a/src/EventStore.Projections.Core/Services/Management/ProjectionStateHandlerFactory.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionStateHandlerFactory.cs
@@ -51,6 +51,10 @@ public class ProjectionStateHandlerFactory {
 							.FirstOrDefault(v => v != null);
 				}
 
+				if (type is null) {
+					throw new NotSupportedException($"Could not find type \"{rest}\"");
+				}
+
 				var handler = Activator.CreateInstance(type, source, logger);
 				result = (IProjectionStateHandler)handler;
 				break;


### PR DESCRIPTION
In practice this could happen if someone tries to run a database started on 25.1+ on a 25.0 or earlier server, because the projection will request a KurrentDB type. (The reverse is not a problem: new servers are able to handle projections attempting to use the EventStore types)