### PR TITLE
[KDB-892] Add persistent subscription docs for 23.10.7

### DIFF
--- a/docs/http-api/persistent.md
+++ b/docs/http-api/persistent.md
@@ -169,12 +169,12 @@ For example:
 
 #### Query parameters
 
-| Parameter           | Description                                                                                                                                                                                                                          |     |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --- |
-| `stream`            | The stream to the persistent subscription is on.                                                                                                                                                                                     |     |
-| `subscription_name` | The name of the subscription group.                                                                                                                                                                                                  |     |
-| `action`            | <ul><li>**Park**: Don't retry the message, park it until a request is sent to reply the parked messages</li><li>**Retry**: Retry the message</li><li>**Skip**: Discard the message</li><li>**Stop**: Stop the subscription</li></ul> |     |
-| `messageid`         | The id of the message that needs to be acked                                                                                                                                                                                         |     |
+| Parameter           | Description                                                                                                                                                                                                                          |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `stream`            | The stream to the persistent subscription is on.                                                                                                                                                                                     |
+| `subscription_name` | The name of the subscription group.                                                                                                                                                                                                  |
+| `action`            | <ul><li>**Park**: Don't retry the message, park it until a request is sent to reply the parked messages</li><li>**Retry**: Retry the message</li><li>**Skip**: Discard the message</li><li>**Stop**: Stop the subscription</li></ul> |
+| `messageid`         | The id of the message that needs to be acked                                                                                                                                                                                         |
 
 ### Nack a single message
 
@@ -197,6 +197,26 @@ For example:
 ### Response
 
 @[code](@httpapi/persistent-subscriptions/get-all-subscriptions-response.json)
+
+
+## Getting information for a page of subscriptions
+
+When a count is specified, the response includes the paging information for the request.
+
+| URI              | Method |
+| ---------------- | ------ |
+| `/subscriptions?count={count}&offset={offset}` | GET    |
+
+### Query parameters
+
+| Parameter | Description |
+| --------- | ----------- |
+| `count`   | The number of streams to get the persistent susbcriptions groups for. Used for paging, omit to get all streams. |
+| `offset`  | The number of streams to skip when getting persistent subscription groups. Used for paging. |
+
+### Response
+
+@[code](@httpapi/persistent-subscriptions/get-all-subscriptions-response-paged.json)
 
 ## Get subscriptions for a stream
 

--- a/docs/http-api/persistent.md
+++ b/docs/http-api/persistent.md
@@ -7,7 +7,7 @@ order: 3
 This document explains how to use HTTP API for setting up and consuming persistent subscriptions and competing consumer subscription groups. For an overview on competing consumers and how they relate to other subscription types please see our [getting started guide](@server/features/persistent-subscriptions.md).
 
 ::: tip
-The Administration UI includes a _Competing Consumers_ section where you are able to create, update, delete and view subscriptions and their statuses.
+The Administration UI includes a _Persistent Subscriptions_ section where you are able to create, update, delete and view subscriptions and their statuses.
 :::
 
 ## Creating a persistent subscription
@@ -99,9 +99,11 @@ Deleting persistent subscriptions to `$all` is not supported over the HTTP API. 
 
 By default, reading a stream via a persistent subscription returns a single event per request and does not embed the event properties as part of the response.
 
-| URI                                                                                                                                                                  | Supported Content Types                                                                      | Method |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | ------ |
-| `/subscriptions/{stream}/{subscription_name} /subscriptions/{stream}/{subscription_name}?embed={embed} /subscriptions/{stream}/{subscription}/{count}?embed={embed}` | `application/vnd.eventstore.competingatom+xml application/vnd.eventstore.competingatom+json` | GET    |
+| URI                                                            | Supported Content Types                                                                         | Method |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ------ |
+| `/subscriptions/{stream}/{subscription_name}`                  | `application/vnd.eventstore.competingatom+json`, `application/vnd.eventstore.competingatom+xml` | GET    |
+| `/subscriptions/{stream}/{subscription_name}?embed={embed}`    | `application/vnd.eventstore.competingatom+json`, `application/vnd.eventstore.competingatom+xml` | GET    |
+| `/subscriptions/{stream}/{subscription}/{count}?embed={embed}` | `application/vnd.eventstore.competingatom+json`, `application/vnd.eventstore.competingatom+xml` | GET    |
 
 ### Query parameters
 
