### PR TITLE
Added rate limiter with two queues to control in-flight requests

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,9 +7,9 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.10" />
     <PackageVersion Include="Bogus" Version="35.6.3" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="DotNext" Version="5.25.0" />
+    <PackageVersion Include="DotNext" Version="5.25.1" />
     <PackageVersion Include="DotNext.IO" Version="5.25.0" />
-    <PackageVersion Include="DotNext.Threading" Version="5.25.0" />
+    <PackageVersion Include="DotNext.Threading" Version="5.25.1" />
     <PackageVersion Include="DotNext.Unsafe" Version="5.25.0" />
     <PackageVersion Include="Ductus.FluentDocker.XUnit" Version="2.10.59" />
     <PackageVersion Include="DuckDB.NET.Data.Full" Version="1.3.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,10 +7,10 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.10" />
     <PackageVersion Include="Bogus" Version="35.6.3" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="DotNext" Version="5.23.0" />
-    <PackageVersion Include="DotNext.IO" Version="5.23.0" />
-    <PackageVersion Include="DotNext.Threading" Version="5.23.0" />
-    <PackageVersion Include="DotNext.Unsafe" Version="5.23.0" />
+    <PackageVersion Include="DotNext" Version="5.25.0" />
+    <PackageVersion Include="DotNext.IO" Version="5.25.0" />
+    <PackageVersion Include="DotNext.Threading" Version="5.25.0" />
+    <PackageVersion Include="DotNext.Unsafe" Version="5.25.0" />
     <PackageVersion Include="Ductus.FluentDocker.XUnit" Version="2.10.59" />
     <PackageVersion Include="DuckDB.NET.Data.Full" Version="1.3.0" />
     <PackageVersion Include="EventStore.Client" Version="22.0.0" />

