### PR TITLE
[v25.0] Make MiniNode TCSs RunContinuationsAsynchronously

### DIFF
--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -57,8 +57,8 @@ public class MiniClusterNode<TLogFormat, TStreamId> {
 	public TFChunkDb Db => Node.Db;
 	private readonly string _dbPath;
 	private readonly bool _isReadOnlyReplica;
-	private readonly TaskCompletionSource<bool> _started = new();
-	private readonly TaskCompletionSource<bool> _adminUserCreated = new();
+	private readonly TaskCompletionSource<bool> _started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+	private readonly TaskCompletionSource<bool> _adminUserCreated = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
 	public Task Started => _started.Task;
 	public Task AdminUserCreated => _adminUserCreated.Task;

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -260,8 +260,8 @@ public class MiniNode<TLogFormat, TStreamId> : MiniNode, IAsyncDisposable {
 		Node.Startup.ConfigureServices(builder.Services);
 		_webHost = builder.Build();
 		Node.Startup.Configure(_webHost);
-		_started = new TaskCompletionSource<bool>();
-		_adminUserCreated = new TaskCompletionSource<bool>();
+		_started = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+		_adminUserCreated = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 	}
 
 	public async Task StartTestServer() {


### PR DESCRIPTION
Cherry pick of #5146

This appears to be the source of the flakiness of the when_reading_an_event_committed_on_leader_and_on_followers tests, quite likely others also.