### PR TITLE
[DB-1634]: Fixed EOF flag for unsuccessful read result

### DIFF
--- a/src/KurrentDB.Core/TransactionLog/ReadResults.cs
+++ b/src/KurrentDB.Core/TransactionLog/ReadResults.cs
@@ -54,7 +54,7 @@ public readonly struct RawReadResult {
 
 public readonly struct SeqReadResult {
 	public static SeqReadResult Failure =>
-		default(SeqReadResult) with { RecordPrePosition = -1L, RecordPostPosition = -1L };
+		default(SeqReadResult) with { RecordPrePosition = -1L, RecordPostPosition = -1L, Eof = true };
 
 	public required ILogRecord LogRecord { get; init; }
 


### PR DESCRIPTION
Changed: trivial fix to stay aligned with the behavior prior to the refactoring