@@ -126,9 +128,10 @@ For example:
 
 ```json
 {
-  "uri": "http://localhost:2113/subscriptions/newstream/competing_consumers_group1/ack/c322e299-cb73-4b47-97c5-5054f920746f",
-  "relation": "ack"
-}
+  "uri": "https://localhost:2113/subscriptions/teststream1/testgroup-1/ack/33635881-5881-5881-5881-175033635881",
+  "relation": "ack",
+  "type": null
+},
 ```
 
 ### Ack multiple messages
@@ -173,7 +176,7 @@ For example:
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `stream`            | The stream to the persistent subscription is on.                                                                                                                                                                                     |
 | `subscription_name` | The name of the subscription group.                                                                                                                                                                                                  |
-| `action`            | <ul><li>**Park**: Don't retry the message, park it until a request is sent to reply the parked messages</li><li>**Retry**: Retry the message</li><li>**Skip**: Discard the message</li><li>**Stop**: Stop the subscription</li></ul> |
+| `action`            | <ul><li>**Park**: Don't retry the message, park it until a request is sent to reply the parked messages</li><li>**Retry**: Retry the message</li><li>**Skip**: Discard the message</li></ul> |
 | `messageid`         | The id of the message that needs to be acked                                                                                                                                                                                         |
 
 ### Nack a single message

--- a/docs/server/diagnostics/metrics.md
+++ b/docs/server/diagnostics/metrics.md
@@ -247,13 +247,15 @@ Persistent subscription metrics track the statistics for the persistent subscrip
 | `eventstore_persistent_subscriptions_replays_requested`                | [Counter](#common-types) | Count of Parked Message replay requests                                     |
 
 ::: warning
-The `eventstore_persistent_subscriptions_messages_parked` and `eventstore_persistent_subscriptions_replays_requested` metrics have been renamed to `eventstore_persistent_sub_park_message_requests` and `eventstore_persistent_sub_parked_message_replays` respectively in EventStoreDB version 24.10 and onwards.
+These metrics have been renamed in EventStoreDB v24.10, see the compatibility note below.
 :::
 
 Example configuration:
 
 ```json
-"PersistentSubscriptionStats": true,
+"PersistentSubscriptions": {
+	"ParkedMessages": true
+},
 ```
 
 Example Output:
@@ -265,6 +267,35 @@ eventstore_persistent_subscriptions_messages_parked{reason="max-retries"} 0 1750
 # TYPE eventstore_persistent_subscriptions_replays_requested counter
 eventstore_persistent_subscriptions_replays_requested 0 1750337191056
 ```
+
+#### Compatibility with v24.10 and onwards
+
+The names of these metrics have been adjusted in EventStoreDB v24.10 and onwards:
+
+| Old name | New name |
+|:---------|:---------|
+| `eventstore_persistent_subscriptions_messages_parked` | `eventstore_persistent_sub_park_message_requests` |
+| `eventstore_persistent_subscriptions_replays_requested` | `eventstore_persistent_sub_parked_message_replays` |
+
+These metrics are now also broken down per stream/group.
+
+The following detail is only important if you edited your `metricsconfig.json` file in EventStoreDB v23.10.6:
+
+In v23.10.6 the metrics were enabled/disabled with this line in `metricsconfig.json`
+
+```json
+"PersistentSubscriptions": {
+	"ParkedMessages": true
+},
+```
+
+In v24.10.5 it is covered by the existing line:
+
+```json
+"PersistentSubscriptionStats": true,
+```
+
+The metrics are on by default in both cases.
 
 ::: note
 Native EventStoreDB metrics do not yet contain all of the metrics for Persistent Subscriptions. To view these in Prometheus you can still use the [Prometheus exporter](https://github.com/marcinbudny/eventstore_exporter).

--- a/docs/server/diagnostics/metrics.md
+++ b/docs/server/diagnostics/metrics.md
@@ -237,7 +237,7 @@ Example Output:
 eventstore_kestrel_connections 1 1688070655500
 ```
 
-### Persistent Subscriptions
+### Persistent Subscriptions (23.10.7+)
 
 Persistent subscription metrics track the statistics for the persistent subscriptions.
 
@@ -279,9 +279,9 @@ The names of these metrics have been adjusted in EventStoreDB v24.10 and onwards
 
 These metrics are now also broken down per stream/group.
 
-The following detail is only important if you edited your `metricsconfig.json` file in EventStoreDB v23.10.6:
+The following detail is only important if you edited your `metricsconfig.json` file in EventStoreDB v23.10:
 
-In v23.10.6 the metrics were enabled/disabled with this line in `metricsconfig.json`
+In v23.10 the metrics were enabled/disabled with this line in `metricsconfig.json`
 
 ```json
 "PersistentSubscriptions": {
@@ -289,7 +289,7 @@ In v23.10.6 the metrics were enabled/disabled with this line in `metricsconfig.j
 },
 ```
 
-In v24.10.5 it is covered by the existing line:
+In v24.10 it is covered by the existing line:
 
 ```json
 "PersistentSubscriptionStats": true,

