### PR TITLE
[DB-1606] Reflect license renewals without restarting the node

### DIFF
--- a/src/KurrentDB.Licensing.Tests/Keygen/KeygenLifecycleServiceTests.cs
+++ b/src/KurrentDB.Licensing.Tests/Keygen/KeygenLifecycleServiceTests.cs
@@ -18,6 +18,13 @@ public sealed class KeygenLifecycleServiceTests : IDisposable {
 
 	public KeygenLifecycleServiceTests() {
 		_licenses = Channel.CreateUnbounded<LicenseInfo>();
+		_keygen = new KeygenSimulator();
+		// High heartbeat count so that most tests exercise the steady-state heartbeat behaviour
+		// without triggering revalidation. Periodic revalidation is covered by its own test.
+		_sut = CreateSut(heartbeatsPerRevalidation: int.MaxValue);
+	}
+
+	KeygenLifecycleService CreateSut(int heartbeatsPerRevalidation) {
 		var options = new KeygenClientOptions {
 			Licensing = new() {
 				LicenseKey = "the-key",
@@ -25,8 +32,7 @@ public sealed class KeygenLifecycleServiceTests : IDisposable {
 			ReadOnlyReplica = true,
 			Archiver = true,
 		};
-		_keygen = new KeygenSimulator();
-		_sut = new KeygenLifecycleService(
+		var sut = new KeygenLifecycleService(
 			new KeygenClient(
 				options,
 				new RestClient(
@@ -34,9 +40,11 @@ public sealed class KeygenLifecycleServiceTests : IDisposable {
 						ConfigureMessageHandler = _ => _keygen,
 					})),
 			new Fingerprint(port: null),
+			heartbeatsPerRevalidation: heartbeatsPerRevalidation,
 			revalidationDelay: TimeSpan.FromMilliseconds(10));
 
-		_sut.Licenses.Subscribe(async x => await _licenses.Writer.WriteAsync(x));
+		sut.Licenses.Subscribe(async x => await _licenses.Writer.WriteAsync(x));
+		return sut;
 	}
 
 	public void Dispose() {
@@ -236,5 +244,53 @@ public sealed class KeygenLifecycleServiceTests : IDisposable {
 		await _keygen.ReplyWith_Error("LICENSE_SUSPENDED");
 
 		await _keygen.ShouldReceive_ValidationRequest();
+	}
+
+	[Fact]
+	public async Task revalidates_to_pick_up_a_renewed_expiry() {
+		var originalExpiry = new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero);
+		var renewedExpiry = new DateTimeOffset(2031, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+		// revalidate after a single heartbeat so the test doesn't depend on timing
+		using var sut = CreateSut(heartbeatsPerRevalidation: 1);
+		await sut.StartAsync(CancellationToken.None);
+
+		// initial validation reports the original expiry
+		await _keygen.ShouldReceive_ValidationRequest();
+		await _keygen.ReplyWith_ValidationResponse("VALID", expiry: originalExpiry);
+		await _keygen.ShouldReceive_EntitlementRequest();
+		await _keygen.ReplyWith_Entitlements("A_SPECIAL_ENTITLEMENT");
+
+		await AssertNextLicense(new LicenseInfo.Conclusive(
+			LicenseId: "the-license-id",
+			Name: "the name of the license",
+			Valid: true,
+			Trial: false,
+			Warning: false,
+			Detail: "valid",
+			Expiry: originalExpiry,
+			Entitlements: ["A_SPECIAL_ENTITLEMENT"]));
+
+		// after one heartbeat the service revalidates from the top
+		await _keygen.ShouldReceive_GetMachine();
+		await _keygen.ReplyWith_Machine();
+		await _keygen.ShouldReceive_Heartbeat();
+		await _keygen.ReplyWith_HeartbeatResponse();
+
+		// revalidation reports the renewed expiry
+		await _keygen.ShouldReceive_ValidationRequest();
+		await _keygen.ReplyWith_ValidationResponse("VALID", expiry: renewedExpiry);
+		await _keygen.ShouldReceive_EntitlementRequest();
+		await _keygen.ReplyWith_Entitlements("A_SPECIAL_ENTITLEMENT");
+
+		await AssertNextLicense(new LicenseInfo.Conclusive(
+			LicenseId: "the-license-id",
+			Name: "the name of the license",
+			Valid: true,
+			Trial: false,
+			Warning: false,
+			Detail: "valid",
+			Expiry: renewedExpiry,
+			Entitlements: ["A_SPECIAL_ENTITLEMENT"]));
 	}
 }

--- a/src/KurrentDB.Licensing.Tests/Keygen/KeygenSimulator.Replies.cs
+++ b/src/KurrentDB.Licensing.Tests/Keygen/KeygenSimulator.Replies.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
+using System;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -9,12 +10,13 @@ using KurrentDB.Licensing.Keygen;
 namespace KurrentDB.Licensing.Tests.Keygen;
 
 partial class KeygenSimulator {
-	public async Task ReplyWith_ValidationResponse(string code) => await Send(
+	public async Task ReplyWith_ValidationResponse(string code, DateTimeOffset? expiry = null) => await Send(
 		HttpStatusCode.OK,
 		new Models.ValidateLicenseResponse {
 			Data = new() {
 				Attributes = new() {
 					Name = "the name of the license",
+					Expiry = expiry,
 					Metadata = new() {
 						{ "trial", "false" }
 					}

--- a/src/KurrentDB.Licensing/Keygen/KeygenLifecycleService.cs
+++ b/src/KurrentDB.Licensing/Keygen/KeygenLifecycleService.cs
@@ -19,13 +19,24 @@ public sealed class KeygenLifecycleService : IHostedService, IDisposable {
 
 	readonly KeygenClient _client;
 	readonly string _fingerprint;
+	// revalidate after this many heartbeats even if they are still working fine, so that changes to
+	// the license (e.g. a renewed expiry) are picked up. keeps the extra load proportional to, and
+	// controllable via, the heartbeat mechanism.
+	readonly int _heartbeatsPerRevalidation;
+	// if revalidating, wait this long first
 	readonly TimeSpan _revalidationDelay;
 	readonly CancellationTokenSource _heartbeatCancellation = new();
 	readonly ReplaySubject<LicenseInfo> _licenses = new(bufferSize: 1);
 
-	public KeygenLifecycleService(KeygenClient client, Fingerprint fingerprint, TimeSpan revalidationDelay) {
+	public KeygenLifecycleService(
+		KeygenClient client,
+		Fingerprint fingerprint,
+		int heartbeatsPerRevalidation,
+		TimeSpan revalidationDelay) {
+
 		_client = client;
 		_fingerprint = fingerprint.Get();
+		_heartbeatsPerRevalidation = heartbeatsPerRevalidation;
 		_revalidationDelay = revalidationDelay;
 	}
 
@@ -74,7 +85,7 @@ public sealed class KeygenLifecycleService : IHostedService, IDisposable {
 
 					await HeartbeatAsNecessary(cancellationToken);
 
-					// heartbeat process has failed, start over.
+					// the heartbeat process has failed or it is time to revalidate; start over.
 					await Task.Delay(_revalidationDelay, cancellationToken);
 					break;
 			}
@@ -161,7 +172,7 @@ public sealed class KeygenLifecycleService : IHostedService, IDisposable {
 		}
 	}
 
-	// completes when the heartbeat fails
+	// completes when the heartbeat fails or it is time to revalidate
 	async Task HeartbeatAsNecessary(CancellationToken cancellationToken) {
 		var restResponse = await _client.GetMachine(_fingerprint, cancellationToken);
 		if (!TryGetParsedResponse(restResponse, "License GetMachine", out var response, out var _)) {
@@ -170,6 +181,8 @@ public sealed class KeygenLifecycleService : IHostedService, IDisposable {
 		}
 
 		if (!response.RequiresHeartbeat) {
+			// Without a heartbeat there is no keep-alive cadence to revalidate on, so we hold the
+			// current license until the node restarts.
 			Log.Debug("No heartbeat required");
 			await Task.Delay(Timeout.Infinite, cancellationToken);
 		}
@@ -177,7 +190,7 @@ public sealed class KeygenLifecycleService : IHostedService, IDisposable {
 		await MaintainHeartbeat(response.HeartbeatInterval, cancellationToken);
 	}
 
-	// completes when the heartbeat fails
+	// completes when the heartbeat fails or it is time to revalidate
 	async Task MaintainHeartbeat(int interval, CancellationToken cancellationToken) {
 		Log.Debug("Starting heartbeat with interval {Interval} seconds", interval);
 
@@ -185,7 +198,8 @@ public sealed class KeygenLifecycleService : IHostedService, IDisposable {
 			? interval - 10
 			: interval / 5.0);
 
-		while (true) {
+		// revalidate once we've sent this many heartbeats, even if they're all healthy
+		for (var beat = 0; beat < _heartbeatsPerRevalidation; beat++) {
 			await Task.Delay(delay, cancellationToken);
 
 			var restResponse = await _client.SendHeartbeat(_fingerprint, cancellationToken);

--- a/src/KurrentDB.Licensing/Keygen/KeygenLifecycleService.cs
+++ b/src/KurrentDB.Licensing/Keygen/KeygenLifecycleService.cs
@@ -34,6 +34,9 @@ public sealed class KeygenLifecycleService : IHostedService, IDisposable {
 		int heartbeatsPerRevalidation,
 		TimeSpan revalidationDelay) {
 
+ 		if (heartbeatsPerRevalidation < 1)
+ 			throw new ArgumentOutOfRangeException(nameof(heartbeatsPerRevalidation), "Must be >= 1.");
+
 		_client = client;
 		_fingerprint = fingerprint.Get();
 		_heartbeatsPerRevalidation = heartbeatsPerRevalidation;

--- a/src/KurrentDB.Licensing/LicensingPlugin.cs
+++ b/src/KurrentDB.Licensing/LicensingPlugin.cs
@@ -83,6 +83,7 @@ public class LicensingPlugin : Plugin {
 							// todo: Interceptors = [new KeygenSignatureInterceptor()],
 						})),
 				new Fingerprint(clientOptions.Licensing.IncludePortInFingerprint ? clientOptions.NodePort : null),
+				heartbeatsPerRevalidation: 4,
 				revalidationDelay: TimeSpan.FromSeconds(10));
 
 			licenses = lifecycleService.Licenses;

--- a/src/KurrentDB/Components/Pages/License.razor
+++ b/src/KurrentDB/Components/Pages/License.razor
@@ -7,7 +7,6 @@
 @using EventStore.Plugins.Licensing
 @using KurrentDB.Licensing
 @using Microsoft.AspNetCore.Authorization
-@nullable enable
 
 <PageTitle>KurrentDB: License</PageTitle>
 
@@ -70,9 +69,10 @@
 </MudStack>
 
 @code {
+#nullable enable
 	[Inject] ILicenseService LicenseService { get; set; } = null!;
 
-	Dictionary<string, object>? _licenseSummary;
+	Dictionary<string, object?>? _licenseSummary;
 	IDisposable? _subscription;
 
 	protected override void OnInitialized() {
@@ -95,9 +95,9 @@
 
 	// Updates arrive off the licensing service's background thread, so marshal to the renderer
 	// and guard the teardown race (the circuit can be disposed while an update is in flight).
-	void Update(Dictionary<string, object>? summary) => _ = RefreshAsync(summary);
+	void Update(Dictionary<string, object?>? summary) => _ = RefreshAsync(summary);
 
-	async Task RefreshAsync(Dictionary<string, object>? summary) {
+	async Task RefreshAsync(Dictionary<string, object?>? summary) {
 		try {
 			await InvokeAsync(() => {
 				_licenseSummary = summary;

--- a/src/KurrentDB/Components/Pages/License.razor
+++ b/src/KurrentDB/Components/Pages/License.razor
@@ -5,9 +5,9 @@
 @attribute [Authorize]
 @implements IDisposable
 @using EventStore.Plugins.Licensing
-@using JetBrains.Annotations
 @using KurrentDB.Licensing
 @using Microsoft.AspNetCore.Authorization
+@nullable enable
 
 <PageTitle>KurrentDB: License</PageTitle>
 
@@ -70,10 +70,10 @@
 </MudStack>
 
 @code {
-	[Inject] ILicenseService LicenseService { get; set; }
+	[Inject] ILicenseService LicenseService { get; set; } = null!;
 
-	[CanBeNull] Dictionary<string, object> _licenseSummary;
-	IDisposable _subscription;
+	Dictionary<string, object>? _licenseSummary;
+	IDisposable? _subscription;
 
 	protected override void OnInitialized() {
 		base.OnInitialized();
@@ -96,9 +96,9 @@
 
 	// Updates arrive off the licensing service's background thread, so marshal to the renderer
 	// and guard the teardown race (the circuit can be disposed while an update is in flight).
-	void Update(Dictionary<string, object> summary) => _ = RefreshAsync(summary);
+	void Update(Dictionary<string, object>? summary) => _ = RefreshAsync(summary);
 
-	async Task RefreshAsync(Dictionary<string, object> summary) {
+	async Task RefreshAsync(Dictionary<string, object>? summary) {
 		try {
 			await InvokeAsync(() => {
 				_licenseSummary = summary;

--- a/src/KurrentDB/Components/Pages/License.razor
+++ b/src/KurrentDB/Components/Pages/License.razor
@@ -3,6 +3,7 @@
 
 @page "/ui/license"
 @attribute [Authorize]
+@implements IDisposable
 @using EventStore.Plugins.Licensing
 @using JetBrains.Annotations
 @using KurrentDB.Licensing
@@ -72,14 +73,44 @@
 	[Inject] ILicenseService LicenseService { get; set; }
 
 	[CanBeNull] Dictionary<string, object> _licenseSummary;
+	IDisposable _subscription;
 
 	protected override void OnInitialized() {
 		base.OnInitialized();
-		if (LicenseService.CurrentLicense == null) {
+
+		// Show the current license immediately (this is also the only work done during prerender).
+		var current = LicenseService.CurrentLicense;
+		_licenseSummary = current is null ? null : LicenseSummary.SelectForEndpoint(current);
+
+		// The live subscription needs the interactive circuit; skip it during the prerender pass.
+		if (!RendererInfo.IsInteractive) {
 			return;
 		}
 
-		_licenseSummary = LicenseSummary.SelectForEndpoint(LicenseService.CurrentLicense);
+		// Replay(1) re-delivers the current license immediately, then any later change
+		// (e.g. a renewed expiry picked up by the licensing service) refreshes the page live.
+		_subscription = LicenseService.Licenses.Subscribe(
+			license => Update(license is null ? null : LicenseSummary.SelectForEndpoint(license)),
+			_ => Update(null));
+	}
+
+	// Updates arrive off the licensing service's background thread, so marshal to the renderer
+	// and guard the teardown race (the circuit can be disposed while an update is in flight).
+	void Update(Dictionary<string, object> summary) => _ = RefreshAsync(summary);
+
+	async Task RefreshAsync(Dictionary<string, object> summary) {
+		try {
+			await InvokeAsync(() => {
+				_licenseSummary = summary;
+				StateHasChanged();
+			});
+		} catch (ObjectDisposedException) {
+			// Component/renderer torn down while an update was in flight — ignore.
+		}
+	}
+
+	public void Dispose() {
+		_subscription?.Dispose();
 	}
 
 	string GetValue(string key) => _licenseSummary?[key]?.ToString() ?? string.Empty;

--- a/src/KurrentDB/Components/Pages/License.razor
+++ b/src/KurrentDB/Components/Pages/License.razor
@@ -87,8 +87,7 @@
 			return;
 		}
 
-		// Replay(1) re-delivers the current license immediately, then any later change
-		// (e.g. a renewed expiry picked up by the licensing service) refreshes the page live.
+		// Delivers the current license immediately and then subsequent changes.
 		_subscription = LicenseService.Licenses.Subscribe(
 			license => Update(license is null ? null : LicenseSummary.SelectForEndpoint(license)),
 			_ => Update(null));


### PR DESCRIPTION
A node with a valid license now periodically revalidates with the licensing server while running, instead of only validating once at
startup. A renewed expiry date (or changed entitlements) is picked up without a restart.

The License page in the admin UI now updates live when the license changes, instead of only showing the license as it was when the page was first opened.