### PR TITLE
[KDB-869] Return xunit concurrency settings to defaults now that we are on xunit 2.8+

### DIFF
--- a/src/KurrentDB.Core.XUnit.Tests/xunit.runner.json
+++ b/src/KurrentDB.Core.XUnit.Tests/xunit.runner.json
@@ -1,4 +1,5 @@
 {
 	"$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-	"maxParallelThreads": -1
+	"parallelAlgorithm": "conservative",
+	"maxParallelThreads": "default"
 }


### PR DESCRIPTION
Previously, by default xunit would run all the test collections in parallel with each other and limit the amount of concurrent execution with a SynchronizationContext.

This could cause individual tests to take a long time to run, causing timeouts.

We therefore previously disabled the concurrency limit https://github.com/kurrent-io/KurrentDB/pull/4155 which helped but doesn't fully address the issue because lots of tests still run in parallel with each other.

In xunit 2.8 the algorithm changed to limit the number of tests running in parallel, which is great. We can now restore the default concurrent limit, which is what this PR does.

https://xunit.net/docs/running-tests-in-parallel.html

I've set the values to explicitly be the default to make it as easy as possible to find in the future.