--- a/docs/server/diagnostics/metrics.md
+++ b/docs/server/diagnostics/metrics.md
@@ -7,7 +7,7 @@ order: 2
 EventStoreDB collects metrics in [prometheus format](https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format), available on the `/metrics` endpoint. Prometheus can be configured to scrape this endpoint directly. The metrics are configured in `metricsconfig.json`. 
 
 ::: note
-Native EventStoreDB metrics do not yet contain metrics for Projections and Persistent Subscriptions. To view these in Prometheus you can still use the [Prometheus exporter](https://github.com/marcinbudny/eventstore_exporter).
+Native EventStoreDB metrics do not yet contain all of the metrics for Projections and Persistent Subscriptions. To view these in Prometheus you can still use the [Prometheus exporter](https://github.com/marcinbudny/eventstore_exporter).
 :::
 
 ## Metrics Reference
@@ -236,6 +236,39 @@ Example Output:
 # TYPE eventstore_kestrel_connections gauge
 eventstore_kestrel_connections 1 1688070655500
 ```
+
+### Persistent Subscriptions
+
+Persistent subscription metrics track the statistics for the persistent subscriptions.
+
+| Time series                                                                                                                 | Type                     | Description                                                    |
+|:----------------------------------------------------------------------------------------------------------------------------|:-------------------------|:---------------------------------------------------------------|
+| `eventstore_persistent_subscriptions_messages_parked`<br/>`{event_stream_id=<STREAM_NAME>,group_name=<GROUP_NAME>,reason=<REASON>}` | [Counter](#common-types) | Count of Park Message requests. Reason can be `client-nak` or `max-retries` |
+| `eventstore_persistent_subscriptions_replays_requested`<br/>`{event_stream_id=<STREAM_NAME>,group_name=<GROUP_NAME>}`                | [Counter](#common-types) | Count of Parked Message replay requests                                     |
+
+::: warning
+The `eventstore_persistent_subscriptions_messages_parked` and `eventstore_persistent_subscriptions_replays_requested` metrics have been renamed to `eventstore_persistent_sub_park_message_requests` and `eventstore_persistent_sub_parked_message_replays` respectively in EventStoreDB version 24.10 and onwards.
+:::
+
+Example configuration:
+
+```json
+"PersistentSubscriptionStats": true,
+```
+
+Example Output:
+```
+# TYPE eventstore_persistent_subscriptions_messages_parked counter
+eventstore_persistent_subscriptions_messages_parked{reason="client-nak"} 0 1750337191056
+eventstore_persistent_subscriptions_messages_parked{reason="max-retries"} 0 1750337191056
+
+# TYPE eventstore_persistent_subscriptions_replays_requested counter
+eventstore_persistent_subscriptions_replays_requested 0 1750337191056
+```
+
+::: note
+Native EventStoreDB metrics do not yet contain all of the metrics for Persistent Subscriptions. To view these in Prometheus you can still use the [Prometheus exporter](https://github.com/marcinbudny/eventstore_exporter).
+:::
 
 ### Process
 

--- a/docs/server/diagnostics/metrics.md
+++ b/docs/server/diagnostics/metrics.md
@@ -243,8 +243,8 @@ Persistent subscription metrics track the statistics for the persistent subscrip
 
 | Time series                                                                                                                 | Type                     | Description                                                    |
 |:----------------------------------------------------------------------------------------------------------------------------|:-------------------------|:---------------------------------------------------------------|
-| `eventstore_persistent_subscriptions_messages_parked`<br/>`{event_stream_id=<STREAM_NAME>,group_name=<GROUP_NAME>,reason=<REASON>}` | [Counter](#common-types) | Count of Park Message requests. Reason can be `client-nak` or `max-retries` |
-| `eventstore_persistent_subscriptions_replays_requested`<br/>`{event_stream_id=<STREAM_NAME>,group_name=<GROUP_NAME>}`                | [Counter](#common-types) | Count of Parked Message replay requests                                     |
+| `eventstore_persistent_subscriptions_messages_parked`<br/>`{reason=<REASON>}` | [Counter](#common-types) | Count of Park Message requests. Reason can be `client-nak` or `max-retries` |
+| `eventstore_persistent_subscriptions_replays_requested`                | [Counter](#common-types) | Count of Parked Message replay requests                                     |
 
 ::: warning
 The `eventstore_persistent_subscriptions_messages_parked` and `eventstore_persistent_subscriptions_replays_requested` metrics have been renamed to `eventstore_persistent_sub_park_message_requests` and `eventstore_persistent_sub_parked_message_replays` respectively in EventStoreDB version 24.10 and onwards.

--- a/samples/http-api/persistent-subscriptions/get-all-subscriptions-response-paged.json
+++ b/samples/http-api/persistent-subscriptions/get-all-subscriptions-response-paged.json
@@ -1,0 +1,63 @@
+{
+  "links": [
+    {
+      "href": "https://localhost:2113/subscriptions?offset=0&count=2",
+      "rel": "self"
+    },
+    {
+      "href": "https://localhost:2113/subscriptions?offset=0&count=2",
+      "rel": "first"
+    },
+    {
+      "href": "https://localhost:2113/subscriptions?offset=2&count=2",
+      "rel": "next"
+    }
+  ],
+  "offset": 0,
+  "count": 2,
+  "total": 6,
+  "subscriptions": [
+    {
+      "links": [
+        {
+          "href": "https://localhost:2113/subscriptions/teststream0/testgroup-0/info",
+          "rel": "detail"
+        }
+      ],
+      "eventStreamId": "teststream0",
+      "groupName": "testgroup-0",
+      "parkedMessageUri": "https://localhost:2113/streams/%24persistentsubscription-teststream0::testgroup-0-parked",
+      "getMessagesUri": "https://localhost:2113/subscriptions/teststream0/testgroup-0/1",
+      "status": "Live",
+      "averageItemsPerSecond": 0.0,
+      "totalItemsProcessed": 0,
+      "lastProcessedEventNumber": 0,
+      "lastCheckpointedEventPosition": null,
+      "lastKnownEventNumber": 0,
+      "lastKnownEventPosition": null,
+      "connectionCount": 1,
+      "totalInFlightMessages": 0
+    },
+    {
+      "links": [
+        {
+          "href": "https://localhost:2113/subscriptions/teststream1/testgroup-1/info",
+          "rel": "detail"
+        }
+      ],
+      "eventStreamId": "teststream1",
+      "groupName": "testgroup-1",
+      "parkedMessageUri": "https://localhost:2113/streams/%24persistentsubscription-teststream1::testgroup-1-parked",
+      "getMessagesUri": "https://localhost:2113/subscriptions/teststream1/testgroup-1/1",
+      "status": "Live",
+      "averageItemsPerSecond": 0.0,
+      "totalItemsProcessed": 5,
+      "lastProcessedEventNumber": 0,
+      "lastCheckpointedEventPosition": null,
+      "lastKnownEventNumber": 4,
+      "lastKnownEventPosition": "4",
+      "connectionCount": 1,
+      "totalInFlightMessages": 0
+    }
+  ]
+}

--- a/samples/http-api/persistent-subscriptions/get-all-subscriptions-response.json
+++ b/samples/http-api/persistent-subscriptions/get-all-subscriptions-response.json
@@ -2,39 +2,127 @@
   {
     "links": [
       {
-        "href": "http://localhost:2113/subscriptions/newstream/competing_consumers_group1/info",
+        "href": "https://localhost:2113/subscriptions/teststream0/testgroup-0/info",
         "rel": "detail"
       }
     ],
-    "eventStreamId": "newstream",
-    "groupName": "competing_consumers_group1",
-    "parkedMessageUri": "http://localhost:2113/streams/$persistentsubscription-newstream::competing_consumers_group1-parked",
-    "getMessagesUri": "http://localhost:2113/subscriptions/newstream/competing_consumers_group1/1",
+    "eventStreamId": "teststream0",
+    "groupName": "testgroup-0",
+    "parkedMessageUri": "https://localhost:2113/streams/%24persistentsubscription-teststream0::testgroup-0-parked",
+    "getMessagesUri": "https://localhost:2113/subscriptions/teststream0/testgroup-0/1",
     "status": "Live",
     "averageItemsPerSecond": 0.0,
     "totalItemsProcessed": 0,
-    "lastProcessedEventNumber": -1,
-    "lastKnownEventNumber": 5,
-    "connectionCount": 0,
+    "lastProcessedEventNumber": 0,
+    "lastCheckpointedEventPosition": null,
+    "lastKnownEventNumber": 0,
+    "lastKnownEventPosition": null,
+    "connectionCount": 1,
     "totalInFlightMessages": 0
   },
   {
     "links": [
       {
-        "href": "http://localhost:2113/subscriptions/another_newstream/competing_consumers_group1/info",
+        "href": "https://localhost:2113/subscriptions/teststream1/testgroup-1/info",
         "rel": "detail"
       }
     ],
-    "eventStreamId": "another_newstream",
-    "groupName": "competing_consumers_group1",
-    "parkedMessageUri": "http://localhost:2113/streams/$persistentsubscription-another_newstream::competing_consumers_group1-parked",
-    "getMessagesUri": "http://localhost:2113/subscriptions/another_newstream/competing_consumers_group1/1",
+    "eventStreamId": "teststream1",
+    "groupName": "testgroup-1",
+    "parkedMessageUri": "https://localhost:2113/streams/%24persistentsubscription-teststream1::testgroup-1-parked",
+    "getMessagesUri": "https://localhost:2113/subscriptions/teststream1/testgroup-1/1",
+    "status": "Live",
+    "averageItemsPerSecond": 0.0,
+    "totalItemsProcessed": 5,
+    "lastProcessedEventNumber": 0,
+    "lastCheckpointedEventPosition": null,
+    "lastKnownEventNumber": 4,
+    "lastKnownEventPosition": "4",
+    "connectionCount": 1,
+    "totalInFlightMessages": 0
+  },
+  {
+    "links": [
+      {
+        "href": "https://localhost:2113/subscriptions/teststream2/testgroup-2/info",
+        "rel": "detail"
+      }
+    ],
+    "eventStreamId": "teststream2",
+    "groupName": "testgroup-2",
+    "parkedMessageUri": "https://localhost:2113/streams/%24persistentsubscription-teststream2::testgroup-2-parked",
+    "getMessagesUri": "https://localhost:2113/subscriptions/teststream2/testgroup-2/1",
+    "status": "Live",
+    "averageItemsPerSecond": 0.0,
+    "totalItemsProcessed": 10,
+    "lastProcessedEventNumber": 9,
+    "lastCheckpointedEventPosition": "9",
+    "lastKnownEventNumber": 9,
+    "lastKnownEventPosition": "9",
+    "connectionCount": 1,
+    "totalInFlightMessages": 0
+  },
+  {
+    "links": [
+      {
+        "href": "https://localhost:2113/subscriptions/teststream3/testgroup-3/info",
+        "rel": "detail"
+      }
+    ],
+    "eventStreamId": "teststream3",
+    "groupName": "testgroup-3",
+    "parkedMessageUri": "https://localhost:2113/streams/%24persistentsubscription-teststream3::testgroup-3-parked",
+    "getMessagesUri": "https://localhost:2113/subscriptions/teststream3/testgroup-3/1",
+    "status": "Live",
+    "averageItemsPerSecond": 0.0,
+    "totalItemsProcessed": 6,
+    "lastProcessedEventNumber": 0,
+    "lastCheckpointedEventPosition": null,
+    "lastKnownEventNumber": 5,
+    "lastKnownEventPosition": "5",
+    "connectionCount": 1,
+    "totalInFlightMessages": 0
+  },
+  {
+    "links": [
+      {
+        "href": "https://localhost:2113/subscriptions/teststream4/testgroup-4/info",
+        "rel": "detail"
+      }
+    ],
+    "eventStreamId": "teststream4",
+    "groupName": "testgroup-4",
+    "parkedMessageUri": "https://localhost:2113/streams/%24persistentsubscription-teststream4::testgroup-4-parked",
+    "getMessagesUri": "https://localhost:2113/subscriptions/teststream4/testgroup-4/1",
+    "status": "Live",
+    "averageItemsPerSecond": 0.0,
+    "totalItemsProcessed": 6,
+    "lastProcessedEventNumber": 0,
+    "lastCheckpointedEventPosition": null,
+    "lastKnownEventNumber": 5,
+    "lastKnownEventPosition": "5",
+    "connectionCount": 1,
+    "totalInFlightMessages": 0
+  },
+  {
+    "links": [
+      {
+        "href": "https://localhost:2113/subscriptions/teststream5/testgroup-5/info",
+        "rel": "detail"
+      }
+    ],
+    "eventStreamId": "teststream5",
+    "groupName": "testgroup-5",
+    "parkedMessageUri": "https://localhost:2113/streams/%24persistentsubscription-teststream5::testgroup-5-parked",
+    "getMessagesUri": "https://localhost:2113/subscriptions/teststream5/testgroup-5/1",
     "status": "Live",
     "averageItemsPerSecond": 0.0,
     "totalItemsProcessed": 0,
-    "lastProcessedEventNumber": -1,
-    "lastKnownEventNumber": -1,
-    "connectionCount": 0,
+    "lastProcessedEventNumber": 0,
+    "lastCheckpointedEventPosition": null,
+    "lastKnownEventNumber": 0,
+    "lastKnownEventPosition": null,
+    "connectionCount": 1,
     "totalInFlightMessages": 0
   }
 ]

--- a/samples/http-api/persistent-subscriptions/get-subscription-response.json
+++ b/samples/http-api/persistent-subscriptions/get-subscription-response.json
@@ -1,43 +1,60 @@
 {
   "links": [
     {
-      "href": "http://localhost:2113/subscriptions/newstream/competing_consumers_group1/info",
+      "href": "https://localhost:2113/subscriptions/teststream1/testgroup-1/info",
       "rel": "detail"
     },
     {
-      "href": "http://localhost:2113/subscriptions/newstream/competing_consumers_group1/replayParked",
+      "href": "https://localhost:2113/subscriptions/teststream1/testgroup-1/replayParked",
       "rel": "replayParked"
     }
   ],
   "config": {
     "resolveLinktos": false,
     "startFrom": 0,
-    "messageTimeoutMilliseconds": 10000,
+    "startPosition": "0",
+    "messageTimeoutMilliseconds": 30000,
     "extraStatistics": false,
     "maxRetryCount": 10,
     "liveBufferSize": 500,
     "bufferSize": 500,
     "readBatchSize": 20,
     "preferRoundRobin": true,
-    "checkPointAfterMilliseconds": 1000,
+    "checkPointAfterMilliseconds": 2000,
     "minCheckPointCount": 10,
-    "maxCheckPointCount": 500,
-    "maxSubscriberCount": 10,
+    "maxCheckPointCount": 1000,
+    "maxSubscriberCount": 0,
     "namedConsumerStrategy": "RoundRobin"
   },
-  "eventStreamId": "newstream",
-  "groupName": "competing_consumers_group1",
+  "eventStreamId": "teststream1",
+  "groupName": "testgroup-1",
   "status": "Live",
   "averageItemsPerSecond": 0.0,
-  "parkedMessageUri": "http://localhost:2113/streams/$persistentsubscription-newstream::competing_consumers_group1-parked",
-  "getMessagesUri": "http://localhost:2113/subscriptions/newstream/competing_consumers_group1/1",
-  "totalItemsProcessed": 0,
+  "parkedMessageUri": "https://localhost:2113/streams/%24persistentsubscription-teststream1::testgroup-1-parked",
+  "getMessagesUri": "https://localhost:2113/subscriptions/teststream1/testgroup-1/1",
+  "totalItemsProcessed": 5,
   "countSinceLastMeasurement": 0,
-  "lastProcessedEventNumber": -1,
-  "lastKnownEventNumber": 5,
-  "readBufferCount": 6,
+  "lastProcessedEventNumber": 0,
+  "lastCheckpointedEventPosition": null,
+  "lastKnownEventNumber": 4,
+  "lastKnownEventPosition": "4",
+  "readBufferCount": 0,
   "liveBufferCount": 5,
   "retryBufferCount": 0,
   "totalInFlightMessages": 0,
-  "connections": []
+  "outstandingMessagesCount": 0,
+  "connections": [
+    {
+      "from": "",
+      "username": "admin",
+      "averageItemsPerSecond": 0.0,
+      "totalItemsProcessed": 5,
+      "countSinceLastMeasurement": 0,
+      "extraStatistics": [],
+      "availableSlots": 10,
+      "inFlightMessages": 0,
+      "connectionName": "ES-2f31191f-7741-42e4-958c-7594ed473c47"
+    }
+  ],
+  "parkedMessageCount": 0
 }

--- a/samples/http-api/persistent-subscriptions/get-subscriptions-for-stream-response.json
+++ b/samples/http-api/persistent-subscriptions/get-subscriptions-for-stream-response.json
@@ -2,20 +2,22 @@
   {
     "links": [
       {
-        "href": "http://localhost:2113/subscriptions/newstream/competing_consumers_group1/info",
+        "href": "https://localhost:2113/subscriptions/teststream1/testgroup-1/info",
         "rel": "detail"
       }
     ],
-    "eventStreamId": "newstream",
-    "groupName": "competing_consumers_group1",
-    "parkedMessageUri": "http://localhost:2113/streams/$persistentsubscription-newstream::competing_consumers_group1-parked",
-    "getMessagesUri": "http://localhost:2113/subscriptions/newstream/competing_consumers_group1/1",
+    "eventStreamId": "teststream1",
+    "groupName": "testgroup-1",
+    "parkedMessageUri": "https://localhost:2113/streams/%24persistentsubscription-teststream1::testgroup-1-parked",
+    "getMessagesUri": "https://localhost:2113/subscriptions/teststream1/testgroup-1/1",
     "status": "Live",
     "averageItemsPerSecond": 0.0,
-    "totalItemsProcessed": 0,
-    "lastProcessedEventNumber": -1,
-    "lastKnownEventNumber": 5,
-    "connectionCount": 0,
+    "totalItemsProcessed": 5,
+    "lastProcessedEventNumber": 0,
+    "lastCheckpointedEventPosition": null,
+    "lastKnownEventNumber": 4,
+    "lastKnownEventPosition": "4",
+    "connectionCount": 1,
     "totalInFlightMessages": 0
   }
 ]

--- a/samples/http-api/persistent-subscriptions/read-stream-response.json
+++ b/samples/http-api/persistent-subscriptions/read-stream-response.json
@@ -1,54 +1,67 @@
 {
-  "title": "All Events Persistent Subscription",
-  "id": "http://localhost:2113/subscriptions/newstream/competing_consumers_group1",
-  "updated": "2015-12-02T09:17:48.556545Z",
+  "title": "Messages for 'teststream1/testgroup-1'",
+  "id": "https://localhost:2113/subscriptions/teststream1/testgroup-1",
+  "updated": "2025-06-19T12:39:12.3009956Z",
+  "streamId": null,
   "author": {
     "name": "EventStore"
   },
   "headOfStream": false,
+  "selfUrl": null,
+  "eTag": null,
   "links": [
     {
-      "uri": "http://localhost:2113/subscriptions/newstream/competing_consumers_group1/ack%3Fids=c322e299-cb73-4b47-97c5-5054f920746f",
-      "relation": "ackAll"
+      "uri": "https://localhost:2113/subscriptions/teststream1/testgroup-1/ack?ids=33635881-5881-5881-5881-175033635881",
+      "relation": "ackAll",
+      "type": null
     },
     {
-      "uri": "http://localhost:2113/subscriptions/newstream/competing_consumers_group1/nack%3Fids=c322e299-cb73-4b47-97c5-5054f920746f",
-      "relation": "nackAll"
+      "uri": "https://localhost:2113/subscriptions/teststream1/testgroup-1/nack?ids=33635881-5881-5881-5881-175033635881",
+      "relation": "nackAll",
+      "type": null
     },
     {
-      "uri": "http://localhost:2113/subscriptions/newstream/competing_consumers_group1/1%3Fembed=None",
-      "relation": "previous"
+      "uri": "https://localhost:2113/subscriptions/teststream1/testgroup-1/1",
+      "relation": "previous",
+      "type": null
     },
     {
-      "uri": "http://localhost:2113/subscriptions/newstream/competing_consumers_group1",
-      "relation": "self"
+      "uri": "https://localhost:2113/subscriptions/teststream1/testgroup-1",
+      "relation": "self",
+      "type": null
     }
   ],
   "entries": [
     {
-      "title": "1@newstream",
-      "id": "http://localhost:2113/streams/newstream/1",
-      "updated": "2015-12-02T09:17:48.556545Z",
+      "title": "5@teststream1",
+      "id": "https://localhost:2113/streams/teststream1/5",
+      "updated": "2025-06-19T12:39:12.3009956Z",
       "author": {
         "name": "EventStore"
       },
-      "summary": "SomeEvent",
+      "summary": "test-event",
+      "retryCount": 0,
+      "content": null,
       "links": [
         {
-          "uri": "http://localhost:2113/streams/newstream/1",
-          "relation": "edit"
+          "uri": "https://localhost:2113/streams/teststream1/5",
+          "relation": "edit",
+          "type": null
         },
         {
-          "uri": "http://localhost:2113/streams/newstream/1",
-          "relation": "alternate"
+          "uri": "https://localhost:2113/streams/teststream1/5",
+          "relation": "alternate",
+          "type": null
         },
         {
-          "uri": "http://localhost:2113/subscriptions/newstream/competing_consumers_group1/ack/c322e299-cb73-4b47-97c5-5054f920746f",
-          "relation": "ack"
+          "uri": "https://localhost:2113/subscriptions/teststream1/testgroup-1/ack/33635881-5881-5881-5881-175033635881",
+          "relation": "ack",
+          "type": null
         },
         {
-          "uri": "http://localhost:2113/subscriptions/newstream/competing_consumers_group1/nack/c322e299-cb73-4b47-97c5-5054f920746f",
-          "relation": "nack"
+          "uri": "https://localhost:2113/subscriptions/teststream1/testgroup-1/nack/33635881-5881-5881-5881-175033635881",
+          "relation": "nack",
+          "type": null
         }
       ]
     }


### PR DESCRIPTION
* Add persistent subscription paging docs.
* Update old persistent subscription http samples.
* Update some out-of-date persistent subscription http docs.
* Add persistent subscription metrics with a warning about them being renamed in EventStoreDB v24.10 and up.