### PR TITLE
[KDB-803] Only store non-redundant log record properties

### DIFF
--- a/src/KurrentDB.Core.Tests/Services/Transport/Grpc/PropertiesTests.cs
+++ b/src/KurrentDB.Core.Tests/Services/Transport/Grpc/PropertiesTests.cs
@@ -1,0 +1,211 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using EventStore.Client;
+using EventStore.Client.Streams;
+using Google.Protobuf;
+using Google.Protobuf.Collections;
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+using KurrentDB.Core.Services.Transport.Grpc;
+using KurrentDB.Core.Tests.Services.Transport.Grpc.StreamsTests;
+using KurrentDB.Protocol.V2;
+using NUnit.Framework;
+using MetadataConstants = KurrentDB.Core.Services.Transport.Grpc.Constants.Metadata;
+using PropertiesConstants = KurrentDB.Core.Services.Transport.Grpc.Constants.Properties;
+
+namespace KurrentDB.Core.Tests.Services.Transport.Grpc;
+
+[TestFixture]
+public class PropertiesTests : GrpcSpecification<LogFormat.V2, string> {
+	static StreamIdentifier CreateStreamIdentifier(string stream) => new() {
+		StreamName = ByteString.CopyFromUtf8(stream)
+	};
+
+	async Task AppendV1(string stream, string contentType, string metadataJson) {
+		using var call = StreamsClient.Append(GetCallOptions(AdminCredentials));
+		await call.RequestStream.WriteAsync(new() {
+			Options = new() {
+				StreamIdentifier = CreateStreamIdentifier(stream),
+				Any = new(),
+			}
+		});
+
+		await call.RequestStream.WriteAsync(new() {
+			ProposedMessage = new() {
+				Data = ByteString.CopyFromUtf8("test-data"),
+				Id = Uuid.NewUuid().ToDto(),
+				CustomMetadata = ByteString.CopyFromUtf8(metadataJson),
+				Metadata = {
+					{ MetadataConstants.Type, "test-type" },
+					{ MetadataConstants.ContentType, contentType },
+				}
+			}
+		});
+		await call.RequestStream.CompleteAsync();
+
+		var response = await call.ResponseAsync;
+		if (response.ResultCase is not AppendResp.ResultOneofCase.Success) {
+			throw new Exception($"Append V1 failed {response.ResultCase}");
+		}
+	}
+
+	async Task AppendV2(string stream, string dataFormat, MapField<string, Protobuf.DynamicValue> extraProperties) {
+		MapField<string, Protobuf.DynamicValue> properties = new() {
+			extraProperties,
+			{ PropertiesConstants.EventType, new() { StringValue = "test-type" } },
+			{ PropertiesConstants.DataFormat, new() { StringValue = dataFormat } },
+		};
+
+		var request = new MultiStreamAppendRequest() {
+			Input = {
+				new AppendStreamRequest() {
+					ExpectedRevision = -1,
+					Stream = stream,
+					Records = {
+						new AppendRecord() {
+							RecordId = Guid.NewGuid().ToString(),
+							Data = ByteString.CopyFromUtf8("test-data"),
+							Properties = { properties },
+						}
+					}
+				}
+			}
+		};
+
+		using var call = StreamsClientV2.MultiStreamAppendAsync(request, GetCallOptions(AdminCredentials));
+
+		var response = await call.ResponseAsync;
+		if (response.ResultCase is not MultiStreamAppendResponse.ResultOneofCase.Success) {
+			throw new Exception($"Append V2 failed {response.ResultCase}");
+		}
+	}
+
+	private async Task<ReadResp> ReadSingleEventV1(string stream) {
+		var request = new ReadReq() {
+			Options = new() {
+				Count = 1,
+				Stream = new() {
+					StreamIdentifier = CreateStreamIdentifier(stream),
+					Start = new(),
+				},
+				UuidOption = new() { Structured = new() },
+				ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards,
+				NoFilter = new(),
+				ControlOption = new() {
+					Compatibility = 21,
+				},
+			},
+		};
+
+		using var call = StreamsClient.Read(request);
+		var readResponses = await call.ResponseStream.ReadAllAsync().ToArrayAsync();
+		// discard the proto messages that are not events
+		return readResponses.Single(x => x.Event is not null);
+	}
+
+	protected override Task Given() => Task.CompletedTask;
+
+	protected override Task When() => Task.CompletedTask;
+
+	[TestCase(MetadataConstants.ContentTypes.ApplicationJson)]
+	[TestCase(MetadataConstants.ContentTypes.ApplicationOctetStream)]
+	public async Task write_with_v1_then_read_with_v1(string contentType) {
+		var stream = $"write_with_v1_read_with_v1_{contentType}-{Guid.NewGuid()}";
+
+		var logRecordMetadataJson = """
+			{
+			  "my-number": 42,
+			  "my-string": "hello world"
+			}
+			""";
+
+		await AppendV1(
+			stream: stream,
+			contentType: contentType,
+			metadataJson: logRecordMetadataJson);
+
+		var evt = (await ReadSingleEventV1(stream)).Event.Event;
+
+		// content-type is preserved
+		var protocolMetadata = evt.Metadata;
+		Assert.AreEqual(3, protocolMetadata.Count);
+		Assert.True(protocolMetadata.TryGetValue(MetadataConstants.Created, out _));
+		Assert.AreEqual("test-type", protocolMetadata[MetadataConstants.Type]);
+		Assert.AreEqual(contentType, protocolMetadata[MetadataConstants.ContentType]);
+
+		// log record metadata comes out the same as it went in
+		Assert.AreEqual(logRecordMetadataJson, evt.CustomMetadata.ToStringUtf8());
+	}
+
+	[TestCase(PropertiesConstants.DataFormats.Json, MetadataConstants.ContentTypes.ApplicationJson)]
+	[TestCase(PropertiesConstants.DataFormats.Avro, MetadataConstants.ContentTypes.ApplicationOctetStream)]
+	[TestCase(PropertiesConstants.DataFormats.Bytes, MetadataConstants.ContentTypes.ApplicationOctetStream)]
+	[TestCase(PropertiesConstants.DataFormats.Protobuf, MetadataConstants.ContentTypes.ApplicationOctetStream)]
+	public async Task write_with_v2_then_read_with_v1(string dataFormat, string expectedContentType) {
+		var stream = $"write_with_v2_read_with_v1_{dataFormat}-{Guid.NewGuid()}";
+
+		var now = new DateTime(2025, 07, 14, 05, 05, 05, DateTimeKind.Utc);
+		await AppendV2(stream, dataFormat, new() {
+			{ "my-null", new() { NullValue = NullValue.NullValue } },
+			{ "my-int32", new() { Int32Value = 32 } },
+			{ "my-int64", new() { Int64Value = 64 } },
+			{ "my-bytes", new() { BytesValue = ByteString.CopyFromUtf8("utf8-bytes") } },
+			{ "my-double", new() { DoubleValue = 123.4 } },
+			{ "my-float", new() { FloatValue = 567.8f } },
+			{ "my-string", new() { StringValue = "hello-world" } },
+			{ "my-boolean", new() { BooleanValue = true } },
+			{ "my-timestamp", new() { TimestampValue = Timestamp.FromDateTime(now) } },
+			{ "my-duration", new() { DurationValue = Duration.FromTimeSpan(TimeSpan.FromSeconds(121)) } },
+		});
+
+		var evt = (await ReadSingleEventV1(stream)).Event.Event;
+
+		// dataFormat is translated to correct content-type
+		var protocolMetadata = evt.Metadata;
+		Assert.AreEqual(3, protocolMetadata.Count);
+		Assert.True(protocolMetadata.TryGetValue(MetadataConstants.Created, out _));
+		Assert.AreEqual("test-type", protocolMetadata[MetadataConstants.Type]);
+		Assert.AreEqual(expectedContentType, protocolMetadata[MetadataConstants.ContentType]);
+
+		// todo: should probably prefer non strings for the numbers and bool.
+		// todo: doubt the timestamp formatting including \u002B is correct
+		// todo: consider formatting timestamp like this since it doesn't have any timezone info: "2025-07-14T05:05:05.0000000Z"
+
+		// log record metadata contains the properties
+		var expectedMetadata = $$"""
+			{
+			  "my-null":             null,
+			  "my-int32":            "32",
+			  "my-int64":            "64",
+			  "my-bytes":            "{{Convert.ToBase64String(Encoding.UTF8.GetBytes("utf8-bytes"))}}",
+			  "my-double":           "123.4",
+			  "my-float":            "567.8",
+			  "my-string":           "hello-world",
+			  "my-boolean":          "True",
+			  "my-timestamp":        "2025-07-14T05:05:05.0000000\u002B00:00",
+			  "my-duration":         "00:02:01",
+			  "$schema.data-format": "{{dataFormat}}",
+			  "$schema.name":        "test-type"
+			}
+			""".Replace(" ", "").Replace(Environment.NewLine, "");
+
+		var actual = evt.CustomMetadata.ToStringUtf8();
+		Assert.AreEqual(expectedMetadata, actual);
+	}
+
+	[Test]
+	public void write_v2_with_invalid_data_format() {
+		var dataFormat = "something-else";
+		var stream = $"write_v2_with_invalid_data_format_{Guid.NewGuid()}";
+
+		var ex = Assert.ThrowsAsync<RpcException>(() => AppendV2(stream, dataFormat, []));
+
+		Assert.AreEqual("Data format 'something-else' is not supported", ex!.Status.Detail);
+		Assert.AreEqual(StatusCode.InvalidArgument, ex.StatusCode);
+	}
+}

