### PR TITLE
[DB-1655] Add forwards compatibility with new persistent subscription checkpoints

### DIFF
--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -52,7 +52,7 @@
 		<None Include="Resources\es-tile.png">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
-		<None Include="..\..\docs\http-api\swagger.yaml">
+		<None Include="..\..\docs\server\http-api\swagger.yaml">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
 	</ItemGroup>

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionCheckpointReaderTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionCheckpointReaderTests.cs
@@ -1,0 +1,52 @@
+﻿using EventStore.Core.Bus;
+using EventStore.Core.Helpers;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.PersistentSubscription;
+using EventStore.Core.Tests.Helpers.IODispatcherTests;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.PersistentSubscription;
+
+public class PersistentSubscriptionCheckpointReaderTests {
+	[TestCase("SubscriptionCheckpoint")] // old checkpoints
+	[TestCase("$SubscriptionCheckpoint")] // new checkpoints
+	public void can_read_checkpoints(string checkpointEventType) {
+		var bus = new InMemoryBus("persistent subscription test bus");
+
+		bus.Subscribe(new AdHocHandler<Messages.ClientMessage.ReadStreamEventsBackward>(msg => {
+			var lastEventNumber = msg.FromEventNumber + 1;
+			var nextEventNumber = lastEventNumber + 1;
+
+			var events = IODispatcherTestHelpers.CreateResolvedEvent<LogFormat.V2, string>(
+				stream: msg.EventStreamId,
+				eventType: checkpointEventType,
+				data: "\"the checkpoint data\"");
+
+			msg.Envelope.ReplyWith(new Messages.ClientMessage.ReadStreamEventsBackwardCompleted(
+				correlationId: msg.CorrelationId,
+				eventStreamId: msg.EventStreamId,
+				fromEventNumber: msg.FromEventNumber,
+				maxCount: msg.MaxCount,
+				result: Data.ReadStreamResult.Success,
+				events: events,
+				streamMetadata: null,
+				isCachePublic: false,
+				error: "",
+				nextEventNumber: nextEventNumber,
+				lastEventNumber: lastEventNumber,
+				isEndOfStream: false,
+				tfLastCommitPosition: 0));
+		}));
+
+		var ioDispatcher = new IODispatcher(bus, new PublishEnvelope(bus));
+		IODispatcherTestHelpers.SubscribeIODispatcher(ioDispatcher, bus);
+		var sut = new PersistentSubscriptionCheckpointReader(ioDispatcher);
+
+		var loadedState = "";
+		sut.BeginLoadState("subscriptionA", state => {
+			loadedState = state;
+		});
+
+		AssertEx.IsOrBecomesTrue(() => loadedState == "the checkpoint data");
+	}
+}

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionCheckpointReader.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionCheckpointReader.cs
@@ -1,6 +1,5 @@
 #nullable enable
 using System;
-using System.Linq;
 using EventStore.Common.Utils;
 using EventStore.Core.Helpers;
 using EventStore.Core.Messages;
@@ -30,11 +29,12 @@ namespace EventStore.Core.Services.PersistentSubscription {
 
 			public void LoadStateCompleted(ClientMessage.ReadStreamEventsBackwardCompleted msg) {
 				if (msg.Events.Length > 0) {
-					var checkpoint = msg.Events.Where(v => v.Event.EventType == "SubscriptionCheckpoint")
-						.Select(x => x.Event).FirstOrDefault();
-					if (checkpoint != null) {
-						string lastEvent = checkpoint.Data.ParseJson<string>();
-						_onStateLoaded(lastEvent);
+					var checkpoint = msg.Events[0].Event;
+
+					if (checkpoint.EventType is "SubscriptionCheckpoint" or "$SubscriptionCheckpoint") {
+
+						var checkpointJson = checkpoint.Data.ParseJson<string>();
+						_onStateLoaded(checkpointJson);
 						return;
 					}
 				}


### PR DESCRIPTION
Added: Forwards compatibility with new persistent subscription checkpoints

24.10 writes Persistent Subscription Checkpoints prefixed with a $. 23.10.7 will not find these.

This PR makes it so that 23.10.8 will find them.

Prior to this PR, if 23.10 opened a database from 24.10, the checkpoint would not be found and the persistent subscription would start from the beginning, which could be slow.

(cherry picked from commit 6e21abb54be4ead53beaeccee23d82a759ebd1ae)

note: cherry picks not necessary, 24.10+ support the new checkpoint natively