### PR TITLE
[v24.10] [KDB-951] Lower Scavenge API GET calls to Verbose (#5197)

### DIFF
--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
@@ -250,7 +250,7 @@ public class AdminController : CommunicationController {
 	}
 
 	private void OnGetCurrentScavenge(HttpEntityManager entity, UriTemplateMatch match) {
-		Log.Information("/admin/scavenge/current GET request has been received.");
+		Log.Verbose("/admin/scavenge/current GET request has been received.");
 
 		var envelope = new SendToHttpEnvelope<ClientMessage.ScavengeDatabaseGetCurrentResponse>(
 			_networkSendQueue,
@@ -277,7 +277,7 @@ public class AdminController : CommunicationController {
 	}
 
 	private void OnGetLastScavenge(HttpEntityManager entity, UriTemplateMatch match) {
-		Log.Information("/admin/scavenge/last GET request has been received.");
+		Log.Verbose("/admin/scavenge/last GET request has been received.");
 
 		var envelope = new SendToHttpEnvelope<ClientMessage.ScavengeDatabaseGetLastResponse>(
 			_networkSendQueue,


### PR DESCRIPTION
Changed: Lowered Log Level of Scavenge API GET calls to Verbose 

The auto-scavenge checks on the status of scavenges frequently, which before this PR is producing a lot of logs