### PR TITLE
Set StreamInfoCacheCapacity to 0 by default

### DIFF
--- a/docs/server/configuration/README.md
+++ b/docs/server/configuration/README.md
@@ -327,14 +327,14 @@ And will output on `stdout`
 only: _Error while parsing options: The option UnknownConfig is not a known option. (Parameter 'UnknownConfig')_.
 :::
 
-## Autoconfigured options
+## Auto-configured options
 
-Some options are configured at startup to make better use of the available resources on larger instances or
+Some options can be auto-configured at startup to make better use of the available resources on larger instances or
 machines.
 
-These options are `StreamInfoCacheCapacity`, `ReaderThreadsCount`, and `WorkerThreads`.
+By default `ReaderThreadsCount` and `WorkerThreads` are auto-configured, and since v25.1 `StreamInfoCacheCapacity` is not.
 
-Autoconfiguration does not apply in containerized environments.
+Auto-configuration does not apply in containerized environments.
 
 ### StreamInfoCacheCapacity
 
@@ -342,19 +342,19 @@ This option sets the maximum number of entries in the stream info cache. This lo
 any stream that has recently been read or written. Having entries in this cache significantly improves the write 
 and read performance to cached streams on larger databases.
 
-By default, the cache dynamically resizes based on the amount of free memory. The minimum it can be set to is 100,000 entries.
-
 | Format               | Syntax                                  |
 |:---------------------|:----------------------------------------|
 | Command line         | `--stream-info-cache-capacity`          |
 | YAML                 | `StreamInfoCacheCapacity`               |
 | Environment variable | `KURRENTDB_STREAM_INFO_CACHE_CAPACITY`  |
 
-The option is set to 0 by default, which enables dynamic resizing. The default on previous versions of
-KurrentDB was 100,000 entries.
+In v25.1 onwards the option is set to 100000 by default.
+Between 21.0 and 25.0 the default was 0 which enables dynamic resizing.
 
 ::: note
-The default value of 0 for `StreamInfoCacheCapacity` might not always be the best value for optimal performance. Ideally, it should be set to double the number of streams in the anticipated working set.
+Dynamically sizing `StreamInfoCacheCapacity` might not always be the best value for optimal performance. Ideally, it should be set to double the number of streams in the anticipated working set.
+
+The disadvantage of setting it too large is that it increases managed memory usage, which increases load on the garbage collector and can cause leader elections to occur more frequently.
 
 Check the event count in the `$streams` system stream to obtain the total number of streams. This stream is created by the [$streams system projection](../features/projections/system.md#streams-projection).
 

--- a/docs/server/quick-start/whatsnew.md
+++ b/docs/server/quick-start/whatsnew.md
@@ -9,10 +9,19 @@ order: 2
 These are the new features in KurrentDB 25.1:
 
 * [ServerGC](#server-garbage-collection)
+* [StreamInfoCacheCapacity default](#streaminfocachecapacity-default)
 
 ### Server Garbage Collection
 
 The .NET runtime Server Garbage Collection is now enabled by default, increasing the performance of the server. See [the documentation](../configuration/db-config.md#garbage-collection) for more information.
+
+### StreamInfoCacheCapacity Default
+
+`StreamInfoCacheCapacity` is now `100,000` by default rather than `0` (dynamically sized).
+
+StreamInfoCache dynamic sizing was introduced introduced in v21.10 and enabled by default. It allows the StreamInfoCache to grow much larger, according to the amount of free memory which is reevaluated periodically. This is desirable for some workloads, but it comes with a tradeoff of very significantly increased managed memory usage, which in turn causes additional GC pressure and can lead to more frequent elections. On balance we have decided that a default of 100,000 (which is the value used before v21.10) is a better default, favouring its predictability and stability.
+
+Users wishing to keep dynamic sizing can enable it by setting StreamInfoCacheCapacity to 0. Additional can be found in the [StreamInfoCache documentation](../configuration/README.md#streaminfocachecapacity)
 
 ## New in 25.0
 

--- a/src/KurrentDB.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/KurrentDB.Core/Configuration/ClusterVNodeOptions.cs
@@ -281,8 +281,8 @@ public partial record ClusterVNodeOptions {
 
 	[Description("Cluster Options")]
 	public record ClusterOptions {
-		[Description("The maximum number of entries to keep in the stream info cache. Set to '0' to scale automatically (Default)")]
-		public int StreamInfoCacheCapacity { get; init; } = 0;
+		[Description("The maximum number of entries to keep in the stream info cache.")]
+		public int StreamInfoCacheCapacity { get; init; } = 100_000;
 
 		[Description("The number of nodes in the cluster.")]
 		public int ClusterSize { get; init; } = 1;


### PR DESCRIPTION
`StreamInfoCacheCapacity` is now `100,000` by default rather than `0` (dynamically sized).

StreamInfoCache dynamic sizing was introduced introduced in v21.10 and enabled by default. It allows the StreamInfoCache to grow much larger, according to the amount of free memory which is reevaluated periodically. This is desirable for some workloads, but it comes with a tradeoff of very significantly increased managed memory usage, which in turn causes additional GC pressure and can lead to more frequent elections. On balance we have decided that a default of 100,000 (which is the value used before v21.10) is a better default, favouring its predictability and stability.

Users wishing to keep dynamic sizing can enable it by setting StreamInfoCacheCapacity to 0.