### PR TITLE
[DB-1648]: Handle multiple CTs without the allocation

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,10 +7,10 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.10" />
     <PackageVersion Include="Bogus" Version="35.6.3" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="DotNext" Version="5.23.0" />
-    <PackageVersion Include="DotNext.IO" Version="5.23.0" />
-    <PackageVersion Include="DotNext.Threading" Version="5.23.0" />
-    <PackageVersion Include="DotNext.Unsafe" Version="5.23.0" />
+    <PackageVersion Include="DotNext" Version="5.25.1" />
+    <PackageVersion Include="DotNext.IO" Version="5.25.0" />
+    <PackageVersion Include="DotNext.Threading" Version="5.25.1" />
+    <PackageVersion Include="DotNext.Unsafe" Version="5.25.0" />
     <PackageVersion Include="Ductus.FluentDocker.XUnit" Version="2.10.59" />
     <PackageVersion Include="DuckDB.NET.Data.Full" Version="1.3.0" />
     <PackageVersion Include="EventStore.Client" Version="22.0.0" />


### PR DESCRIPTION
Changed: Added proper way to handle multiple cancellation tokens without the allocation of CTS for every linkage