### PR TITLE
Add Server Configuration Option for TCP read expiry: TcpReadTimeoutMs

### DIFF
--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service.cs
@@ -9,6 +9,7 @@ using EventStore.Core.Messaging;
 using EventStore.Core.Services;
 using EventStore.Core.Services.Replication;
 using EventStore.Core.Services.Transport.Tcp;
+using EventStore.Core.Settings;
 using EventStore.Core.Tests.Authentication;
 using EventStore.Core.Tests.Authorization;
 using EventStore.Core.Tests.Helpers;
@@ -91,7 +92,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 			var tcpConn = new DummyTcpConnection() { ConnectionId = replicaId };
 
 			manager = new TcpConnectionManager(
-				"Test Subscription Connection manager", TcpServiceType.External, new ClientTcpDispatcher(2000),
+				"Test Subscription Connection manager", TcpServiceType.External, new ClientTcpDispatcher(ESConsts.ReadRequestTimeout, 2000),
 				InMemoryBus.CreateTest(), tcpConn, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(InMemoryBus.CreateTest(),
 					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()),

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service_and_epoch_manager.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service_and_epoch_manager.cs
@@ -13,6 +13,7 @@ using EventStore.Core.Services;
 using EventStore.Core.Services.Replication;
 using EventStore.Core.Services.Storage.EpochManager;
 using EventStore.Core.Services.Transport.Tcp;
+using EventStore.Core.Settings;
 using EventStore.Core.Tests.Authentication;
 using EventStore.Core.Tests.Authorization;
 using EventStore.Core.Tests.Helpers;
@@ -110,7 +111,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 			var tcpConn = new DummyTcpConnection() { ConnectionId = replicaId };
 
 			manager = new TcpConnectionManager(
-				"Test Subscription Connection manager", TcpServiceType.External, new ClientTcpDispatcher(2_000),
+				"Test Subscription Connection manager", TcpServiceType.External, new ClientTcpDispatcher(ESConsts.ReadRequestTimeout, 2_000),
 				InMemoryBus.CreateTest(), tcpConn, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(InMemoryBus.CreateTest(),
 					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()),

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpClientDispatcherTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpClientDispatcherTests.cs
@@ -347,7 +347,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 				resolveLinkTos: true,
 				requireLeader: true);
 
-			var package = new TcpPackage(TcpCommand.ReadStreamEventsForward, Guid.NewGuid(), dto.Serialize());
+			var package = new TcpPackage(TcpCommand.ReadStreamEventsBackward, Guid.NewGuid(), dto.Serialize());
 
 			var message = _dispatcher.UnwrapPackage(
 				package: package,
@@ -357,8 +357,8 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 				connection: null,
 				version: (byte)ClientVersion.V2);
 
-			Assert.IsInstanceOf<ClientMessage.ReadStreamEventsForward>(message);
-			var readEvent = message as ClientMessage.ReadStreamEventsForward;
+			Assert.IsInstanceOf<ClientMessage.ReadStreamEventsBackward>(message);
+			var readEvent = message as ClientMessage.ReadStreamEventsBackward;
 			Assert.AreEqual("my-stream", readEvent.EventStreamId);
 			Assert.AreEqual(5, readEvent.FromEventNumber);
 			Assert.AreEqual(6, readEvent.MaxCount);

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpClientDispatcherTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpClientDispatcherTests.cs
@@ -1,46 +1,32 @@
-using EventStore.Core.Bus;
-using EventStore.Core.Services.Transport.Tcp;
-using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using EventStore.Core.Messaging;
-using EventStore.Core.Tests.Authentication;
 using System.Linq;
-using EventStore.Core.Data;
-using EventStore.Core.Messages;
 using System.Text;
 using EventStore.Client.Messages;
-using EventStore.Core.Authentication.InternalAuthentication;
+using EventStore.Core.Data;
 using EventStore.Core.LogV2;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services;
+using EventStore.Core.Services.Transport.Tcp;
 using EventStore.Core.Services.UserManagement;
 using EventStore.Core.TransactionLog.LogRecords;
-using EventStore.Core.Services;
-using EventStore.Core.Tests.Authorization;
-using EventStore.Core.Util;
+using NUnit.Framework;
 using EventRecord = EventStore.Core.Data.EventRecord;
 using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
 
 namespace EventStore.Core.Tests.Services.Transport.Tcp {
 	[TestFixture]
 	public class TcpClientDispatcherTests {
-		private readonly NoopEnvelope _envelope = new NoopEnvelope();
+		private readonly TimeSpan _readTimeout = TimeSpan.FromSeconds(5);
+		private readonly TimeSpan _writeTimeout = TimeSpan.FromSeconds(2);
+		private readonly TimeSpan _tolerance = TimeSpan.FromSeconds(1);
 
 		private ClientTcpDispatcher _dispatcher;
-		private TcpConnectionManager _connection;
 
 		[OneTimeSetUp]
 		public void Setup() {
-			_dispatcher = new ClientTcpDispatcher(2000);
-			
-			var dummyConnection = new DummyTcpConnection();
-			_connection = new TcpConnectionManager(
-				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(2000),
-				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(), new InternalAuthenticationProvider(
-					InMemoryBus.CreateTest(), new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()),
-					new StubPasswordHashAlgorithm(), 1, false, DefaultData.DefaultUserOptions),
-				new AuthorizationGateway(new TestAuthorizationProvider()), 
-				TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { },
-				Opts.ConnectionPendingSendBytesThresholdDefault, Opts.ConnectionQueueSizeThresholdDefault);
+			_dispatcher = new ClientTcpDispatcher(_readTimeout, _writeTimeout);
 		}
 
 		[Test]
@@ -294,6 +280,213 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 			return new EventRecord(0, LogRecord.Prepare(new LogV2RecordFactory(), 100, Guid.NewGuid(), Guid.NewGuid(), 0, 0,
 				"link-stream", -1, PrepareFlags.SingleWrite | PrepareFlags.Data, SystemEventTypes.LinkTo,
 				Encoding.UTF8.GetBytes(string.Format("{0}@test-stream", long.MaxValue)), new byte[0]), "link-stream", SystemEventTypes.LinkTo);
+		}
+
+		[Test]
+		public void unwraps_ReadEvent() {
+			var dto = new ReadEvent(
+				eventStreamId: "my-stream",
+				eventNumber: 5,
+				resolveLinkTos: true,
+				requireLeader: true);
+
+			var package = new TcpPackage(TcpCommand.ReadEvent, Guid.NewGuid(), dto.Serialize());
+
+			var message = _dispatcher.UnwrapPackage(
+				package: package,
+				envelope: new NoopEnvelope(),
+				user: SystemAccounts.System,
+				tokens: new Dictionary<string, string>(),
+				connection: null,
+				version: (byte)ClientVersion.V2);
+
+			Assert.IsInstanceOf<ClientMessage.ReadEvent>(message);
+			var readEvent = message as ClientMessage.ReadEvent;
+			Assert.AreEqual("my-stream", readEvent.EventStreamId);
+			Assert.AreEqual(5, readEvent.EventNumber);
+			Assert.AreEqual(true, readEvent.ResolveLinkTos);
+			Assert.AreEqual(true, readEvent.RequireLeader);
+			Assert.That(readEvent.Expires, Is.EqualTo(DateTime.UtcNow + _readTimeout).Within(_tolerance));
+		}
+
+		[Test]
+		public void unwraps_ReadStreamEventsForward() {
+			var dto = new ReadStreamEvents(
+				eventStreamId: "my-stream",
+				fromEventNumber: 5,
+				maxCount: 6,
+				resolveLinkTos: true,
+				requireLeader: true);
+
+			var package = new TcpPackage(TcpCommand.ReadStreamEventsForward, Guid.NewGuid(), dto.Serialize());
+
+			var message = _dispatcher.UnwrapPackage(
+				package: package,
+				envelope: new NoopEnvelope(),
+				user: SystemAccounts.System,
+				tokens: new Dictionary<string, string>(),
+				connection: null,
+				version: (byte)ClientVersion.V2);
+
+			Assert.IsInstanceOf<ClientMessage.ReadStreamEventsForward>(message);
+			var readEvent = message as ClientMessage.ReadStreamEventsForward;
+			Assert.AreEqual("my-stream", readEvent.EventStreamId);
+			Assert.AreEqual(5, readEvent.FromEventNumber);
+			Assert.AreEqual(6, readEvent.MaxCount);
+			Assert.AreEqual(true, readEvent.ResolveLinkTos);
+			Assert.AreEqual(true, readEvent.RequireLeader);
+			Assert.That(readEvent.Expires, Is.EqualTo(DateTime.UtcNow + _readTimeout).Within(_tolerance));
+		}
+
+		[Test]
+		public void unwraps_ReadStreamEventsBackward() {
+			var dto = new ReadStreamEvents(
+				eventStreamId: "my-stream",
+				fromEventNumber: 5,
+				maxCount: 6,
+				resolveLinkTos: true,
+				requireLeader: true);
+
+			var package = new TcpPackage(TcpCommand.ReadStreamEventsForward, Guid.NewGuid(), dto.Serialize());
+
+			var message = _dispatcher.UnwrapPackage(
+				package: package,
+				envelope: new NoopEnvelope(),
+				user: SystemAccounts.System,
+				tokens: new Dictionary<string, string>(),
+				connection: null,
+				version: (byte)ClientVersion.V2);
+
+			Assert.IsInstanceOf<ClientMessage.ReadStreamEventsForward>(message);
+			var readEvent = message as ClientMessage.ReadStreamEventsForward;
+			Assert.AreEqual("my-stream", readEvent.EventStreamId);
+			Assert.AreEqual(5, readEvent.FromEventNumber);
+			Assert.AreEqual(6, readEvent.MaxCount);
+			Assert.AreEqual(true, readEvent.ResolveLinkTos);
+			Assert.AreEqual(true, readEvent.RequireLeader);
+			Assert.That(readEvent.Expires, Is.EqualTo(DateTime.UtcNow + _readTimeout).Within(_tolerance));
+		}
+
+		[Test]
+		public void unwraps_ReadAllEventsForward() {
+			var dto = new ReadAllEvents(
+				commitPosition: 2000,
+				preparePosition: 1000,
+				maxCount: 6,
+				resolveLinkTos: true,
+				requireLeader: true);
+
+			var package = new TcpPackage(TcpCommand.ReadAllEventsForward, Guid.NewGuid(), dto.Serialize());
+
+			var message = _dispatcher.UnwrapPackage(
+				package: package,
+				envelope: new NoopEnvelope(),
+				user: SystemAccounts.System,
+				tokens: new Dictionary<string, string>(),
+				connection: null,
+				version: (byte)ClientVersion.V2);
+
+			Assert.IsInstanceOf<ClientMessage.ReadAllEventsForward>(message);
+			var readEvent = message as ClientMessage.ReadAllEventsForward;
+			Assert.AreEqual(2000, readEvent.CommitPosition);
+			Assert.AreEqual(1000, readEvent.PreparePosition);
+			Assert.AreEqual(6, readEvent.MaxCount);
+			Assert.AreEqual(true, readEvent.ResolveLinkTos);
+			Assert.AreEqual(true, readEvent.RequireLeader);
+			Assert.That(readEvent.Expires, Is.EqualTo(DateTime.UtcNow + _readTimeout).Within(_tolerance));
+		}
+
+		[Test]
+		public void unwraps_ReadAllEventsBackward() {
+			var dto = new ReadAllEvents(
+				commitPosition: 2000,
+				preparePosition: 1000,
+				maxCount: 6,
+				resolveLinkTos: true,
+				requireLeader: true);
+
+			var package = new TcpPackage(TcpCommand.ReadAllEventsBackward, Guid.NewGuid(), dto.Serialize());
+
+			var message = _dispatcher.UnwrapPackage(
+				package: package,
+				envelope: new NoopEnvelope(),
+				user: SystemAccounts.System,
+				tokens: new Dictionary<string, string>(),
+				connection: null,
+				version: (byte)ClientVersion.V2);
+
+			Assert.IsInstanceOf<ClientMessage.ReadAllEventsBackward>(message);
+			var readEvent = message as ClientMessage.ReadAllEventsBackward;
+			Assert.AreEqual(2000, readEvent.CommitPosition);
+			Assert.AreEqual(1000, readEvent.PreparePosition);
+			Assert.AreEqual(6, readEvent.MaxCount);
+			Assert.AreEqual(true, readEvent.ResolveLinkTos);
+			Assert.AreEqual(true, readEvent.RequireLeader);
+			Assert.That(readEvent.Expires, Is.EqualTo(DateTime.UtcNow + _readTimeout).Within(_tolerance));
+		}
+
+				[Test]
+		public void unwraps_FilteredReadAllEventsForward() {
+			var dto = new FilteredReadAllEvents(
+				commitPosition: 2000,
+				preparePosition: 1000,
+				maxCount: 6,
+				maxSearchWindow: 7,
+				resolveLinkTos: true,
+				requireLeader: true,
+				filter: null);
+
+			var package = new TcpPackage(TcpCommand.FilteredReadAllEventsForward, Guid.NewGuid(), dto.Serialize());
+
+			var message = _dispatcher.UnwrapPackage(
+				package: package,
+				envelope: new NoopEnvelope(),
+				user: SystemAccounts.System,
+				tokens: new Dictionary<string, string>(),
+				connection: null,
+				version: (byte)ClientVersion.V2);
+
+			Assert.IsInstanceOf<ClientMessage.FilteredReadAllEventsForward>(message);
+			var readEvent = message as ClientMessage.FilteredReadAllEventsForward;
+			Assert.AreEqual(2000, readEvent.CommitPosition);
+			Assert.AreEqual(1000, readEvent.PreparePosition);
+			Assert.AreEqual(6, readEvent.MaxCount);
+			Assert.AreEqual(7, readEvent.MaxSearchWindow);
+			Assert.AreEqual(true, readEvent.ResolveLinkTos);
+			Assert.AreEqual(true, readEvent.RequireLeader);
+			Assert.That(readEvent.Expires, Is.EqualTo(DateTime.UtcNow + _readTimeout).Within(_tolerance));
+		}
+
+		[Test]
+		public void unwraps_FilteredReadAllEventsBackward() {
+			var dto = new FilteredReadAllEvents(
+				commitPosition: 2000,
+				preparePosition: 1000,
+				maxCount: 6,
+				maxSearchWindow: 7,
+				resolveLinkTos: true,
+				requireLeader: true,
+				filter: null);
+
+			var package = new TcpPackage(TcpCommand.FilteredReadAllEventsBackward, Guid.NewGuid(), dto.Serialize());
+
+			var message = _dispatcher.UnwrapPackage(
+				package: package,
+				envelope: new NoopEnvelope(),
+				user: SystemAccounts.System,
+				tokens: new Dictionary<string, string>(),
+				connection: null,
+				version: (byte)ClientVersion.V2);
+
+			Assert.IsInstanceOf<ClientMessage.FilteredReadAllEventsBackward>(message);
+			var readEvent = message as ClientMessage.FilteredReadAllEventsBackward;
+			Assert.AreEqual(2000, readEvent.CommitPosition);
+			Assert.AreEqual(1000, readEvent.PreparePosition);
+			Assert.AreEqual(6, readEvent.MaxCount);
+			Assert.AreEqual(7, readEvent.MaxSearchWindow);
+			Assert.AreEqual(true, readEvent.ResolveLinkTos);
+			Assert.AreEqual(true, readEvent.RequireLeader);
+			Assert.That(readEvent.Expires, Is.EqualTo(DateTime.UtcNow + _readTimeout).Within(_tolerance));
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpClientDispatcherTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpClientDispatcherTests.cs
@@ -425,7 +425,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 			Assert.That(readEvent.Expires, Is.EqualTo(DateTime.UtcNow + _readTimeout).Within(_tolerance));
 		}
 
-				[Test]
+		[Test]
 		public void unwraps_FilteredReadAllEventsForward() {
 			var dto = new FilteredReadAllEvents(
 				commitPosition: 2000,

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionManagerTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionManagerTests.cs
@@ -36,7 +36,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 			var dummyConnection = new DummyTcpConnection();
 
 			var tcpConnectionManager = new TcpConnectionManager(
-				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(2000),
+				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(ESConsts.ReadRequestTimeout, 2000),
 				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(
 					InMemoryBus.CreateTest(), new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()),
@@ -78,7 +78,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 			}));
 
 			var tcpConnectionManager = new TcpConnectionManager(
-				Guid.NewGuid().ToString(), TcpServiceType.Internal, new ClientTcpDispatcher(2000),
+				Guid.NewGuid().ToString(), TcpServiceType.Internal, new ClientTcpDispatcher(ESConsts.ReadRequestTimeout, 2000),
 				publisher, dummyConnection, publisher,
 				new InternalAuthenticationProvider(publisher, new Core.Helpers.IODispatcher(publisher, new NoopEnvelope()),
 					new StubPasswordHashAlgorithm(), 1, false, DefaultData.DefaultUserOptions),
@@ -113,7 +113,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 			dummyConnection.PendingSendBytes = _connectionPendingSendBytesThreshold + 1000;
 
 			var tcpConnectionManager = new TcpConnectionManager(
-				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(2000),
+				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(ESConsts.ReadRequestTimeout, 2000),
 				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(
 					InMemoryBus.CreateTest(), new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(),
@@ -143,7 +143,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 			dummyConnection.PendingSendBytes = 0;
 
 			var tcpConnectionManager = new TcpConnectionManager(
-				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(2000),
+				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(ESConsts.ReadRequestTimeout, 2000),
 				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(InMemoryBus.CreateTest(),
 					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), null, 1, false, DefaultData.DefaultUserOptions),
@@ -176,7 +176,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 			dummyConnection.PendingSendBytes = _connectionPendingSendBytesThreshold + 1000;
 
 			var tcpConnectionManager = new TcpConnectionManager(
-				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(2000),
+				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(ESConsts.ReadRequestTimeout, 2000),
 				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(InMemoryBus.CreateTest(),
 					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), null, 1, false, DefaultData.DefaultUserOptions),
@@ -209,7 +209,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 			dummyConnection.SendQueueSize = ESConsts.MaxConnectionQueueSize - 1;
 
 			var tcpConnectionManager = new TcpConnectionManager(
-				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(2000),
+				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(ESConsts.ReadRequestTimeout, 2000),
 				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(InMemoryBus.CreateTest(),
 					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), null, 1, false, DefaultData.DefaultUserOptions),
@@ -242,7 +242,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 			dummyConnection.SendQueueSize = ESConsts.MaxConnectionQueueSize + 1;
 
 			var tcpConnectionManager = new TcpConnectionManager(
-				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(2000),
+				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(ESConsts.ReadRequestTimeout, 2000),
 				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(InMemoryBus.CreateTest(),
 					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), null, 1, false, DefaultData.DefaultUserOptions),

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -920,7 +920,9 @@ namespace EventStore.Core {
 				if (NodeInfo.ExternalTcp != null && options.Interface.EnableExternalTcp) {
 					var extTcpService = new TcpService(_mainQueue, NodeInfo.ExternalTcp, _workersHandler,
 						TcpServiceType.External, TcpSecurityType.Normal,
-						new ClientTcpDispatcher(TimeSpan.FromMilliseconds(options.Database.WriteTimeoutMs)),
+						new ClientTcpDispatcher(
+							readTimeout: TimeSpan.FromMilliseconds(options.Database.TcpReadTimeoutMs),
+							writeTimeout: TimeSpan.FromMilliseconds(options.Database.WriteTimeoutMs)),
 						TimeSpan.FromMilliseconds(options.Interface.NodeHeartbeatInterval),
 						TimeSpan.FromMilliseconds(options.Interface.NodeHeartbeatTimeout),
 						_authenticationProvider, AuthorizationGateway, null, null, null,
@@ -934,7 +936,9 @@ namespace EventStore.Core {
 				if (NodeInfo.ExternalSecureTcp != null && options.Interface.EnableExternalTcp) {
 					var extSecTcpService = new TcpService(_mainQueue, NodeInfo.ExternalSecureTcp, _workersHandler,
 						TcpServiceType.External, TcpSecurityType.Secure,
-						new ClientTcpDispatcher(TimeSpan.FromMilliseconds(options.Database.WriteTimeoutMs)),
+						new ClientTcpDispatcher(
+							readTimeout: TimeSpan.FromMilliseconds(options.Database.TcpReadTimeoutMs),
+							writeTimeout: TimeSpan.FromMilliseconds(options.Database.WriteTimeoutMs)),
 						TimeSpan.FromMilliseconds(options.Interface.NodeHeartbeatInterval),
 						TimeSpan.FromMilliseconds(options.Interface.NodeHeartbeatTimeout),
 						_authenticationProvider, AuthorizationGateway,

--- a/src/EventStore.Core/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.cs
@@ -601,6 +601,7 @@ namespace EventStore.Core {
 				PrepareTimeoutMs = configurationRoot.GetValue<int>(nameof(PrepareTimeoutMs)),
 				CommitTimeoutMs = configurationRoot.GetValue<int>(nameof(CommitTimeoutMs)),
 				WriteTimeoutMs = configurationRoot.GetValue<int>(nameof(WriteTimeoutMs)),
+				TcpReadTimeoutMs = configurationRoot.GetValue<int>(nameof(TcpReadTimeoutMs)),
 				UnsafeDisableFlushToDisk = configurationRoot.GetValue<bool>(nameof(UnsafeDisableFlushToDisk)),
 				UnsafeIgnoreHardDelete = configurationRoot.GetValue<bool>(nameof(UnsafeIgnoreHardDelete)),
 				SkipIndexVerify = configurationRoot.GetValue<bool>(nameof(SkipIndexVerify)),

--- a/src/EventStore.Core/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.cs
@@ -474,6 +474,9 @@ namespace EventStore.Core {
 			[Description("Write timeout (in milliseconds).")]
 			public int WriteTimeoutMs { get; init; } = 2_000;
 
+			[Description("TCP Client Read Timeout (in milliseconds). Reads older than this will be discarded.")]
+			public int TcpReadTimeoutMs { get; init; } = ESConsts.ReadRequestTimeout;
+
 			private readonly bool _unsafeDisableFlushToDisk = false;
 
 			[Description("Disable flushing to disk. (UNSAFE: on power off)")]


### PR DESCRIPTION
In gRPC this is already driven by the request itself. In TCP we have no such mechanism. We opt for this solution instead of adding it to the TCP protocol to make the change smaller, safer, and easier to roll out while still being useful.