### PR TITLE
Fixed the wrong condition in Secondary Indexing integration tests

### DIFF
--- a/src/KurrentDB.SecondaryIndexing.Tests/IntegrationTests/Fixtures/SecondaryIndexingFixture.cs
+++ b/src/KurrentDB.SecondaryIndexing.Tests/IntegrationTests/Fixtures/SecondaryIndexingFixture.cs
@@ -69,7 +69,7 @@ public abstract class SecondaryIndexingFixture : ClusterVNodeFixture {
 			try {
 				events = await ReadStream(streamName, ct).ToListAsync(ct);
 
-				reachedPosition = events.Count != 0 && events.Last().Event.LogPosition <= (long)position.CommitPosition;
+				reachedPosition = events.Count != 0 && events.Last().Event.LogPosition >= (long)position.CommitPosition;
 			} catch (ReadResponseException.StreamNotFound ex) {
 				streamNotFound = ex;
 			}


### PR DESCRIPTION
That fixes the wrong condition in reading indexed records that could cause looping too long and using too much CPU and memory