### PR TITLE
[KDB-851] Free up space in Ubuntu runners

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -21,6 +21,13 @@ jobs:
     runs-on: ${{ inputs.os }}
     name: ci/github/build-${{ inputs.os }}
     steps:
+    - name: Free Disk Space (Ubuntu)
+      if: inputs.os != 'windows-2019'
+      uses: jlumbroso/free-disk-space@v1.3.1
+      with:
+        tool-cache: false
+        dotnet: false
+        docker-images: false
     - name: Checkout
       uses: actions/checkout@v4
     - name: Set up Docker Buildx


### PR DESCRIPTION
Using the github action [jlumbroso/free-disk-space@v1.3.1](https://github.com/marketplace/actions/free-disk-space-ubuntu) frees up about 25Gb of space on the Ubuntu containers, at the cost of around 3 minutes additional build time.