### PR TITLE
[KDB-844]: Do not throw if io stat is disabled in the Linux kernel

### DIFF
--- a/src/KurrentDB.SystemRuntime/Diagnostics/Interop/OsxNative.cs
+++ b/src/KurrentDB.SystemRuntime/Diagnostics/Interop/OsxNative.cs
@@ -11,13 +11,13 @@ namespace System.Diagnostics.Interop;
 
 public static partial class OsxNative {
 	public static partial class IO {
-		public static DiskIoData GetDiskIo(int processId) {
+		public static DiskIoData GetDiskIo() {
 			const int PROC_PID_RUSAGE = 2;
 			const int PROC_PID_RUSAGE_SIZE = 232;
 
 			var buffer = Marshal.AllocHGlobal(PROC_PID_RUSAGE_SIZE);
 			try {
-				if (proc_pidinfo(processId, PROC_PID_RUSAGE, 0, buffer, PROC_PID_RUSAGE_SIZE) != PROC_PID_RUSAGE_SIZE)
+				if (proc_pidinfo(Environment.ProcessId, PROC_PID_RUSAGE, 0, buffer, PROC_PID_RUSAGE_SIZE) != PROC_PID_RUSAGE_SIZE)
 					throw GetLastExternalException($"Failed to get {RuntimeOSPlatform.OSX} usage info to extract disk I/O");
 
 				var info = Marshal.PtrToStructure<rusage_info_v4>(buffer);

--- a/src/KurrentDB.SystemRuntime/Diagnostics/Interop/WindowsNative.cs
+++ b/src/KurrentDB.SystemRuntime/Diagnostics/Interop/WindowsNative.cs
@@ -11,8 +11,10 @@ namespace System.Diagnostics.Interop;
 
 public static partial class WindowsNative {
 	public static partial class IO {
-		public static DiskIoData GetDiskIo(Process process) {
-			if (GetProcessIoCounters(process.Handle, out var counters)) {
+		private static readonly Process currentProcess = Process.GetCurrentProcess();
+
+		public static DiskIoData GetDiskIo() {
+			if (GetProcessIoCounters(currentProcess.Handle, out var counters)) {
 				return new() {
 					ReadBytes = counters.ReadTransferCount,
 					WrittenBytes = counters.WriteTransferCount,
@@ -23,9 +25,6 @@ public static partial class WindowsNative {
 
 			throw new Win32Exception();
 		}
-
-		public static DiskIoData GetDiskIo() =>
-			GetDiskIo(Process.GetCurrentProcess());
 
 		#region . native .
 

--- a/src/KurrentDB.SystemRuntime/Diagnostics/ProcessStats.cs
+++ b/src/KurrentDB.SystemRuntime/Diagnostics/ProcessStats.cs
@@ -21,7 +21,7 @@ public static class ProcessStats {
 		};
 
 		static DiskIoData GetDiskIoLinux() {
-			const string procIoFile = $"/proc/self/io";
+			const string procIoFile = "/proc/self/io";
 
 			var result = new DiskIoData();
 			if (File.Exists(procIoFile)) {
@@ -37,10 +37,9 @@ public static class ProcessStats {
 							result = result with { WriteOps = writeOps };
 						}
 
-						if (result.ReadBytes is not 0 &&
-						    result.WrittenBytes is not 0 &&
-						    result.ReadOps is not 0 &&
-						    result.WriteOps is not 0)
+						if (result is {
+							    ReadBytes: not 0UL, ReadOps: not 0UL, WriteOps: not 0UL, WrittenBytes: not 0UL
+						    })
 							break;
 					}
 				} catch (Exception ex) {

--- a/src/KurrentDB.SystemRuntime/Diagnostics/ProcessStats.cs
+++ b/src/KurrentDB.SystemRuntime/Diagnostics/ProcessStats.cs
@@ -50,11 +50,10 @@ public static class ProcessStats {
 
 			return result;
 
-			static bool TryExtractIoValue(string line, string key, out ulong value) {
+			static bool TryExtractIoValue(ReadOnlySpan<char> line, ReadOnlySpan<char> key, out ulong value) {
 				if (line.StartsWith(key)) {
 					var rawValue = line[(key.Length + 1)..].Trim(); // handle the `:` character
-					value = Convert.ToUInt64(rawValue);
-					return true;
+					return ulong.TryParse(rawValue, out value);
 				}
 
 				value = 0;


### PR DESCRIPTION
Fixed:  Do not throw if `/proc/self/io` is disabled in the Linux kernel, which is not so uncommon in the containers.

Fixes #5044