### PR TITLE
[KDB-957][DB-1599] Add DuckDB metrics for secondary indexes

### DIFF
--- a/src/KurrentDB.Core/Metrics/DurationMetric.cs
+++ b/src/KurrentDB.Core/Metrics/DurationMetric.cs
@@ -25,6 +25,16 @@ public class DurationMetric {
 
 	public Instant Record(
 		Instant start,
+		KeyValuePair<string, object> tag1) {
+
+		var now = _clock.Now;
+		var elapsedSeconds = now.ElapsedSecondsSince(start);
+		_histogram.Record(elapsedSeconds, tag1);
+		return now;
+	}
+
+	public Instant Record(
+		Instant start,
 		KeyValuePair<string, object> tag1,
 		KeyValuePair<string, object> tag2) {
 

--- a/src/KurrentDB.SecondaryIndexing.LoadTesting/Assertions/DuckDb/DuckDbIndexingSummaryAssertion.cs
+++ b/src/KurrentDB.SecondaryIndexing.LoadTesting/Assertions/DuckDb/DuckDbIndexingSummaryAssertion.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
+using KurrentDB.SecondaryIndexing.Indexes.Diagnostics;
 using KurrentDB.SecondaryIndexing.Storage;
 using KurrentDB.SecondaryIndexing.Tests.Observability;
 using static KurrentDB.SecondaryIndexing.Indexes.Category.CategorySql;
@@ -15,7 +16,7 @@ public class DuckDbIndexingSummaryAssertion(DuckDbDataSource db): IIndexingSumma
 	}
 
 	private ValueTask AssertCategoriesAreIndexed(IndexingSummary summary) {
-		var categories = db.Pool.Query<CategorySummary, GetCategoriesSummaryQuery>();
+		var categories = db.Pool.Query<CategorySummary, GetCategoriesSummaryQuery>(QueryTracker.NoOp);
 
 		if (categories.All(c => summary.Categories.ContainsKey(c.Name)))
 			return ValueTask.FromException(new Exception("Categories doesn't match;"));
@@ -24,7 +25,7 @@ public class DuckDbIndexingSummaryAssertion(DuckDbDataSource db): IIndexingSumma
 	}
 
 	private ValueTask AssertEventTypesAreIndexed(IndexingSummary summary) {
-		var eventTypes = db.Pool.Query<EventTypeSummary, GetEventTypesSummaryQuery>();
+		var eventTypes = db.Pool.Query<EventTypeSummary, GetEventTypesSummaryQuery>(QueryTracker.NoOp);
 
 		if (eventTypes.All(c => summary.EventTypes.ContainsKey(c.Name)))
 			return ValueTask.FromException(new Exception("Event Types doesn't match;"));

--- a/src/KurrentDB.SecondaryIndexing.LoadTesting/Environments/Indexes/IndexMessageBatchAppender.cs
+++ b/src/KurrentDB.SecondaryIndexing.LoadTesting/Environments/Indexes/IndexMessageBatchAppender.cs
@@ -28,9 +28,9 @@ public class IndexMessageBatchAppender : IMessageBatchAppender {
 			new DefaultIndexInFlightRecords(new SecondaryIndexingPluginOptions { CommitBatchSize = commitSize });
 
 		var publisher = new FakePublisher();
-		var categoryIndexProcessor = new CategoryIndexProcessor(dbDataSource, publisher);
-		var eventTypeIndexProcessor = new EventTypeIndexProcessor(dbDataSource, publisher);
-		var streamIndexProcessor = new StreamIndexProcessor(dbDataSource, reader.IndexReader.Backend, hasher);
+		var categoryIndexProcessor = new CategoryIndexProcessor(dbDataSource, publisher, QueryTracker.NoOp);
+		var eventTypeIndexProcessor = new EventTypeIndexProcessor(dbDataSource, publisher, QueryTracker.NoOp);
+		var streamIndexProcessor = new StreamIndexProcessor(dbDataSource, reader.IndexReader.Backend, hasher, QueryTracker.NoOp);
 
 		_processor = new DefaultIndexProcessor(
 			dbDataSource,
@@ -39,6 +39,7 @@ public class IndexMessageBatchAppender : IMessageBatchAppender {
 			eventTypeIndexProcessor,
 			streamIndexProcessor,
 			new NoOpSecondaryIndexProgressTracker(), // TODO: Use the real one with metrics
+			QueryTracker.NoOp,
 			publisher
 		);
 	}

--- a/src/KurrentDB.SecondaryIndexing.Tests/Indexes/DefaultIndexReaderTests/DefaultIndexReaderTests.cs
+++ b/src/KurrentDB.SecondaryIndexing.Tests/Indexes/DefaultIndexReaderTests/DefaultIndexReaderTests.cs
@@ -832,10 +832,10 @@ public class DefaultIndexReaderTests : DuckDbIntegrationTest {
 			new SecondaryIndexingPluginOptions { CommitBatchSize = commitBatchSize });
 
 		var publisher = new FakePublisher();
-		var categoryIndexProcessor = new CategoryIndexProcessor(DuckDb, publisher);
-		var eventTypeIndexProcessor = new EventTypeIndexProcessor(DuckDb, publisher);
+		var categoryIndexProcessor = new CategoryIndexProcessor(DuckDb, publisher, QueryTracker.NoOp);
+		var eventTypeIndexProcessor = new EventTypeIndexProcessor(DuckDb, publisher, QueryTracker.NoOp);
 		var streamIndexProcessor =
-			new StreamIndexProcessor(DuckDb, _readIndexStub.ReadIndex.IndexReader.Backend, hasher);
+			new StreamIndexProcessor(DuckDb, _readIndexStub.ReadIndex.IndexReader.Backend, hasher, QueryTracker.NoOp);
 
 		_processor = new DefaultIndexProcessor(
 			DuckDb,
@@ -844,9 +844,10 @@ public class DefaultIndexReaderTests : DuckDbIntegrationTest {
 			eventTypeIndexProcessor,
 			streamIndexProcessor,
 			new NoOpSecondaryIndexProgressTracker(),
+			QueryTracker.NoOp,
 			publisher
 		);
 
-		_sut = new DefaultIndexReader(DuckDb, _processor, inFlightRecords, _readIndexStub.ReadIndex);
+		_sut = new DefaultIndexReader(DuckDb, _processor, inFlightRecords, _readIndexStub.ReadIndex, QueryTracker.NoOp);
 	}
 }

--- a/src/KurrentDB.SecondaryIndexing/Indexes/Category/CategoryIndexProcessor.cs
+++ b/src/KurrentDB.SecondaryIndexing/Indexes/Category/CategoryIndexProcessor.cs
@@ -26,8 +26,8 @@ internal class CategoryIndexProcessor {
 		_publisher = publisher;
 		_queryTracker = queryTracker;
 
-		var ids = db.Pool.Query<ReferenceRecord, GetCategoriesQuery>(queryTracker);
-		var sequences = db.Pool.Query<(int Id, long Sequence), GetCategoriesMaxSequencesQuery>(queryTracker)
+		var ids = db.Pool.Query<ReferenceRecord, GetCategoriesQuery>(queryTracker.DontTrack);
+		var sequences = db.Pool.Query<(int Id, long Sequence), GetCategoriesMaxSequencesQuery>(queryTracker.DontTrack)
 			.ToDictionary(ks => ks.Id, vs => vs.Sequence);
 
 		_categories = ids.ToDictionary(x => x.Name, x => x.Id);

--- a/src/KurrentDB.SecondaryIndexing/Indexes/Category/CategoryIndexProcessor.cs
+++ b/src/KurrentDB.SecondaryIndexing/Indexes/Category/CategoryIndexProcessor.cs
@@ -4,6 +4,7 @@
 using KurrentDB.Core.Bus;
 using KurrentDB.Core.Data;
 using KurrentDB.Core.Messages;
+using KurrentDB.SecondaryIndexing.Indexes.Diagnostics;
 using KurrentDB.SecondaryIndexing.Readers;
 using KurrentDB.SecondaryIndexing.Storage;
 using static KurrentDB.SecondaryIndexing.Indexes.Category.CategorySql;
@@ -15,16 +16,18 @@ internal class CategoryIndexProcessor {
 	private readonly Dictionary<int, long> _categorySizes = new();
 	private readonly DuckDbDataSource _db;
 	private readonly IPublisher _publisher;
+	private readonly IQueryTracker _queryTracker;
 
 	private int _seq;
 	public long LastIndexedPosition { get; private set; }
 
-	public CategoryIndexProcessor(DuckDbDataSource db, IPublisher publisher) {
+	public CategoryIndexProcessor(DuckDbDataSource db, IPublisher publisher, IQueryTracker queryTracker) {
 		_db = db;
 		_publisher = publisher;
+		_queryTracker = queryTracker;
 
-		var ids = db.Pool.Query<ReferenceRecord, GetCategoriesQuery>();
-		var sequences = db.Pool.Query<(int Id, long Sequence), GetCategoriesMaxSequencesQuery>()
+		var ids = db.Pool.Query<ReferenceRecord, GetCategoriesQuery>(queryTracker);
+		var sequences = db.Pool.Query<(int Id, long Sequence), GetCategoriesMaxSequencesQuery>(queryTracker)
 			.ToDictionary(ks => ks.Id, vs => vs.Sequence);
 
 		_categories = ids.ToDictionary(x => x.Name, x => x.Id);
@@ -39,7 +42,7 @@ internal class CategoryIndexProcessor {
 		if (!_categories.TryGetValue(categoryName, out var categoryId)) {
 			categoryId = ++_seq;
 			_categories[categoryName] = categoryId;
-			_db.Pool.ExecuteNonQuery<AddCategoryStatementArgs, AddCategoryStatement>(new(categoryId, categoryName));
+			_db.Pool.ExecuteNonQuery<AddCategoryStatementArgs, AddCategoryStatement>(new(categoryId, categoryName), _queryTracker);
 		}
 
 		var nextCategorySequence = _categorySizes.GetValueOrDefault(categoryId, -1) + 1;

--- a/src/KurrentDB.SecondaryIndexing/Indexes/Default/DefaultIndexProcessor.cs
+++ b/src/KurrentDB.SecondaryIndexing/Indexes/Default/DefaultIndexProcessor.cs
@@ -117,11 +117,11 @@ internal class DefaultIndexProcessor : Disposable, ISecondaryIndexProcessor {
 	}
 
 	public long? GetLastPosition() =>
-		_connection.QueryFirstOrDefault<Optional<long>, DefaultSql.GetLastLogPositionSql>(_queryTracker)?.OrNull();
+		_connection.QueryFirstOrDefault<Optional<long>, DefaultSql.GetLastLogPositionSql>(_queryTracker.DontTrack)?.OrNull();
 
 
 	private long? GetLastSequence() =>
-		_connection.QueryFirstOrDefault<Optional<long>, DefaultSql.GetLastSequenceSql>(_queryTracker)?.OrNull();
+		_connection.QueryFirstOrDefault<Optional<long>, DefaultSql.GetLastSequenceSql>(_queryTracker.DontTrack)?.OrNull();
 
 	public void Commit() {
 		if (IsDisposingOrDisposed)

--- a/src/KurrentDB.SecondaryIndexing/Indexes/Default/DefaultIndexProcessor.cs
+++ b/src/KurrentDB.SecondaryIndexing/Indexes/Default/DefaultIndexProcessor.cs
@@ -23,6 +23,7 @@ internal class DefaultIndexProcessor : Disposable, ISecondaryIndexProcessor {
 	private readonly EventTypeIndexProcessor _eventTypeIndexProcessor;
 	private readonly StreamIndexProcessor _streamIndexProcessor;
 	private readonly ISecondaryIndexProgressTracker _progressTracker;
+	private readonly IQueryTracker _queryTracker;
 	private readonly IPublisher _publisher;
 	private Appender _appender;
 
@@ -38,6 +39,7 @@ internal class DefaultIndexProcessor : Disposable, ISecondaryIndexProcessor {
 		EventTypeIndexProcessor eventTypeIndexProcessor,
 		StreamIndexProcessor streamIndexProcessor,
 		ISecondaryIndexProgressTracker progressTracker,
+		IQueryTracker queryTracker,
 		IPublisher publisher
 	) {
 		_connection = db.OpenNewConnection();
@@ -48,6 +50,7 @@ internal class DefaultIndexProcessor : Disposable, ISecondaryIndexProcessor {
 		_eventTypeIndexProcessor = eventTypeIndexProcessor;
 		_streamIndexProcessor = streamIndexProcessor;
 		_progressTracker = progressTracker;
+		_queryTracker = queryTracker;
 		_publisher = publisher;
 
 		var lastSequence = GetLastSequence();
@@ -114,11 +117,11 @@ internal class DefaultIndexProcessor : Disposable, ISecondaryIndexProcessor {
 	}
 
 	public long? GetLastPosition() =>
-		_connection.QueryFirstOrDefault<Optional<long>, DefaultSql.GetLastLogPositionSql>()?.OrNull();
+		_connection.QueryFirstOrDefault<Optional<long>, DefaultSql.GetLastLogPositionSql>(_queryTracker)?.OrNull();
 
 
 	private long? GetLastSequence() =>
-		_connection.QueryFirstOrDefault<Optional<long>, DefaultSql.GetLastSequenceSql>()?.OrNull();
+		_connection.QueryFirstOrDefault<Optional<long>, DefaultSql.GetLastSequenceSql>(_queryTracker)?.OrNull();
 
 	public void Commit() {
 		if (IsDisposingOrDisposed)

--- a/src/KurrentDB.SecondaryIndexing/Indexes/Diagnostics/DuckDbSystemMetrics.cs
+++ b/src/KurrentDB.SecondaryIndexing/Indexes/Diagnostics/DuckDbSystemMetrics.cs
@@ -7,13 +7,13 @@ using KurrentDB.SecondaryIndexing.Storage;
 
 namespace KurrentDB.SecondaryIndexing.Indexes.Diagnostics;
 
-public class SecondaryIndexDuckDbMetrics {
+public class DuckDbSystemMetrics {
 	private readonly Meter _meter;
 	private readonly string _meterPrefix;
 	private readonly DuckDbDataSource _db;
 	private readonly string _dbFile;
 
-	public SecondaryIndexDuckDbMetrics(Meter meter, string meterPrefix, DuckDbDataSource db, string dbFile) {
+	public DuckDbSystemMetrics(Meter meter, string meterPrefix, DuckDbDataSource db, string dbFile) {
 		_meter = meter;
 		_meterPrefix = meterPrefix;
 		_db = db;

--- a/src/KurrentDB.SecondaryIndexing/Indexes/Diagnostics/QueryTracker.cs
+++ b/src/KurrentDB.SecondaryIndexing/Indexes/Diagnostics/QueryTracker.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
-using System.Collections.Concurrent;
 using KurrentDB.Core.Metrics;
 using KurrentDB.Core.Time;
 
@@ -9,26 +8,22 @@ namespace KurrentDB.SecondaryIndexing.Indexes.Diagnostics;
 
 public interface IQueryTracker {
 	IDisposable Start<TQuery>();
+	IQueryTracker DontTrack { get; }
 }
 
-public class QueryTracker(DurationMaxMetric durationMaxMetric, int expectedScrapeInterval) : IQueryTracker {
+public class QueryTracker(DurationMetric durationMetric) : IQueryTracker {
 	public static readonly IQueryTracker NoOp = new NoOpQueryTracker();
-	private readonly ConcurrentDictionary<string, DurationMaxTracker> _durationMaxTrackers = new();
-
-	public IDisposable Start<TQuery>() => new QueryTrackerInstance(Instant.Now, GetDurationMaxTracker(typeof(TQuery).Name));
-
-	private DurationMaxTracker GetDurationMaxTracker(string queryType) =>
-		_durationMaxTrackers.GetOrAdd(queryType, key => new DurationMaxTracker(durationMaxMetric, key, expectedScrapeInterval));
+	public IQueryTracker DontTrack => NoOp;
+	public IDisposable Start<TQuery>() => new QueryTrackerInstance(Instant.Now, durationMetric, typeof(TQuery).Name);
 }
 
-file sealed class QueryTrackerInstance(Instant start, DurationMaxTracker durationMaxTracker) : IDisposable {
+file sealed class QueryTrackerInstance(Instant start, DurationMetric durationMetric, string queryType) : IDisposable {
 	public void Dispose() {
-		lock (durationMaxTracker) { // multiple threads cannot record simultaneously
-			durationMaxTracker.RecordNow(start);
-		}
+		durationMetric.Record(start, new KeyValuePair<string, object>("name", queryType));
 	}
 }
 
 file sealed class NoOpQueryTracker : IQueryTracker {
 	public IDisposable Start<TQuery>() => null!;
+	public IQueryTracker DontTrack => this;
 }

--- a/src/KurrentDB.SecondaryIndexing/Indexes/Diagnostics/QueryTracker.cs
+++ b/src/KurrentDB.SecondaryIndexing/Indexes/Diagnostics/QueryTracker.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Collections.Concurrent;
+using KurrentDB.Core.Metrics;
+using KurrentDB.Core.Time;
+
+namespace KurrentDB.SecondaryIndexing.Indexes.Diagnostics;
+
+public interface IQueryTracker {
+	IDisposable Start<TQuery>();
+}
+
+public class QueryTracker(DurationMaxMetric durationMaxMetric, int expectedScrapeInterval) : IQueryTracker {
+	public static readonly IQueryTracker NoOp = new NoOpQueryTracker();
+	private readonly ConcurrentDictionary<string, DurationMaxTracker> _durationMaxTrackers = new();
+
+	public IDisposable Start<TQuery>() => new QueryTrackerInstance(Instant.Now, GetDurationMaxTracker(typeof(TQuery).Name));
+
+	private DurationMaxTracker GetDurationMaxTracker(string queryType) =>
+		_durationMaxTrackers.GetOrAdd(queryType, key => new DurationMaxTracker(durationMaxMetric, key, expectedScrapeInterval));
+}
+
+file sealed class QueryTrackerInstance(Instant start, DurationMaxTracker durationMaxTracker) : IDisposable {
+	public void Dispose() {
+		lock (durationMaxTracker) { // multiple threads cannot record simultaneously
+			durationMaxTracker.RecordNow(start);
+		}
+	}
+}
+
+file sealed class NoOpQueryTracker : IQueryTracker {
+	public IDisposable Start<TQuery>() => null!;
+}

--- a/src/KurrentDB.SecondaryIndexing/Indexes/Diagnostics/SecondaryIndexProgressTracker.cs
+++ b/src/KurrentDB.SecondaryIndexing/Indexes/Diagnostics/SecondaryIndexProgressTracker.cs
@@ -49,7 +49,8 @@ public class SecondaryIndexProgressTracker : ISecondaryIndexProgressTracker {
 
 	public SecondaryIndexProgressTracker(
 		Meter meter,
-		string meterPrefix
+		string meterPrefix,
+		bool useLegacyNames
 	) {
 		meter.CreateObservableGauge(
 			$"{meterPrefix}.subscription.gap",
@@ -72,7 +73,7 @@ public class SecondaryIndexProgressTracker : ISecondaryIndexProgressTracker {
 			"Events pending checkpoint"
 		);
 
-		var commitLatencyTracker = new DurationMetric(meter, $"{meterPrefix}.commit", false);
+		var commitLatencyTracker = new DurationMetric(meter, $"{meterPrefix}.commit", useLegacyNames);
 
 		_trackers.Commit = new DurationTracker(commitLatencyTracker, "commit");
 	}

--- a/src/KurrentDB.SecondaryIndexing/Indexes/Diagnostics/SecondaryIndexSystemMetrics.cs
+++ b/src/KurrentDB.SecondaryIndexing/Indexes/Diagnostics/SecondaryIndexSystemMetrics.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Diagnostics.Metrics;
+using Kurrent.Quack.Diagnostics;
+using KurrentDB.SecondaryIndexing.Storage;
+
+namespace KurrentDB.SecondaryIndexing.Indexes.Diagnostics;
+
+public class SecondaryIndexDuckDbMetrics {
+	private readonly Meter _meter;
+	private readonly string _meterPrefix;
+	private readonly DuckDbDataSource _db;
+	private readonly string _dbFile;
+
+	public SecondaryIndexDuckDbMetrics(Meter meter, string meterPrefix, DuckDbDataSource db, string dbFile) {
+		_meter = meter;
+		_meterPrefix = meterPrefix;
+		_db = db;
+		_dbFile = dbFile;
+
+		CreateMetrics();
+	}
+
+	private void CreateMetrics() {
+		CreateMemoryMetric();
+		CreateDiskMetric();
+	}
+
+	private void CreateMemoryMetric() {
+		_meter.CreateObservableGauge(
+			$"{_meterPrefix}.memory",
+			ObserveMemoryUsage,
+			"bytes",
+			"DuckDB memory usage"
+		);
+	}
+
+	private void CreateDiskMetric() {
+		_meter.CreateObservableGauge(
+			$"{_meterPrefix}.disk",
+			ObserveDiskUsage,
+			"bytes",
+			"DuckDB disk space usage"
+		);
+	}
+
+	private IEnumerable<Measurement<long>> ObserveMemoryUsage() {
+		var totalMem = 0L;
+
+		using (_db.Pool.Rent(out var connection)) {
+			var memoryInfo = connection.GetMemoryInfo();
+
+			yield return GetMeasurement(nameof(memoryInfo.Allocator), memoryInfo.Allocator);
+			yield return GetMeasurement(nameof(memoryInfo.ArtIndex), memoryInfo.ArtIndex);
+			yield return GetMeasurement(nameof(memoryInfo.BaseTable), memoryInfo.BaseTable);
+			yield return GetMeasurement(nameof(memoryInfo.ColumnData), memoryInfo.ColumnData);
+			yield return GetMeasurement(nameof(memoryInfo.CsvReader), memoryInfo.CsvReader);
+			yield return GetMeasurement(nameof(memoryInfo.Extension), memoryInfo.Extension);
+			yield return GetMeasurement(nameof(memoryInfo.HashTable), memoryInfo.HashTable);
+			yield return GetMeasurement(nameof(memoryInfo.InMemoryTable), memoryInfo.InMemoryTable);
+			yield return GetMeasurement(nameof(memoryInfo.Metadata), memoryInfo.Metadata);
+			yield return GetMeasurement(nameof(memoryInfo.OrderByQueries), memoryInfo.OrderByQueries);
+			yield return GetMeasurement(nameof(memoryInfo.OverflowStrings), memoryInfo.OverflowStrings);
+			yield return GetMeasurement(nameof(memoryInfo.ParquetReader), memoryInfo.ParquetReader);
+		}
+
+		yield return new Measurement<long>(totalMem);
+
+		yield break;
+
+		Measurement<long> GetMeasurement(string key, long value) {
+			totalMem += value;
+			return new Measurement<long>(value, new KeyValuePair<string, object?>("component", key));
+		}
+	}
+
+	private IEnumerable<Measurement<long>> ObserveDiskUsage() {
+		var dbFileSize = new FileInfo(_dbFile).Length;
+		yield return new Measurement<long>(dbFileSize, new KeyValuePair<string, object?>("type", "database"));
+
+		using (_db.Pool.Rent(out var connection)) {
+			var tmpFileSize = connection.GetTemporaryFileSize();
+			yield return new Measurement<long>(tmpFileSize, new KeyValuePair<string, object?>("type", "temporary-files"));
+		}
+	}
+}

--- a/src/KurrentDB.SecondaryIndexing/Indexes/EventType/EventTypeIndexProcessor.cs
+++ b/src/KurrentDB.SecondaryIndexing/Indexes/EventType/EventTypeIndexProcessor.cs
@@ -26,8 +26,8 @@ internal class EventTypeIndexProcessor {
 		_publisher = publisher;
 		_queryTracker = queryTracker;
 
-		var ids = db.Pool.Query<ReferenceRecord, GetAllEventTypesQuery>(queryTracker);
-		var sequences = db.Pool.Query<(int Id, long Sequence), GetEventTypeMaxSequencesQuery>(queryTracker)
+		var ids = db.Pool.Query<ReferenceRecord, GetAllEventTypesQuery>(queryTracker.DontTrack);
+		var sequences = db.Pool.Query<(int Id, long Sequence), GetEventTypeMaxSequencesQuery>(queryTracker.DontTrack)
 			.ToDictionary(ks => ks.Id, vs => vs.Sequence);
 
 		_eventTypes = ids.ToDictionary(x => x.Name, x => x.Id);

--- a/src/KurrentDB.SecondaryIndexing/Indexes/EventType/EventTypeIndexProcessor.cs
+++ b/src/KurrentDB.SecondaryIndexing/Indexes/EventType/EventTypeIndexProcessor.cs
@@ -4,6 +4,7 @@
 using KurrentDB.Core.Bus;
 using KurrentDB.Core.Data;
 using KurrentDB.Core.Messages;
+using KurrentDB.SecondaryIndexing.Indexes.Diagnostics;
 using KurrentDB.SecondaryIndexing.Readers;
 using KurrentDB.SecondaryIndexing.Storage;
 using static KurrentDB.SecondaryIndexing.Indexes.EventType.EventTypeSql;
@@ -15,16 +16,18 @@ internal class EventTypeIndexProcessor {
 	private readonly Dictionary<int, long> _eventTypeSizes;
 	private readonly DuckDbDataSource _db;
 	private readonly IPublisher _publisher;
+	private readonly IQueryTracker _queryTracker;
 
 	private int _seq;
 	public long LastIndexedPosition { get; private set; }
 
-	public EventTypeIndexProcessor(DuckDbDataSource db, IPublisher publisher) {
+	public EventTypeIndexProcessor(DuckDbDataSource db, IPublisher publisher, IQueryTracker queryTracker) {
 		_db = db;
 		_publisher = publisher;
+		_queryTracker = queryTracker;
 
-		var ids = db.Pool.Query<ReferenceRecord, GetAllEventTypesQuery>();
-		var sequences = db.Pool.Query<(int Id, long Sequence), GetEventTypeMaxSequencesQuery>()
+		var ids = db.Pool.Query<ReferenceRecord, GetAllEventTypesQuery>(queryTracker);
+		var sequences = db.Pool.Query<(int Id, long Sequence), GetEventTypeMaxSequencesQuery>(queryTracker)
 			.ToDictionary(ks => ks.Id, vs => vs.Sequence);
 
 		_eventTypes = ids.ToDictionary(x => x.Name, x => x.Id);
@@ -39,7 +42,7 @@ internal class EventTypeIndexProcessor {
 		if (!_eventTypes.TryGetValue(eventTypeName, out var eventTypeId)) {
 			eventTypeId = ++_seq;
 			_eventTypes[eventTypeName] = eventTypeId;
-			_db.Pool.ExecuteNonQuery<AddEventTypeStatementArgs, AddEventTypeStatement>(new(eventTypeId, eventTypeName));
+			_db.Pool.ExecuteNonQuery<AddEventTypeStatementArgs, AddEventTypeStatement>(new(eventTypeId, eventTypeName), _queryTracker);
 		}
 
 		var nextEventTypeSequence = _eventTypeSizes.GetValueOrDefault(eventTypeId, -1) + 1;

--- a/src/KurrentDB.SecondaryIndexing/Indexes/Stream/StreamIndexProcessor.cs
+++ b/src/KurrentDB.SecondaryIndexing/Indexes/Stream/StreamIndexProcessor.cs
@@ -37,7 +37,7 @@ internal class StreamIndexProcessor : Disposable {
 
 		_connection = db.OpenNewConnection();
 		_appender = new Appender(_connection, "streams"u8);
-		_seq = _connection.GetStreamMaxSequences(queryTracker) ?? -1;
+		_seq = _connection.GetStreamMaxSequences(queryTracker.DontTrack) ?? -1;
 	}
 
 	public long LastCommittedPosition { get; private set; }

--- a/src/KurrentDB.SecondaryIndexing/Indexes/Stream/StreamSql.cs
+++ b/src/KurrentDB.SecondaryIndexing/Indexes/Stream/StreamSql.cs
@@ -5,6 +5,7 @@ using DotNext;
 using Kurrent.Quack;
 using Kurrent.Quack.ConnectionPool;
 using KurrentDB.Core.Data;
+using KurrentDB.SecondaryIndexing.Indexes.Diagnostics;
 using KurrentDB.SecondaryIndexing.Storage;
 
 namespace KurrentDB.SecondaryIndexing.Indexes.Stream;
@@ -12,18 +13,22 @@ namespace KurrentDB.SecondaryIndexing.Indexes.Stream;
 internal static class StreamSql {
 	public static long? GetStreamIdByName(
 		this DuckDBAdvancedConnection connection,
-		string streamName
+		string streamName,
+		IQueryTracker tracker
 	) =>
 		connection.QueryFirstOrDefault<GetStreamIdByNameQueryArgs, long, GetStreamIdByNameQuery>(
-			new GetStreamIdByNameQueryArgs(streamName)
+			new GetStreamIdByNameQueryArgs(streamName),
+			tracker
 		);
 
 	public static long? GetStreamIdByName(
 		this DuckDBConnectionPool pool,
-		string streamName
+		string streamName,
+		IQueryTracker tracker
 	) =>
 		pool.QueryFirstOrDefault<GetStreamIdByNameQueryArgs, long, GetStreamIdByNameQuery>(
-			new GetStreamIdByNameQueryArgs(streamName)
+			new GetStreamIdByNameQueryArgs(streamName),
+			tracker
 		);
 
 	private record struct GetStreamIdByNameQueryArgs(string StreamName);
@@ -39,11 +44,11 @@ internal static class StreamSql {
 		public static long Parse(ref DataChunk.Row row) => row.ReadInt64();
 	}
 
-	public static long? GetStreamMaxSequences(this DuckDBAdvancedConnection connection) =>
-		connection.QueryFirstOrDefault<Optional<long>, GetStreamMaxSequencesQuery>()?.OrNull();
+	public static long? GetStreamMaxSequences(this DuckDBAdvancedConnection connection, IQueryTracker tracker) =>
+		connection.QueryFirstOrDefault<Optional<long>, GetStreamMaxSequencesQuery>(tracker)?.OrNull();
 
-	public static long? GetStreamMaxSequences(this DuckDBConnectionPool pool) =>
-		pool.QueryFirstOrDefault<Optional<long>, GetStreamMaxSequencesQuery>()?.OrNull();
+	public static long? GetStreamMaxSequences(this DuckDBConnectionPool pool, IQueryTracker tracker) =>
+		pool.QueryFirstOrDefault<Optional<long>, GetStreamMaxSequencesQuery>(tracker)?.OrNull();
 
 	private struct GetStreamMaxSequencesQuery : IQuery<Optional<long>> {
 		public static ReadOnlySpan<byte> CommandText => "select max(id) from streams"u8;
@@ -122,9 +127,10 @@ internal static class StreamSql {
 
 	public static StreamSummary? GetStreamsSummary(
 		this DuckDBConnectionPool pool,
-		string streamName
+		string streamName,
+		IQueryTracker tracker
 	) =>
-		pool.Query<GetStreamSummaryArgs, StreamSummary, GetStreamSummaryQuery>(new GetStreamSummaryArgs(streamName))
+		pool.Query<GetStreamSummaryArgs, StreamSummary, GetStreamSummaryQuery>(new GetStreamSummaryArgs(streamName), tracker)
 			.FirstOrDefault();
 
 	private readonly record struct GetStreamSummaryArgs(string StreamName);

--- a/src/KurrentDB.SecondaryIndexing/SecondaryIndexingPlugin.cs
+++ b/src/KurrentDB.SecondaryIndexing/SecondaryIndexingPlugin.cs
@@ -71,13 +71,14 @@ internal class SecondaryIndexingPlugin(VirtualStreamReader virtualStreamReader)
 		services.AddSingleton<ISecondaryIndexProgressTracker>(sp =>
 			new SecondaryIndexProgressTracker(
 				coreMeter,
-				"indexes.secondary"
+				meterPrefix: $"{conf.ServiceName}-indexes-secondary",
+				useLegacyNames: conf.LegacyCoreNaming
 			)
 		);
 
 		var queryDurationMetric = new DurationMetric(
 			coreMeter,
-			name: "indexes.secondary.duckdb.query",
+			name: $"{conf.ServiceName}-indexes-secondary-duckdb-query",
 			legacyNames: conf.LegacyCoreNaming);
 
 		var queryTracker = new QueryTracker(queryDurationMetric);
@@ -86,7 +87,7 @@ internal class SecondaryIndexingPlugin(VirtualStreamReader virtualStreamReader)
 		services.AddSingleton<DuckDbSystemMetrics>(sp =>
 			new DuckDbSystemMetrics(
 				meter: coreMeter,
-				meterPrefix: "indexes.secondary.duckdb",
+				meterPrefix: $"{conf.ServiceName}-indexes-secondary-duckdb",
 				db: sp.GetRequiredService<DuckDbDataSource>(),
 				dbFile: GetDuckDbFilePath(sp)
 			)

--- a/src/KurrentDB.SecondaryIndexing/SecondaryIndexingPlugin.cs
+++ b/src/KurrentDB.SecondaryIndexing/SecondaryIndexingPlugin.cs
@@ -7,6 +7,7 @@ using EventStore.Plugins;
 using EventStore.Plugins.Subsystems;
 using KurrentDB.Common.Configuration;
 using KurrentDB.Core.Configuration.Sources;
+using KurrentDB.Core.Metrics;
 using KurrentDB.Core.Services.Storage.InMemory;
 using KurrentDB.Core.TransactionLog.Chunks;
 using KurrentDB.SecondaryIndexing.Builders;
@@ -73,6 +74,14 @@ internal class SecondaryIndexingPlugin(VirtualStreamReader virtualStreamReader)
 				"indexes.secondary"
 			)
 		);
+
+		var durationMaxMetric = new DurationMaxMetric(
+			coreMeter,
+			name: "indexes.secondary.duckdb.query.max",
+			legacyNames: conf.LegacyCoreNaming);
+
+		var queryTracker = new QueryTracker(durationMaxMetric, expectedScrapeInterval: 30);
+		services.AddSingleton<IQueryTracker>(queryTracker);
 
 		services.AddSingleton<SecondaryIndexDuckDbMetrics>(sp =>
 			new SecondaryIndexDuckDbMetrics(

--- a/src/KurrentDB.SecondaryIndexing/SecondaryIndexingPlugin.cs
+++ b/src/KurrentDB.SecondaryIndexing/SecondaryIndexingPlugin.cs
@@ -75,12 +75,12 @@ internal class SecondaryIndexingPlugin(VirtualStreamReader virtualStreamReader)
 			)
 		);
 
-		var durationMaxMetric = new DurationMaxMetric(
+		var queryDurationMetric = new DurationMetric(
 			coreMeter,
-			name: "indexes.secondary.duckdb.query.max",
+			name: "indexes.secondary.duckdb.query",
 			legacyNames: conf.LegacyCoreNaming);
 
-		var queryTracker = new QueryTracker(durationMaxMetric, expectedScrapeInterval: 30);
+		var queryTracker = new QueryTracker(queryDurationMetric);
 		services.AddSingleton<IQueryTracker>(queryTracker);
 
 		services.AddSingleton<DuckDbSystemMetrics>(sp =>

--- a/src/KurrentDB.SecondaryIndexing/SecondaryIndexingPlugin.cs
+++ b/src/KurrentDB.SecondaryIndexing/SecondaryIndexingPlugin.cs
@@ -83,8 +83,8 @@ internal class SecondaryIndexingPlugin(VirtualStreamReader virtualStreamReader)
 		var queryTracker = new QueryTracker(durationMaxMetric, expectedScrapeInterval: 30);
 		services.AddSingleton<IQueryTracker>(queryTracker);
 
-		services.AddSingleton<SecondaryIndexDuckDbMetrics>(sp =>
-			new SecondaryIndexDuckDbMetrics(
+		services.AddSingleton<DuckDbSystemMetrics>(sp =>
+			new DuckDbSystemMetrics(
 				meter: coreMeter,
 				meterPrefix: "indexes.secondary.duckdb",
 				db: sp.GetRequiredService<DuckDbDataSource>(),
@@ -114,7 +114,7 @@ internal class SecondaryIndexingPlugin(VirtualStreamReader virtualStreamReader)
 
 		virtualStreamReader.Register(indexReaders.ToArray<IVirtualStreamReader>());
 
-		app.ApplicationServices.GetService<SecondaryIndexDuckDbMetrics>();
+		app.ApplicationServices.GetService<DuckDbSystemMetrics>();
 	}
 
 	public override (bool Enabled, string EnableInstructions) IsEnabled(IConfiguration configuration) {


### PR DESCRIPTION
Added: DuckDB metrics for secondary indexes

Sample metrics:

## Memory usage
```
# TYPE kurrentdb_indexes_secondary_duckdb_memory_bytes gauge
# UNIT kurrentdb_indexes_secondary_duckdb_memory_bytes bytes
# HELP kurrentdb_indexes_secondary_duckdb_memory_bytes DuckDB memory usage
kurrentdb_indexes_secondary_duckdb_memory_bytes{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0"} 6553600 1754481517950
kurrentdb_indexes_secondary_duckdb_memory_bytes{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",component="Allocator"} 0 1754481517950
kurrentdb_indexes_secondary_duckdb_memory_bytes{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",component="ArtIndex"} 0 1754481517950
kurrentdb_indexes_secondary_duckdb_memory_bytes{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",component="BaseTable"} 6553600 1754481517950
kurrentdb_indexes_secondary_duckdb_memory_bytes{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",component="ColumnData"} 0 1754481517950
kurrentdb_indexes_secondary_duckdb_memory_bytes{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",component="CsvReader"} 0 1754481517950
kurrentdb_indexes_secondary_duckdb_memory_bytes{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",component="Extension"} 0 1754481517950
kurrentdb_indexes_secondary_duckdb_memory_bytes{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",component="HashTable"} 0 1754481517950
kurrentdb_indexes_secondary_duckdb_memory_bytes{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",component="InMemoryTable"} 0 1754481517950
kurrentdb_indexes_secondary_duckdb_memory_bytes{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",component="Metadata"} 0 1754481517950
kurrentdb_indexes_secondary_duckdb_memory_bytes{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",component="OrderByQueries"} 0 1754481517950
kurrentdb_indexes_secondary_duckdb_memory_bytes{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",component="OverflowStrings"} 0 1754481517950
kurrentdb_indexes_secondary_duckdb_memory_bytes{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",component="ParquetReader"} 0 1754481517950
```

## Disk usage
```
# TYPE kurrentdb_indexes_secondary_duckdb_disk_bytes gauge
# UNIT kurrentdb_indexes_secondary_duckdb_disk_bytes bytes
# HELP kurrentdb_indexes_secondary_duckdb_disk_bytes DuckDB disk space usage
kurrentdb_indexes_secondary_duckdb_disk_bytes{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",type="database"} 9973760 1754481517950
kurrentdb_indexes_secondary_duckdb_disk_bytes{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",type="temporary-files"} 0 1754481517950
```

## Query time
```
# TYPE kurrentdb_indexes_secondary_duckdb_query_seconds histogram
# UNIT kurrentdb_indexes_secondary_duckdb_query_seconds seconds
kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="DefaultIndexQuery",le="1E-06"} 0 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="DefaultIndexQuery",le="1E-05"} 0 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="DefaultIndexQuery",le="0.0001"} 0 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="DefaultIndexQuery",le="0.001"} 0 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="DefaultIndexQuery",le="0.01"} 4 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="DefaultIndexQuery",le="0.1"} 4 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="DefaultIndexQuery",le="1"} 4 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="DefaultIndexQuery",le="10"} 4 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="DefaultIndexQuery",le="+Inf"} 4 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_sum{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="DefaultIndexQuery"} 0.013449984000000002 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_count{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="DefaultIndexQuery"} 4 1754481848971

kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="CategoryIndexQuery",le="1E-06"} 0 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="CategoryIndexQuery",le="1E-05"} 0 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="CategoryIndexQuery",le="0.0001"} 0 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="CategoryIndexQuery",le="0.001"} 0 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="CategoryIndexQuery",le="0.01"} 7 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="CategoryIndexQuery",le="0.1"} 7 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="CategoryIndexQuery",le="1"} 7 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="CategoryIndexQuery",le="10"} 7 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="CategoryIndexQuery",le="+Inf"} 7 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_sum{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="CategoryIndexQuery"} 0.024177599000000004 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_count{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="CategoryIndexQuery"} 7 1754481848971

kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="ReadEventTypeIndexQuery",le="1E-06"} 0 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="ReadEventTypeIndexQuery",le="1E-05"} 0 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="ReadEventTypeIndexQuery",le="0.0001"} 0 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="ReadEventTypeIndexQuery",le="0.001"} 0 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="ReadEventTypeIndexQuery",le="0.01"} 4 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="ReadEventTypeIndexQuery",le="0.1"} 4 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="ReadEventTypeIndexQuery",le="1"} 4 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="ReadEventTypeIndexQuery",le="10"} 4 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_bucket{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="ReadEventTypeIndexQuery",le="+Inf"} 4 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_sum{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="ReadEventTypeIndexQuery"} 0.011719051 1754481848971
kurrentdb_indexes_secondary_duckdb_query_seconds_count{otel_scope_name="KurrentDB.Core",otel_scope_version="1.0.0",name="ReadEventTypeIndexQuery"} 4 1754481848971
```