--- a/src/KurrentDB.Core.Tests/Services/Transport/Grpc/StreamsTests/GrpcSpecification.cs
+++ b/src/KurrentDB.Core.Tests/Services/Transport/Grpc/StreamsTests/GrpcSpecification.cs
@@ -28,6 +28,7 @@ public abstract class GrpcSpecification<TLogFormat, TStreamId> {
 	protected GrpcChannel Channel;
 	private readonly MiniNode<TLogFormat, TStreamId> _node;
 	internal Streams.StreamsClient StreamsClient { get; set; }
+	internal Protocol.V2.StreamsService.StreamsServiceClient StreamsClientV2 { get; set; }
 	internal PersistentSubscriptions.PersistentSubscriptionsClient PersistentSubscriptionsClient { get; set; }
 	private BatchAppender _batchAppender;
 
@@ -55,6 +56,7 @@ public abstract class GrpcSpecification<TLogFormat, TStreamId> {
 				DisposeHttpClient = false,
 			});
 		StreamsClient = new(Channel);
+		StreamsClientV2 = new(Channel);
 		PersistentSubscriptionsClient = new(Channel);
 		_batchAppender = new(StreamsClient);
 		_batchAppender.Start();

--- a/src/KurrentDB.Core.XUnit.Tests/Services/Transport/Grpc/V2/MSARequestConverterTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Services/Transport/Grpc/V2/MSARequestConverterTests.cs
@@ -12,7 +12,7 @@ using KurrentDB.Protobuf.Server;
 using KurrentDB.Protocol.V2;
 using Xunit;
 