--- a/src/KurrentDB.Core.XUnit.Tests/RateLimiting/AsyncBoundedRateLimiterTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/RateLimiting/AsyncBoundedRateLimiterTests.cs
@@ -120,7 +120,7 @@ public class AsyncBoundedRateLimiterTests {
 	public static async Task StressTest() {
 		using var rateLimiter = new AsyncBoundedRateLimiter(concurrencyLimit: 3, maxQueueSize: 1);
 
-		// start 4 competing tasks in parallel
+		// start 4 competing tasks in parallel, which is larger than concurrency limit
 		await Task.WhenAll(
 			Task.Run(AcquireReleaseAsync),
 			Task.Run(AcquireReleaseAsync),
@@ -131,7 +131,7 @@ public class AsyncBoundedRateLimiterTests {
 
 		async Task AcquireReleaseAsync() {
 			for (var i = 0; i < 100; i++) {
-				await rateLimiter.AcquireAsync(prioritized: false);
+				Assert.True(await rateLimiter.AcquireAsync(prioritized: false));
 				await Task.Delay(10);
 				rateLimiter.Release();
 			}

--- a/src/KurrentDB.Core.XUnit.Tests/RateLimiting/AsyncBoundedRateLimiterTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/RateLimiting/AsyncBoundedRateLimiterTests.cs
@@ -104,4 +104,15 @@ public class AsyncBoundedRateLimiterTests {
 		rateLimiter.Release();
 		Assert.True(await task2);
 	}
+
+	[Fact]
+	public static async Task AcquireInParallel() {
+		using var rateLimiter = new AsyncBoundedRateLimiter(concurrencyLimit: 3, maxQueueSize: 0);
+		await Task.WhenAll(Task.Run(AcquireAsync), Task.Run(AcquireAsync), Task.Run(AcquireAsync));
+		Assert.False(await rateLimiter.AcquireAsync(prioritized: false));
+
+		async Task AcquireAsync() {
+			Assert.True(await rateLimiter.AcquireAsync(prioritized: false));
+		}
+	}
 }

--- a/src/KurrentDB.Core.XUnit.Tests/RateLimiting/AsyncBoundedRateLimiterTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/RateLimiting/AsyncBoundedRateLimiterTests.cs
@@ -137,4 +137,16 @@ public class AsyncBoundedRateLimiterTests {
 			}
 		}
 	}
+
+	[Fact]
+	public static async Task TimeoutWhenAcquiringLease() {
+		using var rateLimiter = new AsyncBoundedRateLimiter(concurrencyLimit: 1, maxQueueSize: 1);
+		Assert.True(await rateLimiter.AcquireAsync(prioritized: false, TimeSpan.Zero));
+
+		await Assert.ThrowsAsync<TimeoutException>(async () =>
+			await rateLimiter.AcquireAsync(prioritized: false, TimeSpan.Zero));
+
+		await Assert.ThrowsAsync<TimeoutException>(async () =>
+			await rateLimiter.AcquireAsync(prioritized: false, TimeSpan.FromMilliseconds(1)));
+	}
 }

--- a/src/KurrentDB.Core.XUnit.Tests/RateLimiting/AsyncBoundedRateLimiterTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/RateLimiting/AsyncBoundedRateLimiterTests.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Threading.Tasks;
+using DotNext;
+using KurrentDB.Core.RateLimiting;
+using Xunit;
+
+namespace KurrentDB.Core.XUnit.Tests.RateLimiting;
+
+public class AsyncBoundedRateLimiterTests {
+	[Fact]
+	public static async Task AcquireRelease() {
+		using var rateLimiter = new AsyncBoundedRateLimiter(concurrencyLimit: 1, maxQueueSize: 2);
+		var task = rateLimiter.AcquireAsync(prioritized: false).AsTask();
+
+		// the lease acquired synchronously
+		Assert.True(task.IsCompletedSuccessfully);
+		Assert.True(await task);
+
+		// suspended caller
+		task = rateLimiter.AcquireAsync(prioritized: false).AsTask();
+		Assert.False(task.IsCompleted);
+
+		// resume the suspended caller
+		rateLimiter.Release();
+		Assert.True(await task);
+	}
+
+	[Fact]
+	public static async Task DisposeRateLimiter() {
+		var rateLimiter = new AsyncBoundedRateLimiter(concurrencyLimit: 1, maxQueueSize: 2);
+		var task = rateLimiter.AcquireAsync(prioritized: false).AsTask();
+
+		// the lease acquired synchronously
+		Assert.True(task.IsCompletedSuccessfully);
+		Assert.True(await task);
+
+		// suspended caller
+		task = rateLimiter.AcquireAsync(prioritized: false).AsTask();
+		Assert.False(task.IsCompleted);
+
+		// resume the suspended caller with ObjectDisposedException
+		rateLimiter.Dispose();
+
+		await Assert.ThrowsAsync<ObjectDisposedException>(Func.Constant(task));
+
+		// Ensure that call to Release() doesn't throw
+		rateLimiter.Release();
+	}
+
+	[Fact]
+	public static async Task PrioritizedQueueResumedFirst() {
+		using var rateLimiter = new AsyncBoundedRateLimiter(concurrencyLimit: 1, maxQueueSize: 2);
+		Assert.True(await rateLimiter.AcquireAsync(prioritized: false));
+
+		var task1 = rateLimiter.AcquireAsync(prioritized: false).AsTask();
+		Assert.False(task1.IsCompleted);
+
+		var task2 = rateLimiter.AcquireAsync(prioritized: false).AsTask();
+		Assert.False(task2.IsCompleted);
+
+		var prioritizedTask = rateLimiter.AcquireAsync(prioritized: true).AsTask();
+		Assert.False(prioritizedTask.IsCompleted);
+
+		// resume the prioritized caller
+		rateLimiter.Release();
+		Assert.True(await prioritizedTask);
+
+		Assert.False(task1.IsCompleted);
+		Assert.False(task2.IsCompleted);
+	}
+
+	[Fact]
+	public static async Task ConcurrencyLimitReached() {
+		using var rateLimiter = new AsyncBoundedRateLimiter(concurrencyLimit: 1, maxQueueSize: 2);
+		Assert.True(await rateLimiter.AcquireAsync(prioritized: false));
+
+		var task1 = rateLimiter.AcquireAsync(prioritized: false).AsTask();
+		Assert.False(task1.IsCompleted);
+
+		var task2 = rateLimiter.AcquireAsync(prioritized: false).AsTask();
+		Assert.False(task2.IsCompleted);
+
+		Assert.False(await rateLimiter.AcquireAsync(prioritized: false));
+	}
+
+	[Fact]
+	public static async Task QueueOrderPreserved() {
+		using var rateLimiter = new AsyncBoundedRateLimiter(concurrencyLimit: 1, maxQueueSize: 2);
+		Assert.True(await rateLimiter.AcquireAsync(prioritized: false));
+
+		var task1 = rateLimiter.AcquireAsync(prioritized: false).AsTask();
+		Assert.False(task1.IsCompleted);
+
+		var task2 = rateLimiter.AcquireAsync(prioritized: false).AsTask();
+		Assert.False(task2.IsCompleted);
+
+		rateLimiter.Release();
+		Assert.True(await task1);
+		Assert.False(task2.IsCompleted);
+
+		rateLimiter.Release();
+		Assert.True(await task2);
+	}
+}

--- a/src/KurrentDB.Core.XUnit.Tests/RateLimiting/AsyncBoundedRateLimiterTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/RateLimiting/AsyncBoundedRateLimiterTests.cs
@@ -127,7 +127,7 @@ public class AsyncBoundedRateLimiterTests {
 			Task.Run(AcquireReleaseAsync),
 			Task.Run(AcquireReleaseAsync));
 
-		Assert.Equal(3, rateLimiter.LeaseCount);
+		Assert.Equal(3, rateLimiter.RemainingLeases);
 
 		async Task AcquireReleaseAsync() {
 			for (var i = 0; i < 100; i++) {

--- a/src/KurrentDB.Core.XUnit.Tests/RateLimiting/AsyncBoundedRateLimiterTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/RateLimiting/AsyncBoundedRateLimiterTests.cs
@@ -143,10 +143,7 @@ public class AsyncBoundedRateLimiterTests {
 		using var rateLimiter = new AsyncBoundedRateLimiter(concurrencyLimit: 1, maxQueueSize: 1);
 		Assert.True(await rateLimiter.AcquireAsync(prioritized: false, TimeSpan.Zero));
 
-		await Assert.ThrowsAsync<TimeoutException>(async () =>
-			await rateLimiter.AcquireAsync(prioritized: false, TimeSpan.Zero));
-
-		await Assert.ThrowsAsync<TimeoutException>(async () =>
-			await rateLimiter.AcquireAsync(prioritized: false, TimeSpan.FromMilliseconds(1)));
+		Assert.False(await rateLimiter.AcquireAsync(prioritized: false, TimeSpan.Zero));
+		Assert.False(await rateLimiter.AcquireAsync(prioritized: false, TimeSpan.FromMilliseconds(1)));
 	}
 }

--- a/src/KurrentDB.Core/ClusterVNode.cs
+++ b/src/KurrentDB.Core/ClusterVNode.cs
@@ -766,8 +766,7 @@ public class ClusterVNode<TStreamId> :
 
 		// Storage Reader
 		var storageReader = new StorageReaderService<TStreamId>(_mainQueue, _mainBus, readIndex,
-			logFormat.SystemStreams, Db.Config.WriterCheckpoint.AsReadOnly(), virtualStreamReader, _queueStatsManager,
-			trackers.QueueTrackers);
+			logFormat.SystemStreams, Db.Config.WriterCheckpoint.AsReadOnly(), virtualStreamReader);
 
 		_mainBus.Subscribe<SystemMessage.SystemInit>(storageReader);
 		_mainBus.Subscribe<SystemMessage.BecomeShuttingDown>(storageReader);

--- a/src/KurrentDB.Core/RateLimiting/AsyncBoundedRateLimiter.Pool.cs
+++ b/src/KurrentDB.Core/RateLimiting/AsyncBoundedRateLimiter.Pool.cs
@@ -14,11 +14,11 @@ partial class AsyncBoundedRateLimiter {
 
 	private void BackToPool(WaitNode node) {
 		lock (_syncRoot) {
-			BackToPoolUnsafe(node);
+			BackToPoolCore(node);
 		}
 	}
 
-	private void BackToPoolUnsafe(WaitNode node) {
+	private void BackToPoolCore(WaitNode node) {
 		Debug.Assert(Monitor.IsEntered(_syncRoot));
 		Debug.Assert(node.Status is ManualResetCompletionSourceStatus.WaitForActivation);
 		Debug.Assert(node is { Next: null, Previous: null });

--- a/src/KurrentDB.Core/RateLimiting/AsyncBoundedRateLimiter.Pool.cs
+++ b/src/KurrentDB.Core/RateLimiting/AsyncBoundedRateLimiter.Pool.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Diagnostics;
+using System.Threading;
+using DotNext.Threading.Tasks;
+
+namespace KurrentDB.Core.RateLimiting;
+
+partial class AsyncBoundedRateLimiter {
+	private readonly int _maxPoolSize;
+	private int _poolSize;
+	private WaitNode _poolHead;
+
+	private void BackToPool(WaitNode node) {
+		Debug.Assert(Monitor.IsEntered(_syncRoot));
+		Debug.Assert(node.Status is ManualResetCompletionSourceStatus.WaitForActivation);
+		Debug.Assert(node is { Next: null, Previous: null });
+
+		// Skip the node if the pool is full. The node can be reclaimed by the GC.
+		if (_poolSize < _maxPoolSize) {
+			node.Next = _poolHead;
+			_poolHead = node;
+			_poolSize++;
+		}
+	}
+
+	private WaitNode RentNode() {
+		Debug.Assert(Monitor.IsEntered(_syncRoot));
+
+		WaitNode node;
+		if (_poolHead is null) {
+			node = new();
+		} else {
+			node = _poolHead;
+			_poolHead = node.Next;
+			node.Next = null;
+			_poolSize--;
+		}
+
+		Debug.Assert(node is { Next: null, Previous: null });
+		return node;
+	}
+}

--- a/src/KurrentDB.Core/RateLimiting/AsyncBoundedRateLimiter.Pool.cs
+++ b/src/KurrentDB.Core/RateLimiting/AsyncBoundedRateLimiter.Pool.cs
@@ -13,6 +13,12 @@ partial class AsyncBoundedRateLimiter {
 	private WaitNode _poolHead;
 
 	private void BackToPool(WaitNode node) {
+		lock (_syncRoot) {
+			BackToPoolUnsafe(node);
+		}
+	}
+
+	private void BackToPoolUnsafe(WaitNode node) {
 		Debug.Assert(Monitor.IsEntered(_syncRoot));
 		Debug.Assert(node.Status is ManualResetCompletionSourceStatus.WaitForActivation);
 		Debug.Assert(node is { Next: null, Previous: null });

--- a/src/KurrentDB.Core/RateLimiting/AsyncBoundedRateLimiter.Queue.cs
+++ b/src/KurrentDB.Core/RateLimiting/AsyncBoundedRateLimiter.Queue.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using DotNext;
+
+namespace KurrentDB.Core.RateLimiting;
+
+partial class AsyncBoundedRateLimiter {
+	private readonly int _maxQueueSize;
+	private WaitQueue _incomingQueue, _inFlightQueue;
+
+	private ISupplier<TimeSpan, CancellationToken, ValueTask<bool>> EnqueueNode(bool prioritized) {
+		Debug.Assert(Monitor.IsEntered(_syncRoot));
+
+		ref var queue = ref Unsafe.NullRef<WaitQueue>();
+		if (prioritized) {
+			queue = ref _inFlightQueue;
+		} else if (_incomingQueue.Count >= _maxQueueSize) {
+			return RejectedTaskFactory.Instance;
+		} else {
+			queue = ref _incomingQueue;
+		}
+
+		var node = RentNode();
+		node.Initialize(this, prioritized);
+		queue.Add(node);
+		return node;
+	}
+
+	// should be called only when the source of ValueTask<bool> is consumed
+	private void ReturnNode(WaitNode node) {
+		if (node.NeedsRemoval) {
+			RemoveNode(node);
+		}
+
+		// reset the node for further reuse and return it back to the pool
+		if (node.TryReset(out _) && !IsDisposingOrDisposed) {
+			BackToPool(node);
+		}
+	}
+
+	private void RemoveNode(WaitNode node) {
+		ref var queue = ref node.IsPrioritized
+			? ref _inFlightQueue
+			: ref _incomingQueue;
+
+		lock (_syncRoot) {
+			queue.Remove(node);
+		}
+	}
+
+	[StructLayout(LayoutKind.Auto)]
+	private struct WaitQueue {
+		private WaitNodeList _list;
+		private int _count;
+
+		public void Add(WaitNode node) {
+			_list.Add(node);
+			_count++;
+		}
+
+		public readonly int Count => _count;
+
+		public void Remove(WaitNode node) {
+			_list.Remove(node);
+			_count--;
+
+			Debug.Assert(_count >= 0);
+		}
+
+		public void Clear() => _list = default;
+
+		public readonly void NotifyObjectDisposed(ObjectDisposedException e) {
+			for (WaitNode current = _list.First; current is not null; current = current.Next) {
+				current.TrySetException(e);
+			}
+		}
+
+		public bool SignalFirst(out WaitNode suspendedCaller) {
+			for (WaitNode current = _list.First, next; current is not null; current = next) {
+				next = current.Next;
+
+				// Possibly, the node is already in signaled state (triggered by cancellation concurrently).
+				// In that case, it should not be considered as alive suspended caller.
+				// Skip it and try to resume the next node.
+				if (!current.TrySignal(out var resumable))
+					continue;
+
+				Remove(current);
+				suspendedCaller = resumable ? current : null;
+				return true;
+			}
+
+			suspendedCaller = null;
+			return false;
+		}
+	}
+}

--- a/src/KurrentDB.Core/RateLimiting/AsyncBoundedRateLimiter.TaskFactory.cs
+++ b/src/KurrentDB.Core/RateLimiting/AsyncBoundedRateLimiter.TaskFactory.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DotNext;
+using DotNext.Patterns;
+
+namespace KurrentDB.Core.RateLimiting;
+
+partial class AsyncBoundedRateLimiter {
+	// produces the canceled task with the associated canceled token
+	private sealed class CanceledTaskFactory :
+		ISupplier<TimeSpan, CancellationToken, ValueTask<bool>>,
+		ISingleton<CanceledTaskFactory> {
+		public static CanceledTaskFactory Instance { get; } = new();
+
+		private CanceledTaskFactory() {
+		}
+
+		ValueTask<bool> ISupplier<TimeSpan, CancellationToken, ValueTask<bool>>.Invoke(TimeSpan timeout,
+			CancellationToken token)
+			=> ValueTask.FromCanceled<bool>(token);
+	}
+
+	// produces synchronously and successfully completed task with 'true' result
+	private sealed class CompletedTaskFactory :
+		ISupplier<TimeSpan, CancellationToken, ValueTask<bool>>,
+		ISingleton<CompletedTaskFactory> {
+		public static CompletedTaskFactory Instance { get; } = new();
+
+		private CompletedTaskFactory() {
+		}
+
+		ValueTask<bool> ISupplier<TimeSpan, CancellationToken, ValueTask<bool>>.Invoke(TimeSpan timeout,
+			CancellationToken token)
+			=> ValueTask.FromResult(true);
+	}
+
+	// produces synchronously and successfully completed task with 'false' result
+	private sealed class RejectedTaskFactory :
+		ISupplier<TimeSpan, CancellationToken, ValueTask<bool>>,
+		ISingleton<RejectedTaskFactory> {
+		public static RejectedTaskFactory Instance { get; } = new();
+
+		private RejectedTaskFactory() {
+		}
+
+		ValueTask<bool> ISupplier<TimeSpan, CancellationToken, ValueTask<bool>>.Invoke(TimeSpan timeout,
+			CancellationToken token)
+			=> ValueTask.FromResult(false);
+	}
+
+	// produces synchronously completed task with ObjectDisposedException
+	private sealed class DisposedTaskFactory :
+		ISupplier<TimeSpan, CancellationToken, ValueTask<bool>>,
+		ISingleton<DisposedTaskFactory> {
+		public static DisposedTaskFactory Instance { get; } = new();
+
+		private DisposedTaskFactory() {
+		}
+
+		ValueTask<bool> ISupplier<TimeSpan, CancellationToken, ValueTask<bool>>.Invoke(TimeSpan timeout,
+			CancellationToken token)
+			=> ValueTask.FromException<bool>(new ObjectDisposedException(nameof(AsyncBoundedRateLimiter)));
+	}
+}

--- a/src/KurrentDB.Core/RateLimiting/AsyncBoundedRateLimiter.WaitNode.cs
+++ b/src/KurrentDB.Core/RateLimiting/AsyncBoundedRateLimiter.WaitNode.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using DotNext;
 using DotNext.Threading.Tasks;
 
 namespace KurrentDB.Core.RateLimiting;
@@ -24,7 +25,7 @@ partial class AsyncBoundedRateLimiter {
 		public WaitNode Previous => _previous;
 
 		/// <summary>
-		/// <see cref="Sentinel"/> object is used to fill <see cref="ManualResetCompletionSource.CompletionData"/>
+		/// <see cref="AsyncBoundedRateLimiter.Sentinel"/> object is used to fill <see cref="ManualResetCompletionSource.CompletionData"/>
 		/// when we need to distinguish two completion reasons:
 		/// 1. Completed by cancellation token. We need to remove the node manually from the queue
 		/// 2. Completed normally by signaling thread. The node is removed by the thread.
@@ -45,6 +46,8 @@ partial class AsyncBoundedRateLimiter {
 		}
 
 		protected override void AfterConsumed() => _owner?.ReturnNode(this);
+
+		protected override Result<bool> OnTimeout() => false;
 
 		public void Append(WaitNode node) {
 			Debug.Assert(node.Next is null);

--- a/src/KurrentDB.Core/RateLimiting/AsyncBoundedRateLimiter.WaitNode.cs
+++ b/src/KurrentDB.Core/RateLimiting/AsyncBoundedRateLimiter.WaitNode.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using DotNext.Threading.Tasks;
+
+namespace KurrentDB.Core.RateLimiting;
+
+partial class AsyncBoundedRateLimiter {
+	private static readonly object Sentinel = new();
+
+	/// <summary>
+	/// Represents the suspended caller.
+	/// </summary>
+	private sealed class WaitNode: ValueTaskCompletionSource<bool> {
+		private AsyncBoundedRateLimiter _owner;
+		private bool _prioritized;
+		private WaitNode _previous;
+
+		// Reused by the queue and the pool
+		public WaitNode Next;
+
+		public WaitNode Previous => _previous;
+
+		/// <summary>
+		/// <see cref="Sentinel"/> object is used to fill <see cref="ManualResetCompletionSource.CompletionData"/>
+		/// when we need to distinguish two completion reasons:
+		/// 1. Completed by cancellation token. We need to remove the node manually from the queue
+		/// 2. Completed normally by signaling thread. The node is removed by the thread.
+		/// </summary>
+		public bool NeedsRemoval => CompletionData is null;
+
+		public void Initialize(AsyncBoundedRateLimiter owner, bool prioritized) {
+			_prioritized = prioritized;
+			_owner = owner;
+		}
+
+		public bool IsPrioritized => _prioritized;
+
+		protected override void CleanUp() {
+			_prioritized = false;
+			_owner = null;
+			base.CleanUp();
+		}
+
+		protected override void AfterConsumed() => _owner?.ReturnNode(this);
+
+		public void Append(WaitNode node) {
+			Debug.Assert(node.Next is null);
+
+			Next = node;
+			node._previous = this;
+		}
+
+		public void Detach() {
+			if (_previous is not null)
+				_previous.Next = Next;
+
+			if (Next is not null)
+				Next._previous = _previous;
+
+			Next = _previous = null;
+		}
+
+		// resumable flag indicates that the node has the registered consumer, e.g. suspended caller
+		// that awaits on ValueTask<bool> produced by this source. If there is a consumer,
+		// we can resume it later out of the main lock by using NotifyConsumer() method
+		public bool TrySignal(out bool resumable)
+			=> TrySetResult(completionData: Sentinel, completionToken: null, result: true, out resumable);
+
+		public new void NotifyConsumer() => base.NotifyConsumer();
+	}
+
+	[StructLayout(LayoutKind.Auto)]
+	private struct WaitNodeList {
+		private WaitNode _first, _last;
+
+		public readonly WaitNode First => _first;
+
+		public void Add(WaitNode node) {
+			if (_first is null) {
+				_first = _last = node;
+			} else {
+				Debug.Assert(_last is not null);
+
+				_last.Append(node);
+				_last = node;
+			}
+		}
+
+		public void Remove(WaitNode node) {
+			if (ReferenceEquals(_first, node)) {
+				_first = node.Next;
+			}
+
+			if (ReferenceEquals(_last, node)) {
+				_last = node.Previous;
+			}
+
+			node.Detach();
+		}
+	}
+}

--- a/src/KurrentDB.Core/RateLimiting/AsyncBoundedRateLimiter.WaitNode.cs
+++ b/src/KurrentDB.Core/RateLimiting/AsyncBoundedRateLimiter.WaitNode.cs
@@ -69,7 +69,12 @@ partial class AsyncBoundedRateLimiter {
 		public bool TrySignal(out bool resumable)
 			=> TrySetResult(completionData: Sentinel, completionToken: null, result: true, out resumable);
 
-		public new void NotifyConsumer() => base.NotifyConsumer();
+		public new void NotifyConsumer() {
+			Debug.Assert(!NeedsRemoval);
+			Debug.Assert(Status is ManualResetCompletionSourceStatus.WaitForConsumption);
+
+			base.NotifyConsumer();
+		}
 	}
 
 	[StructLayout(LayoutKind.Auto)]

--- a/src/KurrentDB.Core/RateLimiting/AsyncBoundedRateLimiter.cs
+++ b/src/KurrentDB.Core/RateLimiting/AsyncBoundedRateLimiter.cs
@@ -76,6 +76,8 @@ public sealed partial class AsyncBoundedRateLimiter : Disposable {
 		suspendedCaller?.NotifyConsumer();
 	}
 
+	public int LeaseCount => Volatile.Read(in _leasesAvailable);
+
 	protected override void Dispose(bool disposing) {
 		if (disposing) {
 			NotifyObjectDisposed();

--- a/src/KurrentDB.Core/RateLimiting/AsyncBoundedRateLimiter.cs
+++ b/src/KurrentDB.Core/RateLimiting/AsyncBoundedRateLimiter.cs
@@ -14,7 +14,7 @@ public sealed partial class AsyncBoundedRateLimiter : Disposable {
 
 	public AsyncBoundedRateLimiter(int concurrencyLimit, int maxQueueSize) {
 		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(concurrencyLimit);
-		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxQueueSize);
+		ArgumentOutOfRangeException.ThrowIfNegative(maxQueueSize);
 
 		_leasesAvailable = concurrencyLimit;
 		_maxQueueSize = maxQueueSize;

--- a/src/KurrentDB.Core/RateLimiting/AsyncBoundedRateLimiter.cs
+++ b/src/KurrentDB.Core/RateLimiting/AsyncBoundedRateLimiter.cs
@@ -37,7 +37,7 @@ public sealed partial class AsyncBoundedRateLimiter : Disposable {
 	/// <see langword="false"/> if the rate limit is reached and <paramref name="prioritized"/>
 	/// is <see langword="false"/>.
 	/// </returns>
-	public ValueTask<bool> AcquireAsync(bool prioritized, CancellationToken token) {
+	public ValueTask<bool> AcquireAsync(bool prioritized, CancellationToken token = default) {
 		ISupplier<TimeSpan, CancellationToken, ValueTask<bool>> factory;
 		lock (_syncRoot) {
 			if (IsDisposingOrDisposed) {

--- a/src/KurrentDB.Core/RateLimiting/AsyncBoundedRateLimiter.cs
+++ b/src/KurrentDB.Core/RateLimiting/AsyncBoundedRateLimiter.cs
@@ -76,7 +76,10 @@ public sealed partial class AsyncBoundedRateLimiter : Disposable {
 		suspendedCaller?.NotifyConsumer();
 	}
 
-	public int LeaseCount => Volatile.Read(in _leasesAvailable);
+	/// <summary>
+	/// Gets the approximate number of available leases.
+	/// </summary>
+	public int RemainingLeases => Volatile.Read(in _leasesAvailable);
 
 	protected override void Dispose(bool disposing) {
 		if (disposing) {

--- a/src/KurrentDB.Core/RateLimiting/AsyncBoundedRateLimiter.cs
+++ b/src/KurrentDB.Core/RateLimiting/AsyncBoundedRateLimiter.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DotNext;
+
+namespace KurrentDB.Core.RateLimiting;
+
+public sealed partial class AsyncBoundedRateLimiter : Disposable {
+	private readonly object _syncRoot;
+	private int _leasesAvailable;
+
+	public AsyncBoundedRateLimiter(int concurrencyLimit, int maxQueueSize) {
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(concurrencyLimit);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxQueueSize);
+
+		_leasesAvailable = concurrencyLimit;
+		_maxQueueSize = maxQueueSize;
+
+		// we need to cover cached wait nodes for incoming queue (which is bounded)
+		// and in-flight queue (which is unbounded). But we assume that the size
+		// of the in-flight queue should not be too high, so keep maxQueueSize / 2 of nodes
+		// for the in-flight queue.
+		_maxPoolSize = int.CreateSaturating(maxQueueSize / 2 * 3L);
+		_syncRoot = new();
+	}
+
+	/// <summary>
+	/// Acquires the lease.
+	/// </summary>
+	/// <param name="prioritized"></param>
+	/// <param name="token"></param>
+	/// <returns>
+	/// <see langword="true"/> if the lease is acquired successfully;
+	/// <see langword="false"/> if the rate limit is reached and <paramref name="prioritized"/>
+	/// is <see langword="false"/>.
+	/// </returns>
+	public ValueTask<bool> AcquireAsync(bool prioritized, CancellationToken token) {
+		ISupplier<TimeSpan, CancellationToken, ValueTask<bool>> factory;
+		lock (_syncRoot) {
+			if (IsDisposingOrDisposed) {
+				// produce the task with ObjectDisposedException
+				factory = DisposedTaskFactory.Instance;
+			} else if (_leasesAvailable > 0) {
+				// leases are available, complete synchronously
+				_leasesAvailable--;
+				factory = CompletedTaskFactory.Instance;
+			} else if (token.IsCancellationRequested) {
+				// canceled, complete synchronously
+				factory = CanceledTaskFactory.Instance;
+			} else {
+				// slow path - create a node that implements IValueTaskSource
+				factory = EnqueueNode(prioritized);
+			}
+		}
+
+		// activate the completion source out of the lock to reduce the lock contention
+		return factory.Invoke(Timeout.InfiniteTimeSpan, token);
+	}
+
+	/// <summary>
+	/// Releases the lease previously acquired with <see cref="AcquireAsync"/>.
+	/// </summary>
+	public void Release() {
+		WaitNode suspendedCaller;
+		lock (_syncRoot) {
+			// do not throw if Dispose() is in progress
+			if (!_inFlightQueue.SignalFirst(out suspendedCaller) && !_incomingQueue.SignalFirst(out suspendedCaller)) {
+				// Both queues are empty, just increase the number of available leases
+				_leasesAvailable++;
+			}
+		}
+
+		suspendedCaller?.NotifyConsumer();
+	}
+
+	protected override void Dispose(bool disposing) {
+		if (disposing) {
+			NotifyObjectDisposed();
+		}
+
+		base.Dispose(disposing);
+	}
+
+	private void NotifyObjectDisposed() {
+		var e = CreateException();
+		lock (_syncRoot) {
+			_incomingQueue.NotifyObjectDisposed(e);
+			_incomingQueue.Clear();
+
+			_inFlightQueue.NotifyObjectDisposed(e);
+			_inFlightQueue.Clear();
+		}
+	}
+}

--- a/src/KurrentDB.Core/Services/Storage/StorageReaderService.cs
+++ b/src/KurrentDB.Core/Services/Storage/StorageReaderService.cs
@@ -9,7 +9,6 @@ using KurrentDB.Common.Utils;
 using KurrentDB.Core.Bus;
 using KurrentDB.Core.LogAbstraction;
 using KurrentDB.Core.Messages;
-using KurrentDB.Core.Metrics;
 using KurrentDB.Core.Services.Storage.InMemory;
 using KurrentDB.Core.Services.Storage.ReaderIndex;
 using KurrentDB.Core.TransactionLog.Checkpoint;
@@ -36,9 +35,7 @@ public class StorageReaderService<TStreamId> : StorageReaderService, IHandle<Sys
 		IReadIndex<TStreamId> readIndex,
 		ISystemStreamLookup<TStreamId> systemStreams,
 		IReadOnlyCheckpoint writerCheckpoint,
-		IVirtualStreamReader inMemReader,
-		QueueStatsManager queueStatsManager,
-		QueueTrackers trackers) {
+		IVirtualStreamReader inMemReader) {
 		Ensure.NotNull(subscriber);
 		Ensure.NotNull(systemStreams);
 		Ensure.NotNull(writerCheckpoint);


### PR DESCRIPTION
Changed: Added proper way to handle multiple cancellation tokens without the allocation of CTS for every linkage. Added rate limiter.