### PR TITLE
Fixed race condition in Secondary Index Checkpoint Tracker

### DIFF
--- a/src/KurrentDB.SecondaryIndexing.Tests/Subscriptions/SecondaryIndexCheckpointTrackerTests.cs
+++ b/src/KurrentDB.SecondaryIndexing.Tests/Subscriptions/SecondaryIndexCheckpointTrackerTests.cs
@@ -25,7 +25,7 @@ public class SecondaryIndexCheckpointTrackerTests {
 			tracker.Increment();
 		}
 
-		var committed = commitSignal.Wait(HalfOfASecond);
+		var committed = commitSignal.Wait(FiveSeconds);
 		await tracker.DisposeAsync();
 
 		// Then
@@ -48,7 +48,7 @@ public class SecondaryIndexCheckpointTrackerTests {
 
 		// When
 		tracker.Increment();
-		var committed = commitSignal.Wait(HalfOfASecond);
+		var committed = commitSignal.Wait(FiveSeconds);
 		await tracker.DisposeAsync();
 
 		// Then
@@ -115,7 +115,7 @@ public class SecondaryIndexCheckpointTrackerTests {
 		// When
 		for (int i = 0; i < 3; i++) tracker.Increment();
 
-		Assert.True(commitInProgress.Wait(HalfOfASecond));
+		Assert.True(commitInProgress.Wait(FiveSeconds));
 
 		for (int i = 0; i < 3; i++) tracker.Increment();
 
@@ -146,7 +146,7 @@ public class SecondaryIndexCheckpointTrackerTests {
 
 		await Task.WhenAll(tasks);
 
-		var committed = commitSignal.Wait(HalfOfASecond);
+		var committed = commitSignal.Wait(FiveSeconds);
 		await tracker.DisposeAsync();
 
 		// Then
@@ -290,5 +290,5 @@ public class SecondaryIndexCheckpointTrackerTests {
 		Assert.True(commitCompleted);
 	}
 
-	private static readonly TimeSpan HalfOfASecond = TimeSpan.FromMilliseconds(500);
+	private static readonly TimeSpan FiveSeconds = TimeSpan.FromSeconds(5);
 }

--- a/src/KurrentDB.SecondaryIndexing.Tests/Subscriptions/SecondaryIndexCheckpointTrackerTests.cs
+++ b/src/KurrentDB.SecondaryIndexing.Tests/Subscriptions/SecondaryIndexCheckpointTrackerTests.cs
@@ -25,7 +25,7 @@ public class SecondaryIndexCheckpointTrackerTests {
 			tracker.Increment();
 		}
 
-		var committed = commitSignal.Wait(FiveSeconds);
+		var committed = commitSignal.Wait(CommitSignalTimeout);
 		await tracker.DisposeAsync();
 
 		// Then
@@ -48,7 +48,7 @@ public class SecondaryIndexCheckpointTrackerTests {
 
 		// When
 		tracker.Increment();
-		var committed = commitSignal.Wait(FiveSeconds);
+		var committed = commitSignal.Wait(CommitSignalTimeout);
 		await tracker.DisposeAsync();
 
 		// Then
@@ -115,7 +115,7 @@ public class SecondaryIndexCheckpointTrackerTests {
 		// When
 		for (int i = 0; i < 3; i++) tracker.Increment();
 
-		Assert.True(commitInProgress.Wait(FiveSeconds));
+		Assert.True(commitInProgress.Wait(CommitSignalTimeout));
 
 		for (int i = 0; i < 3; i++) tracker.Increment();
 
@@ -146,7 +146,7 @@ public class SecondaryIndexCheckpointTrackerTests {
 
 		await Task.WhenAll(tasks);
 
-		var committed = commitSignal.Wait(FiveSeconds);
+		var committed = commitSignal.Wait(CommitSignalTimeout);
 		await tracker.DisposeAsync();
 
 		// Then
@@ -290,5 +290,5 @@ public class SecondaryIndexCheckpointTrackerTests {
 		Assert.True(commitCompleted);
 	}
 
-	private static readonly TimeSpan FiveSeconds = TimeSpan.FromSeconds(5);
+	private static readonly TimeSpan CommitSignalTimeout = TimeSpan.FromSeconds(5);
 }

--- a/src/KurrentDB.SecondaryIndexing/Subscriptions/SecondaryIndexCheckpointTracker.cs
+++ b/src/KurrentDB.SecondaryIndexing/Subscriptions/SecondaryIndexCheckpointTracker.cs
@@ -62,11 +62,11 @@ public sealed class SecondaryIndexCheckpointTracker : IAsyncDisposable {
 		while (!ct.IsCancellationRequested) {
 			await _signal.WaitAsync(_timeout, ct);
 
+			// reset the signal to avoid race conditions of two loops getting into this section
+			_signal.Reset();
+
 			// either signalled or timed out
 			var count = Interlocked.Exchange(ref _counter, 0);
-
-			// reset the signal after clearing the _counter to avoid premature setting
-			_signal.Reset();
 
 			if (count == 0)
 				continue;

--- a/src/KurrentDB.SecondaryIndexing/Subscriptions/SecondaryIndexCheckpointTracker.cs
+++ b/src/KurrentDB.SecondaryIndexing/Subscriptions/SecondaryIndexCheckpointTracker.cs
@@ -62,11 +62,11 @@ public sealed class SecondaryIndexCheckpointTracker : IAsyncDisposable {
 		while (!ct.IsCancellationRequested) {
 			await _signal.WaitAsync(_timeout, ct);
 
-			// reset the signal to avoid race conditions of two loops getting into this section
-			_signal.Reset();
-
 			// either signalled or timed out
 			var count = Interlocked.Exchange(ref _counter, 0);
+
+			// reset the signal after clearing the _counter to avoid premature setting
+			_signal.Reset();
 
 			if (count == 0)
 				continue;


### PR DESCRIPTION
In the CI where the thread number is limited, 500ms may be too short for high threading tests, increased the max waiting time in `SecondaryIndexCheckpointTrackerTests`.