### PR TITLE
Lower Scavenge API GET calls to Verbose

### DIFF
--- a/src/KurrentDB.Core/Services/Transport/Http/Controllers/AdminController.cs
+++ b/src/KurrentDB.Core/Services/Transport/Http/Controllers/AdminController.cs
@@ -259,7 +259,7 @@ public class AdminController : CommunicationController {
 	}
 
 	private void OnGetCurrentScavenge(HttpEntityManager entity, UriTemplateMatch match) {
-		Log.Information("/admin/scavenge/current GET request has been received.");
+		Log.Verbose("/admin/scavenge/current GET request has been received.");
 
 		var envelope = new SendToHttpEnvelope<ClientMessage.ScavengeDatabaseGetCurrentResponse>(
 			_networkSendQueue,
@@ -286,7 +286,7 @@ public class AdminController : CommunicationController {
 	}
 
 	private void OnGetLastScavenge(HttpEntityManager entity, UriTemplateMatch match) {
-		Log.Information("/admin/scavenge/last GET request has been received.");
+		Log.Verbose("/admin/scavenge/last GET request has been received.");
 
 		var envelope = new SendToHttpEnvelope<ClientMessage.ScavengeDatabaseGetLastResponse>(
 			_networkSendQueue,


### PR DESCRIPTION
The auto-scavenge checks on the status of scavenges frequently, which before this PR is producting a lot of logs