### PR TITLE
Exclude documentation from release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,6 +2,7 @@ changelog:
   exclude:
     labels:
       - ignore-for-release
+      - documentation
   categories:
     - title: Added
       labels:
@@ -15,9 +16,6 @@ changelog:
     - title: Breaking Changes
       labels:
         - breaking
-    - title: Documentation
-      labels:
-        - documentation
     - title: Changed
       labels:
         - "*"


### PR DESCRIPTION
Because docs are generally deployed out of band with releases