### PR TITLE
[DB-1656] Avoid adding windows event logging when running as a windows service

### DIFF
--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Security;
@@ -229,10 +230,9 @@ internal static class Program {
 					if (WindowsServiceHelpers.IsWindowsService()) {
 						await builder
 							.ConfigureServices(services => {
-								// roslyn analyser doesn't recognise the outer IsWindowsService check, check again.
-								if (WindowsServiceHelpers.IsWindowsService()) {
-									services.AddSingleton<IHostLifetime, WindowsServiceLifetime>();
-								}
+								// roslyn analyser doesn't recognise the outer IsWindowsService check
+								Debug.Assert(WindowsServiceHelpers.IsWindowsService());
+								services.AddSingleton<IHostLifetime, WindowsServiceLifetime>();
 							})
 							.Build()
 							.RunAsync(cts.Token);


### PR DESCRIPTION
Removed: Logging to Windows EventLog when running as a Windows Service

When running as a windows service we log to the windows event log, but on shutdown some part of this mechanism in the framework gets shutdown before we are done logging, resulting in scary errors in the regular log about not being able to log.

This also cuts down on the amount of logs being produced.