### PR TITLE
Clarify in settings description that NodePriority isn't a guarantee of the election outcome (#5245)

### DIFF
--- a/docs/server/configuration/cluster.md
+++ b/docs/server/configuration/cluster.md
@@ -216,7 +216,7 @@ The replica node needs to have the cluster gossip DNS or seed configured. For th
 
 ### Node priority
 
-You can control which clones the cluster promotes with the `NodePriority` setting. The default value is `0`, and the cluster is more likely to promote nodes with higher values.
+You can influence which clones the cluster promotes with the `NodePriority` setting. The default value is `0`, and the cluster is more likely to promote nodes with higher values.
 
 | Format               | Syntax                    |
 |:---------------------|:--------------------------|

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
@@ -286,7 +286,7 @@ public partial record ClusterVNodeOptions {
 		[Description("The number of nodes in the cluster.")]
 		public int ClusterSize { get; init; } = 1;
 
-		[Description("The node priority used during leader election.")]
+		[Description("The node priority used during leader election. This is a hint to the election algorithm but does not guarantee the outcome of the election.")]
 		public int NodePriority { get; init; } = 0;
 
 		[Description("Whether to use DNS lookup to discover other cluster nodes.")]


### PR DESCRIPTION
Cherry pick from https://github.com/kurrent-io/KurrentDB/pull/5245