-namespace KurrentDB.Core.XUnit.Tests.Services.Transport.Grpc;
+namespace KurrentDB.Core.XUnit.Tests.Services.Transport.Grpc.V2;
 
 public class MSARequestConverterTests {
 	const int TestChunkSize = 10_000;
@@ -187,9 +187,11 @@ public class MSARequestConverterTests {
 	}
 
 	[Theory]
-	[InlineData("json", true)]
-	[InlineData("avro", false)]
-	public void can_ConvertRecord(string dataFormat, bool expectedIsJson) {
+	[InlineData("json", true, false)]
+	[InlineData("bytes", false, false)]
+	[InlineData("avro", false, true)]
+	[InlineData("protobuf", false, true)]
+	public void can_ConvertToEvent(string dataFormat, bool expectedIsJson, bool storedInProperties) {
 		// given
 		var recordId = Guid.NewGuid();
 		var input = new AppendRecord {
@@ -216,7 +218,13 @@ public class MSARequestConverterTests {
 
 		var properties = Properties.Parser.ParseFrom(output.Properties);
 
-		Assert.Equal(5, properties.PropertiesValues.Count);
+		if (storedInProperties) {
+			Assert.Equal(4, properties.PropertiesValues.Count);
+			properties.PropertiesValues.TryGetValue(Constants.Properties.DataFormat, out var prop);
+			Assert.Equal(dataFormat, prop!.StringValue);
+		} else {
+			Assert.Equal(3, properties.PropertiesValues.Count);
+		}
 
 		properties.PropertiesValues.TryGetValue("property1", out var property1);
 		Assert.True(property1!.BooleanValue);
@@ -229,7 +237,7 @@ public class MSARequestConverterTests {
 	}
 
 	[Fact]
-	public void can_ConvertRecord_with_minimal_fields() {
+	public void can_ConvertToEvent_with_minimal_fields() {
 		// data and metadata can be blank
 		// given
 		var input = new AppendRecord {
@@ -239,8 +247,6 @@ public class MSARequestConverterTests {
 			},
 		};
 
-		// var expectedMetadata = ProtoJsonSerializer.Default.Serialize(new Properties { PropertiesValues = { input.Properties } }).ToArray();
-
 		// when
 		var output = MultiStreamAppendConverter.ConvertToEvent(input);
 
@@ -249,13 +255,13 @@ public class MSARequestConverterTests {
 		Assert.Equal("my-event-type", output.EventType);
 		Assert.False(output.IsJson);
 		Assert.Empty(output.Data);
-		Assert.Equal([],output.Metadata);
+		Assert.Equal([], output.Metadata);
 	}
 
 	[Theory]
 	[InlineData("")]
 	[InlineData("junk")]
-	public void ConvertRecord_throws_when_record_has_invalid_id(string recordId) {
+	public void ConvertToEvent_throws_when_record_has_invalid_id(string recordId) {
 		// given
 		var input = new AppendRecord {
 			RecordId = recordId,
@@ -274,10 +280,30 @@ public class MSARequestConverterTests {
 		Assert.Empty(ex.Trailers);
 	}
 
+	[Fact]
+	public void ConvertToEvent_throws_when_record_has_invalid_data_format() {
+		// given
+		var input = new AppendRecord {
+			RecordId = Guid.NewGuid().ToString(),
+			Properties = {
+				{ Constants.Properties.EventType, new() { StringValue = "my-event-type" } },
+				{ Constants.Properties.DataFormat, new() { StringValue = "a-different-data-format" } },
+			},
+		};
+
+		// when
+		var ex = Assert.Throws<RpcException>(() => MultiStreamAppendConverter.ConvertToEvent(input));
+
+		// then
+		Assert.Equal($"Data format 'a-different-data-format' is not supported", ex.Status.Detail);
+		Assert.Equal(StatusCode.InvalidArgument, ex.Status.StatusCode);
+		Assert.Empty(ex.Trailers);
+	}
+
 	[Theory]
 	[InlineData(Constants.Properties.EventType)]
 	[InlineData(Constants.Properties.DataFormat)]
-	public void ConvertRecord_throws_when_record_has_missing_required_property(string missingProperty) {
+	public void ConvertToEvent_throws_when_record_has_missing_required_property(string missingProperty) {
 		// given
 		var input = new AppendRecord {
 			Properties = {
@@ -309,7 +335,7 @@ public class MSARequestConverterTests {
 	[Theory]
 	[InlineData(Constants.Properties.EventType)]
 	[InlineData(Constants.Properties.DataFormat)]
-	public void ConvertRecord_throws_when_record_has_required_property_with_wrong_type(string wrongProperty) {
+	public void ConvertToEvent_throws_when_record_has_required_property_with_wrong_type(string wrongProperty) {
 		// given
 		var input = new AppendRecord {
 			Properties = {

--- a/src/KurrentDB.Core.XUnit.Tests/Services/Transport/Grpc/V2/MSAResponseConverterTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Services/Transport/Grpc/V2/MSAResponseConverterTests.cs
@@ -14,7 +14,7 @@ using KurrentDB.Core.Services.Transport.Grpc.V2;
 using KurrentDB.Protocol.V2;
 using Xunit;
 
-namespace KurrentDB.Core.XUnit.Tests.Services.Transport.Grpc;
+namespace KurrentDB.Core.XUnit.Tests.Services.Transport.Grpc.V2;
 
 public class MSAResponseConverterTests {
 	const int TestChunkSize = 10_000;
@@ -41,7 +41,7 @@ public class MSAResponseConverterTests {
 			failureCurrentVersions: new long[] { 10 });
 
 		// when
-		var result = Sut.ConvertToResponse(input,requests);
+		var result = Sut.ConvertToResponse(input, requests);
 
 		// then
 		Assert.Collection(
@@ -70,7 +70,7 @@ public class MSAResponseConverterTests {
 			failureCurrentVersions: new long[] { 11 });
 
 		// when
-		var result = Sut.ConvertToResponse(input,requests);
+		var result = Sut.ConvertToResponse(input, requests);
 
 		// then
 		Assert.Collection(
@@ -99,7 +99,7 @@ public class MSAResponseConverterTests {
 			failureCurrentVersions: new long[] { 11, 13 });
 
 		// when
-		var result = Sut.ConvertToResponse(input,requests);
+		var result = Sut.ConvertToResponse(input, requests);
 
 		// then
 		Assert.Collection(
@@ -134,7 +134,7 @@ public class MSAResponseConverterTests {
 			failureCurrentVersions: isStreamKnown ? [11] : []);
 
 		// when
-		var result = Sut.ConvertToResponse(input,requests);
+		var result = Sut.ConvertToResponse(input, requests);
 
 		// then
 		Assert.Collection(

--- a/src/KurrentDB.Core.XUnit.Tests/Services/Transport/Grpc/V2/MultiStreamAppendServiceTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Services/Transport/Grpc/V2/MultiStreamAppendServiceTests.cs
@@ -24,7 +24,7 @@ using KurrentDB.Protocol.V2;
 using Microsoft.AspNetCore.Http;
 using Xunit;
 
-namespace KurrentDB.Core.XUnit.Tests.Services.Transport.Grpc;
+namespace KurrentDB.Core.XUnit.Tests.Services.Transport.Grpc.V2;
 
 public class MultiStreamAppendServiceTests {
 	readonly AdHocPublisher _mainQueue = new();

--- a/src/KurrentDB.Core/Services/Transport/Grpc/Constants.cs
+++ b/src/KurrentDB.Core/Services/Transport/Grpc/Constants.cs
@@ -72,6 +72,9 @@ public static class Constants {
 		public static class DataFormats {
 			// can be others (protobuf, avro, ...) but json is the only one the server cares about
 			public const string Json = "json";
+			public const string Bytes = "bytes";
+			public const string Avro = "avro";
+			public const string Protobuf = "protobuf";
 		}
 
 		// for write


### PR DESCRIPTION
Log record properties that are already captured elsewhere in the log record need not be stored as properties. They are reconstituted on read.

i.e.
- EventType
- ContentType if it is fully described by the IsJson flag (`application/json` or `application/octet-stream`)