### PR TITLE
Introduce MemberInfoLite for describing the leader

### DIFF
--- a/src/Connectors/KurrentDB.Connectors.Tests/System/LeaderNodeBackgroundServiceTests.cs
+++ b/src/Connectors/KurrentDB.Connectors.Tests/System/LeaderNodeBackgroundServiceTests.cs
@@ -72,7 +72,7 @@ public class LeaderNodeBackgroundServiceTests(ITestOutputHelper output, Connecto
 
 			await sut.WaitUntilExecuting();
 
-			MessageBus.Publish(new SystemMessage.BecomeFollower(Guid.NewGuid(), FakeMemberInfo));
+			MessageBus.Publish(new SystemMessage.BecomeFollower(Guid.NewGuid(), FakeMemberInfo.ToLite()));
 
 			TaskCompletionSource<SystemMessage.ComponentTerminated> componentTerminated = new();
 			MessageBus.Subscribe<SystemMessage.ComponentTerminated>((message, _) => {
@@ -113,7 +113,7 @@ public class LeaderNodeBackgroundServiceTests(ITestOutputHelper output, Connecto
 
 			await sut.WaitUntilExecuting();
 
-			MessageBus.Publish(new SystemMessage.BecomeFollower(Guid.NewGuid(), FakeMemberInfo));
+			MessageBus.Publish(new SystemMessage.BecomeFollower(Guid.NewGuid(), FakeMemberInfo.ToLite()));
 
 			await sut.WaitUntilExecuted();
 			await Task.Delay(1000, cancellator.Token);
@@ -122,7 +122,7 @@ public class LeaderNodeBackgroundServiceTests(ITestOutputHelper output, Connecto
 
 			await sut.WaitUntilExecuting();
 
-			MessageBus.Publish(new SystemMessage.BecomeFollower(Guid.NewGuid(), FakeMemberInfo));
+			MessageBus.Publish(new SystemMessage.BecomeFollower(Guid.NewGuid(), FakeMemberInfo.ToLite()));
 
 			await sut.WaitUntilExecuted();
 			await Task.Delay(1000, cancellator.Token);
@@ -272,7 +272,7 @@ public class LeaderNodeBackgroundServiceTests(ITestOutputHelper output, Connecto
 
 			await sut.WaitUntilExecuting();
 
-			MessageBus.Publish(new SystemMessage.BecomeFollower(Guid.NewGuid(), FakeMemberInfo));
+			MessageBus.Publish(new SystemMessage.BecomeFollower(Guid.NewGuid(), FakeMemberInfo.ToLite()));
 
 			await sut.WaitUntilExecuted();
 

--- a/src/Connectors/KurrentDB.Connectors.Tests/System/NodeLifetimeServiceTests.cs
+++ b/src/Connectors/KurrentDB.Connectors.Tests/System/NodeLifetimeServiceTests.cs
@@ -134,7 +134,7 @@ public class NodeLifetimeServiceTests(ITestOutputHelper output, ConnectorsAssemb
 
 			await waitForLeadershipTask;
 
-			MessageBus.Publish(new SystemMessage.BecomeFollower(Guid.NewGuid(), FakeMemberInfo));
+			MessageBus.Publish(new SystemMessage.BecomeFollower(Guid.NewGuid(), FakeMemberInfo.ToLite()));
 
 			// Act & Assert
 

--- a/src/KurrentDB.Core.Tests/Services/ElectionsService/ElectionsServiceTests.cs
+++ b/src/KurrentDB.Core.Tests/Services/ElectionsService/ElectionsServiceTests.cs
@@ -829,7 +829,7 @@ public class when_receiving_a_proposal_as_acceptor : ElectionsFixture {
 					_nodeThree.InternalTcp,
 					_nodeThree.InternalSecureTcp, _nodeThree.ExternalTcp, _nodeThree.ExternalSecureTcp,
 					_nodeThree.HttpEndPoint, null, 0, 0, 0, 0, 0, 0, 0, _epochId, 0,
-					_nodeThree.IsReadOnlyReplica)),
+					_nodeThree.IsReadOnlyReplica).ToLite()),
 			new GrpcMessage.SendOverGrpc(_nodeThree.HttpEndPoint,
 				new ElectionMessage.Accept(_node.InstanceId, _node.HttpEndPoint,
 					_nodeThree.InstanceId,
@@ -967,7 +967,7 @@ public class when_receiving_majority_accept : ElectionsFixture {
 					_nodeTwo.InternalTcp,
 					_nodeTwo.InternalSecureTcp, _nodeTwo.ExternalTcp, _nodeTwo.ExternalSecureTcp,
 					_nodeTwo.HttpEndPoint, null, 0, 0, 0, 0, 0, 0, 0, _epochId, 0,
-					_nodeTwo.IsReadOnlyReplica)),
+					_nodeTwo.IsReadOnlyReplica).ToLite()),
 		};
 		_publisher.Messages.Should().BeEquivalentTo(expected);
 	}
@@ -1183,7 +1183,7 @@ public class when_electing_a_leader_and_leader_node_resigned : ElectionsFixture 
 					_nodeTwo.InternalTcp,
 					_nodeTwo.InternalSecureTcp, _nodeTwo.ExternalTcp, _nodeTwo.ExternalSecureTcp,
 					_nodeTwo.HttpEndPoint, null, 0, 0, 0, 0, 0, 0, 0, _epochId, 0,
-					_nodeTwo.IsReadOnlyReplica)),
+					_nodeTwo.IsReadOnlyReplica).ToLite()),
 		};
 		_publisher.Messages.Should().BeEquivalentTo(expected);
 	}
@@ -1193,7 +1193,7 @@ public class when_a_leader_is_found_during_leader_discovery : ElectionsFixture {
 	public when_a_leader_is_found_during_leader_discovery() :
 		base(NodeFactory(3), NodeFactory(2), NodeFactory(1)) {
 		var info = MemberInfoFromVNode(_nodeTwo, _timeProvider.UtcNow, VNodeState.Unknown, true, 0, _epochId, 0);
-		_sut.Handle(new LeaderDiscoveryMessage.LeaderFound(info));
+		_sut.Handle(new LeaderDiscoveryMessage.LeaderFound(info.ToLite()));
 		_sut.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
 			MemberInfoFromVNode(_node, _timeProvider.UtcNow, VNodeState.Unknown, true, 0, _epochId, 0),
 			info,
@@ -1266,7 +1266,7 @@ public class when_electing_a_leader_and_prepare_ok_is_received_from_previous_lea
 					_nodeThree.InternalSecureTcp, _nodeThree.ExternalTcp, _nodeThree.ExternalSecureTcp,
 					_nodeThree.HttpEndPoint, null, 0, 0,
 					0, 0, 0, 0, 0, _epochId, 0,
-					_nodeThree.IsReadOnlyReplica)),
+					_nodeThree.IsReadOnlyReplica).ToLite()),
 		};
 
 		_publisher.Messages.Should().BeEquivalentTo(expected);
@@ -1355,7 +1355,7 @@ public class when_electing_a_leader_and_prepare_ok_is_not_received_from_previous
 						_nodeTwo.InternalSecureTcp, _nodeTwo.ExternalTcp, _nodeTwo.ExternalSecureTcp,
 						_nodeTwo.HttpEndPoint, null, 0, 0,
 						0, 0, 0, 0, 0, _epochId, 0,
-						_nodeTwo.IsReadOnlyReplica)),
+						_nodeTwo.IsReadOnlyReplica).ToLite()),
 			};
 
 			_publisher.Messages.Should().BeEquivalentTo(expected);
@@ -1388,7 +1388,7 @@ public class when_electing_a_leader_and_prepare_ok_is_not_received_from_previous
 						_nodeTwo.InternalSecureTcp, _nodeTwo.ExternalTcp, _nodeTwo.ExternalSecureTcp,
 						_nodeTwo.HttpEndPoint, null, 0, 0,
 						0, 0, 0, 0, 0, _epochId, 0,
-						_nodeTwo.IsReadOnlyReplica)),
+						_nodeTwo.IsReadOnlyReplica).ToLite()),
 			};
 
 			_publisher.Messages.Should().BeEquivalentTo(expected);
@@ -1439,7 +1439,7 @@ public class when_electing_a_leader_and_prepare_ok_is_not_received_from_previous
 						_nodeTwo.InternalSecureTcp, _nodeTwo.ExternalTcp, _nodeTwo.ExternalSecureTcp,
 						_nodeTwo.HttpEndPoint, null, 0, 0,
 						0, 0, 0, 0, 0, _epochId, 0,
-						_nodeTwo.IsReadOnlyReplica)),
+						_nodeTwo.IsReadOnlyReplica).ToLite()),
 			};
 
 			_publisher.Messages.Should().BeEquivalentTo(expected);
@@ -1472,7 +1472,7 @@ public class when_electing_a_leader_and_prepare_ok_is_not_received_from_previous
 						_nodeTwo.InternalSecureTcp, _nodeTwo.ExternalTcp, _nodeTwo.ExternalSecureTcp,
 						_nodeTwo.HttpEndPoint, null, 0, 0,
 						0, 0, 0, 0, 0, _epochId, 0,
-						_nodeTwo.IsReadOnlyReplica)),
+						_nodeTwo.IsReadOnlyReplica).ToLite()),
 			};
 
 			_publisher.Messages.Should().BeEquivalentTo(expected);

--- a/src/KurrentDB.Core.Tests/Services/GossipService/ClusterMixedInternalTlsLoggerTests.cs
+++ b/src/KurrentDB.Core.Tests/Services/GossipService/ClusterMixedInternalTlsLoggerTests.cs
@@ -1,0 +1,116 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Linq;
+using System.Net;
+using FluentAssertions;
+using KurrentDB.Common.Utils;
+using KurrentDB.Core.Cluster;
+using KurrentDB.Core.Data;
+using KurrentDB.Core.Messages;
+using KurrentDB.Core.Services.Gossip;
+using NUnit.Framework;
+
+namespace KurrentDB.Core.Tests.Services.GossipService;
+
+[TestFixture]
+public class ClusterMixedInternalTlsLoggerTests {
+	private static readonly DateTime Now = DateTime.UtcNow;
+
+	// A node configures exactly one of its internal endpoints, so which one is set is its TLS setting.
+	private static MemberInfo Node(int index, bool usesTls, bool isAlive = true,
+		string esVersion = VersionInfo.DefaultVersion) {
+		var endPoint = new IPEndPoint(IPAddress.Loopback, 1110 + index);
+		return MemberInfo.ForVNode(
+			instanceId: Guid.NewGuid(),
+			timeStamp: Now,
+			state: VNodeState.Follower,
+			isAlive: isAlive,
+			internalTcpEndPoint: usesTls ? null : endPoint,
+			internalSecureTcpEndPoint: usesTls ? endPoint : null,
+			externalTcpEndPoint: null,
+			externalSecureTcpEndPoint: null,
+			httpEndPoint: new IPEndPoint(IPAddress.Loopback, 2110 + index),
+			advertiseHostToClientAs: null,
+			advertiseHttpPortToClientAs: 0,
+			advertiseTcpPortToClientAs: 0,
+			lastCommitPosition: -1,
+			writerCheckpoint: -1,
+			chaserCheckpoint: -1,
+			epochPosition: -1,
+			epochNumber: -1,
+			epochId: Guid.Empty,
+			nodePriority: 0,
+			isReadOnlyReplica: false,
+			esVersion: esVersion);
+	}
+
+	// A gossip seed before it has been replaced by real gossip about that node.
+	private static MemberInfo Seed(int index) => MemberInfo.ForManager(
+		Guid.NewGuid(), Now, isAlive: true, new IPEndPoint(IPAddress.Loopback, 2110 + index));
+
+	private static int DistinctSettings(params MemberInfo[] members) =>
+		ClusterMixedInternalTlsLogger.GetReplicationTls(new ClusterInfo(members))
+			.Select(static x => x.UsesTls)
+			.Distinct()
+			.Count();
+
+	[Test]
+	public void agrees_when_every_node_uses_tls() {
+		DistinctSettings(Node(1, usesTls: true), Node(2, usesTls: true), Node(3, usesTls: true))
+			.Should().Be(1);
+	}
+
+	[Test]
+	public void agrees_when_no_node_uses_tls() {
+		DistinctSettings(Node(1, usesTls: false), Node(2, usesTls: false), Node(3, usesTls: false))
+			.Should().Be(1);
+	}
+
+	[Test]
+	public void disagrees_when_one_node_differs() {
+		DistinctSettings(Node(1, usesTls: true), Node(2, usesTls: true), Node(3, usesTls: false))
+			.Should().Be(2);
+	}
+
+	[Test]
+	public void ignores_dead_nodes() {
+		// A node that is gone tells us nothing about the cluster's current configuration.
+		DistinctSettings(Node(1, usesTls: true), Node(2, usesTls: false, isAlive: false))
+			.Should().Be(1);
+	}
+
+	[Test]
+	public void ignores_gossip_seeds() {
+		// ForManager fabricates a plain internal endpoint, which would read as "no TLS" and warn
+		// spuriously until real gossip about that node arrives.
+		DistinctSettings(Node(1, usesTls: true), Seed(2))
+			.Should().Be(1);
+	}
+
+	[Test]
+	public void ignores_nodes_of_unknown_version() {
+		// We have no gossip from the node itself, so its endpoints are not its own report.
+		DistinctSettings(Node(1, usesTls: true), Node(2, usesTls: false, esVersion: VersionInfo.UnknownVersion))
+			.Should().Be(1);
+	}
+
+	[Test]
+	public void reports_each_node_it_considers() {
+		var nodeOne = Node(1, usesTls: true);
+		var nodeTwo = Node(2, usesTls: false);
+
+		ClusterMixedInternalTlsLogger.GetReplicationTls(new ClusterInfo(nodeOne, nodeTwo, Seed(3)))
+			.Should().BeEquivalentTo(new[] {
+				(HttpEndPoint: nodeOne.HttpEndPoint, UsesTls: true),
+				(HttpEndPoint: nodeTwo.HttpEndPoint, UsesTls: false),
+			});
+	}
+
+	[Test]
+	public void tolerates_gossip_without_cluster_info() {
+		var sut = new ClusterMixedInternalTlsLogger();
+		Assert.DoesNotThrow(() => sut.Handle(new GossipMessage.GossipUpdated(null)));
+	}
+}

--- a/src/KurrentDB.Core.Tests/Services/GossipService/NodeGossipServiceTests.cs
+++ b/src/KurrentDB.Core.Tests/Services/GossipService/NodeGossipServiceTests.cs
@@ -620,7 +620,7 @@ public class when_state_changed_to_non_leader : NodeGossipServiceTestFixture {
 		);
 
 	protected override Message When() =>
-		new SystemMessage.BecomeFollower(Guid.NewGuid(), MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow));
+		new SystemMessage.BecomeFollower(Guid.NewGuid(), MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow).ToLite());
 
 	[Test]
 	public void should_update_gossip() {
@@ -675,7 +675,7 @@ public class when_gossip_send_failed_to_the_current_leader_node : NodeGossipServ
 					MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow),
 					MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow, nodeState: VNodeState.Leader)),
 				_nodeTwo.HttpEndPoint),
-			new SystemMessage.BecomeFollower(Guid.NewGuid(), MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow))
+			new SystemMessage.BecomeFollower(Guid.NewGuid(), MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow).ToLite())
 		);
 
 	protected override Message When() => new GossipMessage.GossipSendFailed("failed",
@@ -905,7 +905,7 @@ public class when_elections_are_done : NodeGossipServiceTestFixture {
 
 	protected override Message When() =>
 		new ElectionMessage.ElectionsDone(0, 0,
-			MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow, nodeState: VNodeState.Leader));
+			MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow, nodeState: VNodeState.Leader).ToLite());
 
 	[Test]
 	public void should_set_leader_node_and_other_nodes_to_unknown() {

--- a/src/KurrentDB.Core.Tests/Services/Replication/LogReplication/AdHocReplicaController.cs
+++ b/src/KurrentDB.Core.Tests/Services/Replication/LogReplication/AdHocReplicaController.cs
@@ -100,7 +100,7 @@ internal class AdHocReplicaController<TStreamId> : IAsyncHandle<Message> {
 		_state = VNodeState.CatchingUp;
 		_outputBus.Publish(new SystemMessage.BecomeCatchingUp(
 			correlationId: Guid.NewGuid(),
-			leader: _leaderInfo.MemberInfo));
+			leader: _leaderInfo.MemberInfo.ToLite()));
 		_outputBus.Publish(message);
 	}
 
@@ -111,7 +111,7 @@ internal class AdHocReplicaController<TStreamId> : IAsyncHandle<Message> {
 		_state = VNodeState.Clone;
 		_outputBus.Publish(new SystemMessage.BecomeClone(
 			correlationId: Guid.NewGuid(),
-			leader: _leaderInfo.MemberInfo));
+			leader: _leaderInfo.MemberInfo.ToLite()));
 		_outputBus.Publish(message);
 	}
 
@@ -122,7 +122,7 @@ internal class AdHocReplicaController<TStreamId> : IAsyncHandle<Message> {
 		_state = VNodeState.Follower;
 		_outputBus.Publish(new SystemMessage.BecomeFollower(
 			correlationId: Guid.NewGuid(),
-			leader: _leaderInfo.MemberInfo));
+			leader: _leaderInfo.MemberInfo.ToLite()));
 		_outputBus.Publish(message);
 	}
 

--- a/src/KurrentDB.Core.Tests/Services/Replication/LogReplication/LogReplicationFixture.cs
+++ b/src/KurrentDB.Core.Tests/Services/Replication/LogReplication/LogReplicationFixture.cs
@@ -266,7 +266,7 @@ public abstract class LogReplicationFixture<TLogFormat, TStreamId> : Specificati
 		_replicaInfo.Publisher.Publish(new SystemMessage.BecomePreReplica(
 			correlationId: Guid.NewGuid(),
 			leaderConnectionCorrelationId: Guid.NewGuid(),
-			leader: _leaderInfo.MemberInfo));
+			leader: _leaderInfo.MemberInfo.ToLite()));
 		_replicaInfo.ConnectionEstablished.WaitOne();
 		_replicaInfo.Publisher.Publish(new ReplicationMessage.SubscribeToLeader(
 			stateCorrelationId: Guid.NewGuid(),

--- a/src/KurrentDB.Core.Tests/Services/RequestManagement/Service/when_writing_and_deposed_as_leader.cs
+++ b/src/KurrentDB.Core.Tests/Services/RequestManagement/Service/when_writing_and_deposed_as_leader.cs
@@ -20,7 +20,7 @@ public class when_writing_and_deposed_as_leader : RequestManagerServiceSpecifica
 	}
 
 	protected override Message When() {
-		return new SystemMessage.BecomePreReplica(Guid.NewGuid(), Guid.NewGuid(), FakeMemberInfo());
+		return new SystemMessage.BecomePreReplica(Guid.NewGuid(), Guid.NewGuid(), FakeMemberInfo().ToLite());
 	}
 
 	[Test]

--- a/src/KurrentDB.Core.Tests/Services/RequestManagement/Service/when_writing_and_deposed_as_leader_and_replica_moves_forward.cs
+++ b/src/KurrentDB.Core.Tests/Services/RequestManagement/Service/when_writing_and_deposed_as_leader_and_replica_moves_forward.cs
@@ -17,7 +17,7 @@ public class when_writing_and_deposed_as_leader_and_replica_moves_forward : Requ
 	protected override void Given() {
 		Dispatcher.Publish(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 		Dispatcher.Publish(ClientMessage.WriteEvents.ForSingleStream(InternalCorrId, ClientCorrId, Envelope, true, StreamId, ExpectedVersion.Any, new(DummyEvent()), null));
-		Dispatcher.Publish(new SystemMessage.BecomePreReplica(Guid.NewGuid(), Guid.NewGuid(), FakeMemberInfo()));
+		Dispatcher.Publish(new SystemMessage.BecomePreReplica(Guid.NewGuid(), Guid.NewGuid(), FakeMemberInfo().ToLite()));
 	}
 
 	protected override Message When() {

--- a/src/KurrentDB.Core.Tests/Services/VNode/InaugurationManager/given_waiting_for_chaser.cs
+++ b/src/KurrentDB.Core.Tests/Services/VNode/InaugurationManager/given_waiting_for_chaser.cs
@@ -11,7 +11,7 @@ namespace KurrentDB.Core.Tests.Services.VNode.InaugurationManager;
 [TestFixture]
 public class given_waiting_for_chaser : InaugurationManagerTests {
 	protected override void Given() {
-		_sut.Handle(new ElectionMessage.ElectionsDone(123, _epochNumber, _leader));
+		_sut.Handle(new ElectionMessage.ElectionsDone(123, _epochNumber, _leader.ToLite()));
 		_sut.Handle(new SystemMessage.BecomePreLeader(_correlationId1));
 		_publisher.Messages.Clear();
 	}

--- a/src/KurrentDB.Core.Tests/Services/VNode/InaugurationManager/given_waiting_for_conditions.cs
+++ b/src/KurrentDB.Core.Tests/Services/VNode/InaugurationManager/given_waiting_for_conditions.cs
@@ -11,7 +11,7 @@ namespace KurrentDB.Core.Tests.Services.VNode.InaugurationManager;
 [TestFixture]
 public class given_waiting_for_conditions : InaugurationManagerTests {
 	protected override void Given() {
-		_sut.Handle(new ElectionMessage.ElectionsDone(123, _epochNumber, _leader));
+		_sut.Handle(new ElectionMessage.ElectionsDone(123, _epochNumber, _leader.ToLite()));
 		_sut.Handle(new SystemMessage.BecomePreLeader(_correlationId1));
 		_sut.Handle(new SystemMessage.ChaserCaughtUp(_correlationId1));
 		_sut.Handle(GenEpoch(_epochNumber));

--- a/src/KurrentDB.Core.Tests/Services/VNode/InaugurationManager/given_writing_epoch.cs
+++ b/src/KurrentDB.Core.Tests/Services/VNode/InaugurationManager/given_writing_epoch.cs
@@ -11,7 +11,7 @@ namespace KurrentDB.Core.Tests.Services.VNode.InaugurationManager;
 [TestFixture]
 public class given_writing_epoch : InaugurationManagerTests {
 	protected override void Given() {
-		_sut.Handle(new ElectionMessage.ElectionsDone(123, _epochNumber, _leader));
+		_sut.Handle(new ElectionMessage.ElectionsDone(123, _epochNumber, _leader.ToLite()));
 		_sut.Handle(new SystemMessage.BecomePreLeader(_correlationId1));
 		_sut.Handle(new SystemMessage.ChaserCaughtUp(_correlationId1));
 		_publisher.Messages.Clear();

--- a/src/KurrentDB.Core.Tests/Services/VNode/leader_info_provider.cs
+++ b/src/KurrentDB.Core.Tests/Services/VNode/leader_info_provider.cs
@@ -26,26 +26,26 @@ public class leader_info_provider {
 				Expected: new (TcpEndPoint: null)),
 			new ("Leader: TcpEndPoint",
 				Given: new (Leader: new(TcpEndPoint: "1.1.1.1:1")),
-				Expected: new (TcpEndPoint: "1.1.1.1:1", IsTcpSecure: false)),
+				Expected: new (TcpEndPoint: "9.9.9.9:1", IsTcpSecure: false)),
 			new ("Leader: SecureTcpEndPoint",
 				Given: new (Leader: new(SecureTcpEndPoint: "2.2.2.2:2")),
-				Expected: new (TcpEndPoint: "2.2.2.2:2", IsTcpSecure: true)),
+				Expected: new (TcpEndPoint: "9.9.9.9:2", IsTcpSecure: true)),
 			new ("Leader: TcpEndPoint + SecureTcpEndPoint",
 				Given: new (Leader: new(TcpEndPoint: "1.1.1.1:1", SecureTcpEndPoint: "2.2.2.2:2")),
-				Expected: new (TcpEndPoint: "1.1.1.1:1", IsTcpSecure: true)),
+				Expected: new (TcpEndPoint: "9.9.9.9:1", IsTcpSecure: true)),
 			// AdvertiseTcpPort
 			new ("Leader: AdvertiseTcpPort & NoEndPoints",
 				Given: new (Leader: new(AdvertiseTcpPort: 9)),
 				Expected: new (TcpEndPoint: null, IsTcpSecure: false)),
 			new ("Leader: AdvertiseTcpPort & TcpEndPoint",
 				Given: new (Leader: new(AdvertiseTcpPort: 9, TcpEndPoint: "1.1.1.1:1")),
-				Expected: new (TcpEndPoint: "1.1.1.1:9")),
+				Expected: new (TcpEndPoint: "9.9.9.9:9")),
 			new ("Leader: AdvertiseTcpPort & SecureTcpEndPoint",
 				Given: new (Leader: new(AdvertiseTcpPort: 9, SecureTcpEndPoint: "2.2.2.2:2")),
-				Expected: new (TcpEndPoint: "2.2.2.2:9", IsTcpSecure: true)),
+				Expected: new (TcpEndPoint: "9.9.9.9:9", IsTcpSecure: true)),
 			new ("Leader: AdvertiseTcpPort & TcpEndPoint + SecureTcpEndPoint",
 				Given: new (Leader: new(TcpEndPoint: "1.1.1.1:1", SecureTcpEndPoint: "2.2.2.2:2", AdvertiseTcpPort: 9)),
-				Expected: new (TcpEndPoint: "1.1.1.1:9", IsTcpSecure: true)),
+				Expected: new (TcpEndPoint: "9.9.9.9:9", IsTcpSecure: true)),
 			// AdvertiseHost
 			new ("Leader: AdvertiseHost & NoEndPoints",
 				Given: new (Leader: new(AdvertiseHost: "host", HttpEndPoint: "3.3.3.3:3")),
@@ -120,7 +120,7 @@ public class leader_info_provider {
 
 		LeaderInfoProvider leaderInfoProvider = new LeaderInfoProvider(
 			given.GossipInfo,
-			given.LeaderInfo,
+			given.LeaderInfo?.ToLite(),
 			NodeInstanceId);
 
 		var result = leaderInfoProvider.GetLeaderInfoEndPoints();

--- a/src/KurrentDB.Core.XUnit.Tests/Metrics/ElectionsCounterTrackerTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Metrics/ElectionsCounterTrackerTests.cs
@@ -24,7 +24,7 @@ public class ElectionsCounterTrackerTests : IDisposable {
 			VNodeState.Unknown, true,
 			endPoint, endPoint, endPoint, endPoint, endPoint,
 			null, 0, 0, 0, false);
-		_electionsDoneMessage = new ElectionMessage.ElectionsDone(1, 1, memberInfo);
+		_electionsDoneMessage = new ElectionMessage.ElectionsDone(1, 1, memberInfo.ToLite());
 	}
 
 	public void Dispose() {

--- a/src/KurrentDB.Core.XUnit.Tests/Telemetry/TelemetryServiceTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Telemetry/TelemetryServiceTests.cs
@@ -161,9 +161,9 @@ public sealed class TelemetryServiceTests : IAsyncLifetime {
 		var schedule = Assert.IsType<TimerMessage.Schedule>(await _channelReader.ReadAsync());
 		var mem1 = CreateMemberInfo(Guid.NewGuid(), VNodeState.Leader, false);
 		var mem2 = CreateMemberInfo(Guid.NewGuid(), VNodeState.Follower, false);
-		var _electionsDoneMessage = new ElectionMessage.ElectionsDone(1, mem1.EpochNumber, mem1);
-		var _leaderFoundMessage = new LeaderDiscoveryMessage.LeaderFound(mem1);
-		var _replicaStateMessage = new SystemMessage.BecomeReadOnlyReplica(mem1.InstanceId, mem1);
+		var _electionsDoneMessage = new ElectionMessage.ElectionsDone(1, mem1.EpochNumber, mem1.ToLite());
+		var _leaderFoundMessage = new LeaderDiscoveryMessage.LeaderFound(mem1.ToLite());
+		var _replicaStateMessage = new SystemMessage.BecomeReadOnlyReplica(mem1.InstanceId, mem1.ToLite());
 		_sut.Handle(_electionsDoneMessage);
 		_sut.Handle(_leaderFoundMessage);
 		_sut.Handle(_replicaStateMessage);

--- a/src/KurrentDB.Core/Cluster/MemberInfo.cs
+++ b/src/KurrentDB.Core/Cluster/MemberInfo.cs
@@ -166,11 +166,11 @@ public class MemberInfo : IEquatable<MemberInfo> {
 
 	public bool Is(EndPoint endPoint) {
 		return endPoint != null
-			   && HttpEndPoint.EndPointEquals(endPoint)
+			   && (HttpEndPoint.EndPointEquals(endPoint)
 				  || (InternalTcpEndPoint != null && InternalTcpEndPoint.EndPointEquals(endPoint))
 				  || (InternalSecureTcpEndPoint != null && InternalSecureTcpEndPoint.EndPointEquals(endPoint))
 				  || (ExternalTcpEndPoint != null && ExternalTcpEndPoint.EndPointEquals(endPoint))
-				  || (ExternalSecureTcpEndPoint != null && ExternalSecureTcpEndPoint.EndPointEquals(endPoint));
+				  || (ExternalSecureTcpEndPoint != null && ExternalSecureTcpEndPoint.EndPointEquals(endPoint)));
 	}
 
 	public MemberInfo Updated(DateTime utcNow,
@@ -217,6 +217,21 @@ public class MemberInfo : IEquatable<MemberInfo> {
 			$"Version: {ESVersion}] " +
 			$"{LastCommitPosition}/{WriterCheckpoint}/{ChaserCheckpoint}/E{EpochNumber}@{EpochPosition}:{EpochId:B} | {TimeStamp:yyyy-MM-dd HH:mm:ss.fff}";
 	}
+
+	public MemberInfoLite ToLite() => new() {
+		InstanceId = InstanceId,
+		HttpEndPoint = HttpEndPoint,
+		ReplicationEndPoint = InternalTcpEndPoint ?? InternalSecureTcpEndPoint,
+		ClientHttpEndPoint = MemberInfoLite.ToClientEndPoint(
+			endPoint: HttpEndPoint,
+			advertiseHost: AdvertiseHostToClientAs,
+			advertisePort: AdvertiseHttpPortToClientAs),
+		ClientTcpPort = MemberInfoLite.ToClientTcpPort(
+			endPoint: ExternalTcpEndPoint ?? ExternalSecureTcpEndPoint,
+			advertisePort: AdvertiseTcpPortToClientAs),
+		ClientTcpApiIsSecure = ExternalSecureTcpEndPoint is not null,
+		EpochNumber = EpochNumber,
+	};
 
 	public bool Equals(MemberInfo other) {
 		// we ignore timestamp and checkpoints for equality comparison

--- a/src/KurrentDB.Core/Cluster/MemberInfoLite.cs
+++ b/src/KurrentDB.Core/Cluster/MemberInfoLite.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Net;
+using KurrentDB.Common.Utils;
+
+namespace KurrentDB.Core.Cluster;
+
+// What the rest of the node needs to know about the leader.
+// It is a subset of the information stored in <see cref="MemberInfo"/> but arranged around allowing
+// the leader to be reached from elsewhere so that KPlane, Gossip, and Elections can all populate it.
+public record MemberInfoLite {
+	public required Guid InstanceId { get; init; }
+	public required EndPoint HttpEndPoint { get; init; }
+	public required EndPoint ReplicationEndPoint { get; init; }
+	public required EndPoint ClientHttpEndPoint { get; init; }
+	public int ClientTcpPort { get; init; }
+	public bool ClientTcpApiIsSecure { get; init; }
+	public required int EpochNumber { get; init; }
+
+	public bool HasReplicationEndPoint(EndPoint endPoint) =>
+		endPoint is not null &&
+		ReplicationEndPoint is not null &&
+		ReplicationEndPoint.EndPointEquals(endPoint);
+
+	// The TCP API is reached at the client-facing address, on a port of its own - the same way the
+	// Kontrol Plane's DatabaseNode models it. Zero means the node does not expose the TCP API.
+	[CanBeNull]
+	public EndPoint ClientTcpEndPoint =>
+		ClientTcpPort is not 0
+			? new DnsEndPoint(ClientHttpEndPoint.GetHost(), ClientTcpPort)
+			: null;
+
+	// The port a client uses to reach the TCP API, or 0 if the node does not expose one. As with
+	// ToClientEndPoint the override may be absent, in which case the endpoint supplies it.
+	public static int ToClientTcpPort(EndPoint endPoint, int advertisePort) =>
+		endPoint is null
+			? 0
+			: advertisePort is not 0
+				? advertisePort
+				: endPoint.GetPort();
+
+	// Applies the advertise-to-client overrides to an endpoint, as LeaderInfoProvider does for this
+	// node's own addresses. Either override may be absent, in which case the endpoint supplies it.
+	public static EndPoint ToClientEndPoint(EndPoint endPoint, string advertiseHost, int advertisePort) =>
+		endPoint is null
+			? null
+			: new DnsEndPoint(
+				host: string.IsNullOrEmpty(advertiseHost) ? endPoint.GetHost() : advertiseHost,
+				port: advertisePort is 0 ? endPoint.GetPort() : advertisePort);
+}

--- a/src/KurrentDB.Core/ClusterVNode.cs
+++ b/src/KurrentDB.Core/ClusterVNode.cs
@@ -1631,6 +1631,9 @@ public class ClusterVNode<TStreamId> :
 		var clusterStateChangeListener = new ClusterMultipleVersionsLogger();
 		_mainBus.Subscribe<GossipMessage.GossipUpdated>(clusterStateChangeListener);
 
+		var mixedInternalTlsListener = new ClusterMixedInternalTlsLogger();
+		_mainBus.Subscribe<GossipMessage.GossipUpdated>(mixedInternalTlsListener);
+
 		_reloadConfigSignalRegistration = PosixSignalRegistration.Create(PosixSignal.SIGHUP, c => {
 			c.Cancel = true;
 			Log.Information("Reloading the node's configuration since {Signal} has been received.", c.Signal);

--- a/src/KurrentDB.Core/Data/VNodeInfo.cs
+++ b/src/KurrentDB.Core/Data/VNodeInfo.cs
@@ -38,11 +38,11 @@ public class VNodeInfo {
 
 	public bool Is(EndPoint endPoint) {
 		return endPoint != null
-			   && HttpEndPoint.Equals(endPoint)
+			   && (HttpEndPoint.Equals(endPoint)
 				   || (InternalTcp != null && InternalTcp.Equals(endPoint))
 				   || (InternalSecureTcp != null && InternalSecureTcp.Equals(endPoint))
 				   || (ExternalTcp != null && ExternalTcp.Equals(endPoint))
-				   || (ExternalSecureTcp != null && ExternalSecureTcp.Equals(endPoint));
+				   || (ExternalSecureTcp != null && ExternalSecureTcp.Equals(endPoint)));
 	}
 
 	public override string ToString() {

--- a/src/KurrentDB.Core/Messages/ElectionMessage.cs
+++ b/src/KurrentDB.Core/Messages/ElectionMessage.cs
@@ -333,9 +333,9 @@ public static partial class ElectionMessage {
 	public partial class ElectionsDone : Message {
 		public readonly int InstalledView;
 		public readonly int ProposalNumber;
-		public readonly MemberInfo Leader;
+		public readonly MemberInfoLite Leader;
 
-		public ElectionsDone(int installedView, int proposalNumber, MemberInfo leader) {
+		public ElectionsDone(int installedView, int proposalNumber, MemberInfoLite leader) {
 			Ensure.Nonnegative(installedView, "installedView");
 			Ensure.NotNull(leader, "leader");
 			InstalledView = installedView;

--- a/src/KurrentDB.Core/Messages/LeaderDiscoveryMessage.cs
+++ b/src/KurrentDB.Core/Messages/LeaderDiscoveryMessage.cs
@@ -10,9 +10,9 @@ namespace KurrentDB.Core.Messages;
 public static partial class LeaderDiscoveryMessage {
 	[DerivedMessage(CoreMessage.LeaderDiscovery)]
 	public partial class LeaderFound : Message {
-		public readonly MemberInfo Leader;
+		public readonly MemberInfoLite Leader;
 
-		public LeaderFound(MemberInfo leader) {
+		public LeaderFound(MemberInfoLite leader) {
 			Ensure.NotNull(leader, "leader");
 			Leader = leader;
 		}

--- a/src/KurrentDB.Core/Messages/ReplicationMessage.cs
+++ b/src/KurrentDB.Core/Messages/ReplicationMessage.cs
@@ -146,10 +146,10 @@ public static partial class ReplicationMessage {
 
 	[DerivedMessage(CoreMessage.Replication)]
 	public partial class ReconnectToLeader : Message {
-		public readonly MemberInfo Leader;
+		public readonly MemberInfoLite Leader;
 		public readonly Guid ConnectionCorrelationId;
 
-		public ReconnectToLeader(Guid connectionCorrelationId, MemberInfo leader) {
+		public ReconnectToLeader(Guid connectionCorrelationId, MemberInfoLite leader) {
 			Ensure.NotEmptyGuid(connectionCorrelationId, nameof(connectionCorrelationId));
 			Ensure.NotNull(leader, nameof(leader));
 			ConnectionCorrelationId = connectionCorrelationId;
@@ -159,10 +159,10 @@ public static partial class ReplicationMessage {
 
 	[DerivedMessage(CoreMessage.Replication)]
 	public partial class LeaderConnectionFailed : Message {
-		public readonly MemberInfo Leader;
+		public readonly MemberInfoLite Leader;
 		public readonly Guid LeaderConnectionCorrelationId;
 
-		public LeaderConnectionFailed(Guid leaderConnectionCorrelationId, MemberInfo leader) {
+		public LeaderConnectionFailed(Guid leaderConnectionCorrelationId, MemberInfoLite leader) {
 			Ensure.NotEmptyGuid(leaderConnectionCorrelationId, nameof(leaderConnectionCorrelationId));
 			Ensure.NotNull(leader, nameof(leader));
 			LeaderConnectionCorrelationId = leaderConnectionCorrelationId;

--- a/src/KurrentDB.Core/Messages/SystemMessage.cs
+++ b/src/KurrentDB.Core/Messages/SystemMessage.cs
@@ -130,9 +130,9 @@ public static partial class SystemMessage {
 
 	[DerivedMessage]
 	public abstract partial class ReplicaStateMessage : StateChangeMessage {
-		public readonly MemberInfo Leader;
+		public readonly MemberInfoLite Leader;
 
-		protected ReplicaStateMessage(Guid correlationId, VNodeState state, MemberInfo leader)
+		protected ReplicaStateMessage(Guid correlationId, VNodeState state, MemberInfoLite leader)
 			: base(correlationId, state) {
 			Ensure.NotNull(leader, "leader");
 			Leader = leader;
@@ -143,7 +143,7 @@ public static partial class SystemMessage {
 	public partial class BecomePreReplica : ReplicaStateMessage {
 		public readonly Guid LeaderConnectionCorrelationId;
 
-		public BecomePreReplica(Guid correlationId, Guid leaderConnectionCorrelationId, MemberInfo leader)
+		public BecomePreReplica(Guid correlationId, Guid leaderConnectionCorrelationId, MemberInfoLite leader)
 			: base(correlationId, VNodeState.PreReplica, leader) {
 			LeaderConnectionCorrelationId = leaderConnectionCorrelationId;
 		}
@@ -151,20 +151,20 @@ public static partial class SystemMessage {
 
 	[DerivedMessage(CoreMessage.System)]
 	public partial class BecomeCatchingUp : ReplicaStateMessage {
-		public BecomeCatchingUp(Guid correlationId, MemberInfo leader) : base(correlationId, VNodeState.CatchingUp,
+		public BecomeCatchingUp(Guid correlationId, MemberInfoLite leader) : base(correlationId, VNodeState.CatchingUp,
 			leader) {
 		}
 	}
 
 	[DerivedMessage(CoreMessage.System)]
 	public partial class BecomeClone : ReplicaStateMessage {
-		public BecomeClone(Guid correlationId, MemberInfo leader) : base(correlationId, VNodeState.Clone, leader) {
+		public BecomeClone(Guid correlationId, MemberInfoLite leader) : base(correlationId, VNodeState.Clone, leader) {
 		}
 	}
 
 	[DerivedMessage(CoreMessage.System)]
 	public partial class BecomeFollower : ReplicaStateMessage {
-		public BecomeFollower(Guid correlationId, MemberInfo leader) : base(correlationId, VNodeState.Follower,
+		public BecomeFollower(Guid correlationId, MemberInfoLite leader) : base(correlationId, VNodeState.Follower,
 			leader) {
 		}
 	}
@@ -180,7 +180,7 @@ public static partial class SystemMessage {
 	public partial class BecomePreReadOnlyReplica : ReplicaStateMessage {
 		public readonly Guid LeaderConnectionCorrelationId;
 
-		public BecomePreReadOnlyReplica(Guid correlationId, Guid leaderConnectionCorrelationId, MemberInfo leader)
+		public BecomePreReadOnlyReplica(Guid correlationId, Guid leaderConnectionCorrelationId, MemberInfoLite leader)
 			: base(correlationId, VNodeState.PreReadOnlyReplica, leader) {
 			LeaderConnectionCorrelationId = leaderConnectionCorrelationId;
 		}
@@ -188,7 +188,7 @@ public static partial class SystemMessage {
 
 	[DerivedMessage(CoreMessage.System)]
 	public partial class BecomeReadOnlyReplica : ReplicaStateMessage {
-		public BecomeReadOnlyReplica(Guid correlationId, MemberInfo leader)
+		public BecomeReadOnlyReplica(Guid correlationId, MemberInfoLite leader)
 			: base(correlationId, VNodeState.ReadOnlyReplica, leader) {
 		}
 	}

--- a/src/KurrentDB.Core/Services/ElectionsService.cs
+++ b/src/KurrentDB.Core/Services/ElectionsService.cs
@@ -662,7 +662,7 @@ public class ElectionsService : IHandle<SystemMessage.BecomeShuttingDown>,
 					FormatNodeInfo(_leaderProposal), FormatNodeInfo(GetOwnInfo()));
 				_lastElectedLeader = _leader;
 				_resigningLeaderInstanceId = null;
-				_publisher.Publish(new ElectionMessage.ElectionsDone(message.View, _leaderProposal.ProposalNumber, leader));
+				_publisher.Publish(new ElectionMessage.ElectionsDone(message.View, _leaderProposal.ProposalNumber, leader.ToLite()));
 			}
 		}
 	}

--- a/src/KurrentDB.Core/Services/Gossip/ClusterMixedInternalTlsLogger.cs
+++ b/src/KurrentDB.Core/Services/Gossip/ClusterMixedInternalTlsLogger.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using KurrentDB.Common.Log;
+using KurrentDB.Common.Utils;
+using KurrentDB.Core.Bus;
+using KurrentDB.Core.Cluster;
+using KurrentDB.Core.Data;
+using KurrentDB.Core.Messages;
+
+namespace KurrentDB.Core.Services.Gossip;
+
+/// <summary>
+/// Warns when the cluster's nodes do not agree on whether replication uses TLS.
+/// </summary>
+public class ClusterMixedInternalTlsLogger : IHandle<GossipMessage.GossipUpdated> {
+	private static readonly ThrottledLog<ClusterMixedInternalTlsLogger> Log = new(TimeSpan.FromMinutes(1));
+
+	public void Handle(GossipMessage.GossipUpdated message) {
+		if (message.ClusterInfo is not { } cluster)
+			return;
+
+		var nodes = GetReplicationTls(cluster);
+		if (nodes.Select(static x => x.UsesTls).Distinct().Count() <= 1)
+			return;
+
+		var described = nodes.Select(static x => $"({x.HttpEndPoint},{(x.UsesTls ? "TLS" : "no TLS")})");
+		Log.Warning($"CLUSTER NODES DISAGREE ON REPLICATION TLS [ {string.Join(", ", described)} ]. " +
+					"Replication cannot be established between nodes configured differently.");
+	}
+
+	// Whether each node replicates over TLS. A node sets exactly one of its internal endpoints
+	// (VNodeInfo enforces it), so which one tells us its setting.
+	//
+	// Gossip seeds are skipped: MemberInfo.ForManager stands them up as alive with only a plain
+	// internal endpoint, which would read as "no TLS" until real gossip replaces them.
+	public static IReadOnlyList<(EndPoint HttpEndPoint, bool UsesTls)> GetReplicationTls(ClusterInfo cluster) => cluster
+		.Members
+		.Where(static member => member.IsAlive
+							 && member.State is not VNodeState.Manager
+							 && !VersionInfo.UnknownVersion.Equals(member.ESVersion))
+		.Select(static member => (member.HttpEndPoint, member.InternalSecureTcpEndPoint is not null))
+		.ToList();
+}

--- a/src/KurrentDB.Core/Services/Gossip/GossipServiceBase.cs
+++ b/src/KurrentDB.Core/Services/Gossip/GossipServiceBase.cs
@@ -37,7 +37,7 @@ public abstract class GossipServiceBase : IHandle<SystemMessage.SystemInit>,
 
 	protected readonly MemberInfo MemberInfo;
 	protected VNodeState CurrentRole = VNodeState.Initializing;
-	private MemberInfo _currentLeader;
+	private MemberInfoLite _currentLeader;
 	private readonly TimeSpan _gossipInterval;
 	private readonly TimeSpan _allowedTimeDifference;
 	private readonly TimeSpan _gossipTimeout;

--- a/src/KurrentDB.Core/Services/HttpSendService.cs
+++ b/src/KurrentDB.Core/Services/HttpSendService.cs
@@ -29,7 +29,7 @@ public class HttpSendService : IHttpForwarder,
 	private readonly HttpMessagePipe _httpPipe;
 	private readonly bool _forwardRequests;
 	private readonly HttpClient _forwardClient;
-	private MemberInfo _leaderInfo;
+	private MemberInfoLite _leaderInfo;
 
 	public HttpSendService(HttpMessagePipe httpPipe, bool forwardRequests, CertificateDelegates.ServerCertificateValidator externServerCertValidator) {
 		_httpPipe = Ensure.NotNull(httpPipe);

--- a/src/KurrentDB.Core/Services/Replication/ReplicaService.cs
+++ b/src/KurrentDB.Core/Services/Replication/ReplicaService.cs
@@ -144,10 +144,10 @@ public class ReplicaService :
 		ConnectToLeader(message.ConnectionCorrelationId, message.Leader);
 	}
 
-	private void ConnectToLeader(Guid leaderConnectionCorrelationId, MemberInfo leader) {
+	private void ConnectToLeader(Guid leaderConnectionCorrelationId, MemberInfoLite leader) {
 		Debug.Assert(_state is VNodeState.PreReplica or VNodeState.PreReadOnlyReplica);
 
-		var leaderEndPoint = GetLeaderEndPoint(leader, _useSsl);
+		var leaderEndPoint = leader.ReplicationEndPoint;
 		if (leaderEndPoint == null) {
 			Log.Error("No valid endpoint found to connect to the Leader. Aborting connection operation to Leader.");
 			return;
@@ -183,24 +183,6 @@ public class ReplicaService :
 			Log.Error(ex, "Failed to connect to leader [{leader}]. This will be retried.", leader);
 			_publisher.Publish(new ReplicationMessage.LeaderConnectionFailed(leaderConnectionCorrelationId, leader));
 		}
-	}
-
-	private static EndPoint GetLeaderEndPoint(MemberInfo leader, bool useSsl) {
-		Ensure.NotNull(leader);
-		switch (useSsl) {
-			case true when leader.InternalSecureTcpEndPoint == null:
-				Log.Error(
-					"Internal secure connections are required, but no internal secure TCP end point is specified for leader [{leader}]!",
-					leader);
-				break;
-			case false when leader.InternalTcpEndPoint == null:
-				Log.Error(
-					"Internal connections are required, but no internal TCP end point is specified for leader [{leader}]!",
-					leader);
-				break;
-		}
-
-		return useSsl ? leader.InternalSecureTcpEndPoint : leader.InternalTcpEndPoint;
 	}
 
 	async ValueTask IAsyncHandle<ReplicationMessage.SubscribeToLeader>.HandleAsync(ReplicationMessage.SubscribeToLeader message, CancellationToken token) {

--- a/src/KurrentDB.Core/Services/VNode/ClusterVNodeController.cs
+++ b/src/KurrentDB.Core/Services/VNode/ClusterVNodeController.cs
@@ -49,7 +49,7 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 		}
 	}
 
-	private MemberInfo _leader;
+	private MemberInfoLite _leader;
 	private Guid _stateCorrelationId = Guid.NewGuid();
 	private Guid _leaderConnectionCorrelationId = Guid.NewGuid();
 	private Guid _subscriptionId = Guid.Empty;
@@ -1024,7 +1024,7 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 	}
 
 	private ValueTask Handle(SystemMessage.VNodeConnectionLost message, CancellationToken token) {
-		if (_leader?.Is(message.VNodeEndPoint) ?? false) // leader connection failed
+		if (_leader?.HasReplicationEndPoint(message.VNodeEndPoint) ?? false) // leader connection failed
 		{
 			_leaderConnectionCorrelationId = Guid.NewGuid();
 			var msg = State is VNodeState.PreReplica
@@ -1037,7 +1037,7 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 	}
 
 	private ValueTask HandleAsReadOnlyReplica(SystemMessage.VNodeConnectionLost message, CancellationToken token) {
-		if (_leader?.Is(message.VNodeEndPoint) ?? false) // leader connection failed
+		if (_leader?.HasReplicationEndPoint(message.VNodeEndPoint) ?? false) // leader connection failed
 		{
 			_leaderConnectionCorrelationId = Guid.NewGuid();
 			var msg = State is VNodeState.PreReadOnlyReplica
@@ -1094,7 +1094,7 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 		var aliveLeaders = message.ClusterInfo.Members.Where(IsAliveLeader);
 		var leaderCount = aliveLeaders.Count();
 		if (leaderCount is 1) {
-			_leader = aliveLeaders.First();
+			_leader = aliveLeaders.First().ToLite();
 			Log.Information("LEADER found in READ ONLY LEADERLESS state. LEADER: [{leader}]. Proceeding to READ ONLY PRE-REPLICA state.", _leader);
 			_stateCorrelationId = Guid.NewGuid();
 			_leaderConnectionCorrelationId = Guid.NewGuid();
@@ -1135,7 +1135,7 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 		var aliveLeaders = message.ClusterInfo.Members.Where(IsAliveLeader);
 		var leaderCount = aliveLeaders.Count();
 		if (leaderCount is 1) {
-			_leader = aliveLeaders.First();
+			_leader = aliveLeaders.First().ToLite();
 			Log.Information("Existing LEADER found during LEADER DISCOVERY stage. LEADER: [{leader}]. Proceeding to PRE-REPLICA state.", _leader);
 			_mainQueue.Publish(new LeaderDiscoveryMessage.LeaderFound(_leader));
 			_stateCorrelationId = Guid.NewGuid();
@@ -1255,10 +1255,9 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 	private async ValueTask Handle(ReplicationMessage.FollowerAssignment message, CancellationToken token) {
 		if (IsLegitimateReplicationMessage(message)) {
 			Log.Information(
-				"========== [{httpEndPoint}] FOLLOWER ASSIGNMENT RECEIVED FROM [{internalTcp},{internalSecureTcp},{leaderId:B}].",
+				"========== [{httpEndPoint}] FOLLOWER ASSIGNMENT RECEIVED FROM [{replicationEndPoint},{leaderId:B}].",
 				_nodeInfo.HttpEndPoint,
-				_leader.InternalTcpEndPoint == null ? "n/a" : _leader.InternalTcpEndPoint.ToString(),
-				_leader.InternalSecureTcpEndPoint == null ? "n/a" : _leader.InternalSecureTcpEndPoint.ToString(),
+				_leader.ReplicationEndPoint,
 				message.LeaderId);
 			await _outputBus.DispatchAsync(message, token);
 			await _fsm.HandleAsync(new SystemMessage.BecomeFollower(_stateCorrelationId, _leader), token);
@@ -1268,10 +1267,9 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 	private async ValueTask Handle(ReplicationMessage.CloneAssignment message, CancellationToken token) {
 		if (IsLegitimateReplicationMessage(message)) {
 			Log.Information(
-				"========== [{httpEndPoint}] CLONE ASSIGNMENT RECEIVED FROM [{internalTcp},{internalSecureTcp},{leaderId:B}].",
+				"========== [{httpEndPoint}] CLONE ASSIGNMENT RECEIVED FROM [{replicationEndPoint},{leaderId:B}].",
 				_nodeInfo.HttpEndPoint,
-				_leader.InternalTcpEndPoint == null ? "n/a" : _leader.InternalTcpEndPoint.ToString(),
-				_leader.InternalSecureTcpEndPoint == null ? "n/a" : _leader.InternalSecureTcpEndPoint.ToString(),
+				_leader.ReplicationEndPoint,
 				message.LeaderId);
 			await _outputBus.DispatchAsync(message, token);
 			await _fsm.HandleAsync(new SystemMessage.BecomeClone(_stateCorrelationId, _leader), token);
@@ -1283,10 +1281,9 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 		try {
 			if (IsLegitimateReplicationMessage(message)) {
 				Log.Information(
-					"========== [{httpEndPoint}] DROP SUBSCRIPTION REQUEST RECEIVED FROM [{internalTcp},{internalSecureTcp},{leaderId:B}]. THIS MEANS THAT THERE IS A SURPLUS OF NODES IN THE CLUSTER, SHUTTING DOWN.",
+					"========== [{httpEndPoint}] DROP SUBSCRIPTION REQUEST RECEIVED FROM [{replicationEndPoint},{leaderId:B}]. THIS MEANS THAT THERE IS A SURPLUS OF NODES IN THE CLUSTER, SHUTTING DOWN.",
 					_nodeInfo.HttpEndPoint,
-					_leader.InternalTcpEndPoint == null ? "n/a" : _leader.InternalTcpEndPoint.ToString(),
-					_leader.InternalSecureTcpEndPoint == null ? "n/a" : _leader.InternalSecureTcpEndPoint.ToString(),
+					_leader.ReplicationEndPoint,
 					message.LeaderId);
 				task = _outputBus.DispatchAsync(new ClientMessage.RequestShutdown(exitProcess: true, shutdownHttp: true), token);
 			} else {

--- a/src/KurrentDB.Core/Services/VNode/LeaderInfoProvider.cs
+++ b/src/KurrentDB.Core/Services/VNode/LeaderInfoProvider.cs
@@ -2,7 +2,6 @@
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
 using System;
-using System.Net;
 using KurrentDB.Common.Utils;
 using KurrentDB.Core.Cluster;
 using KurrentDB.Core.Data;
@@ -13,49 +12,39 @@ namespace KurrentDB.Core.Services.VNode;
 
 public class LeaderInfoProvider {
 	private readonly GossipAdvertiseInfo _gossipInfo;
-	private readonly MemberInfo _leaderInfo;
+	private readonly MemberInfoLite _leaderInfo;
 	private readonly Guid _nodeInstanceId;
 
-	public LeaderInfoProvider(GossipAdvertiseInfo gossipInfo, MemberInfo leaderInfo, Guid nodeInstanceId) {
+	public LeaderInfoProvider(GossipAdvertiseInfo gossipInfo, MemberInfoLite leaderInfo, Guid nodeInstanceId) {
 		Ensure.NotNull(gossipInfo, "gossipInfo");
 		_gossipInfo = gossipInfo;
 		_leaderInfo = leaderInfo;
 		_nodeInstanceId = nodeInstanceId;
 	}
 
+	// Get the endpoints for a client to talk to the leader.
+	// If we have leader info this is best. Otherwise go with what we heard on the grape vine.
 	public (EndPoint AdvertisedTcpEndPoint, bool IsTcpEndPointSecure, EndPoint AdvertisedHttpEndPoint, Guid InstanceId)
 		GetLeaderInfoEndPoints() {
 
-		var endpoints = _leaderInfo != null
-			? (TcpEndPoint: _leaderInfo.ExternalTcpEndPoint ?? _leaderInfo.ExternalSecureTcpEndPoint,
-				IsTcpEndPointSecure: _leaderInfo.ExternalSecureTcpEndPoint != null,
-				HttpEndPoint: _leaderInfo.HttpEndPoint,
-				AdvertiseHost: _leaderInfo.AdvertiseHostToClientAs,
-				AdvertiseHttpPort: _leaderInfo.AdvertiseHttpPortToClientAs,
-				AdvertiseTcpPort: _leaderInfo.AdvertiseTcpPortToClientAs,
-				InstanceId: _leaderInfo.InstanceId)
-			// TC: if we don't know who the leader is we return our own info. is this ideal?
-			: (TcpEndPoint: _gossipInfo.ExternalTcp ?? _gossipInfo.ExternalSecureTcp,
-				IsTcpEndPointSecure: _gossipInfo.ExternalSecureTcp != null,
-				HttpEndPoint: _gossipInfo.HttpEndPoint,
-				AdvertiseHost: _gossipInfo.AdvertiseHostToClientAs,
-				AdvertiseHttpPort: _gossipInfo.AdvertiseHttpPortToClientAs,
-				AdvertiseTcpPort: _gossipInfo.AdvertiseTcpPortToClientAs,
-				InstanceId: _nodeInstanceId);
+		if (_leaderInfo is { } leader)
+			return (
+				AdvertisedTcpEndPoint: leader.ClientTcpEndPoint,
+				IsTcpEndPointSecure: leader.ClientTcpApiIsSecure,
+				AdvertisedHttpEndPoint: leader.ClientHttpEndPoint,
+				InstanceId: leader.InstanceId);
 
-		var advertisedTcpEndPoint = endpoints.TcpEndPoint == null
-			? null
-			: new DnsEndPoint(
-				string.IsNullOrEmpty(endpoints.AdvertiseHost)
-					? endpoints.TcpEndPoint.GetHost()
-					: endpoints.AdvertiseHost,
-				endpoints.AdvertiseTcpPort == 0 ? endpoints.TcpEndPoint.GetPort() : endpoints.AdvertiseTcpPort);
-		var advertisedHttpEndPoint = new DnsEndPoint(
-			string.IsNullOrEmpty(endpoints.AdvertiseHost)
-				? endpoints.HttpEndPoint.GetHost()
-				: endpoints.AdvertiseHost,
-			endpoints.AdvertiseHttpPort == 0 ? endpoints.HttpEndPoint.GetPort() : endpoints.AdvertiseHttpPort);
-
-		return (advertisedTcpEndPoint, endpoints.IsTcpEndPointSecure, advertisedHttpEndPoint, endpoints.InstanceId);
+		// TC: if we don't know who the leader is we return our own info. is this ideal?
+		return (
+			AdvertisedTcpEndPoint: MemberInfoLite.ToClientEndPoint(
+				endPoint: _gossipInfo.ExternalTcp ?? _gossipInfo.ExternalSecureTcp,
+				advertiseHost: _gossipInfo.AdvertiseHostToClientAs,
+				advertisePort: _gossipInfo.AdvertiseTcpPortToClientAs),
+			IsTcpEndPointSecure: _gossipInfo.ExternalSecureTcp != null,
+			AdvertisedHttpEndPoint: MemberInfoLite.ToClientEndPoint(
+				endPoint: _gossipInfo.HttpEndPoint,
+				advertiseHost: _gossipInfo.AdvertiseHostToClientAs,
+				advertisePort: _gossipInfo.AdvertiseHttpPortToClientAs),
+			InstanceId: _nodeInstanceId);
 	}
 }

--- a/src/KurrentDB.Projections.Management.Tests/Services/projections_system/when_starting_up.cs
+++ b/src/KurrentDB.Projections.Management.Tests/Services/projections_system/when_starting_up.cs
@@ -60,7 +60,7 @@ namespace KurrentDB.Projections.Core.Tests.Services.projections_system {
 						new IPEndPoint(IPAddress.Loopback, 1115), null, 0, 0,
 						1,
 						false
-					)));
+					).ToLite()));
 				yield return (new SystemMessage.SystemCoreReady());
 				yield return Yield;
 				if (_startSystemProjections) {

--- a/src/SchemaRegistry/KurrentDB.SchemaRegistry.Tests/Planes/Projection/DuckDBProjectorServiceTests.cs
+++ b/src/SchemaRegistry/KurrentDB.SchemaRegistry.Tests/Planes/Projection/DuckDBProjectorServiceTests.cs
@@ -40,7 +40,7 @@ public class DuckDBProjectorServiceTests : SchemaApplicationTestFixture {
 		executing.IsCancellationRequested.ShouldBeFalse();
 
 		// Act
-		MessageBus.Publish(new SystemMessage.BecomeFollower(Guid.NewGuid(), FakeMemberInfo));
+		MessageBus.Publish(new SystemMessage.BecomeFollower(Guid.NewGuid(), FakeMemberInfo.ToLite()));
 
 		await Task.Delay(1000, cancellationToken);
 


### PR DESCRIPTION
Consumers that only need to know "who is the leader and how do I reach them" were being handed a full MemberInfo, most of whose fields they never read. That made the type hard to produce from anything other than gossip. MemberInfoLite is the subset that is actually consumed, so it can be produced by anything that knows a node's addresses.

Migrates the messages and holders that carry the leader: ElectionsDone, LeaderDiscoveryMessage.LeaderFound, SystemMessage.ReplicaStateMessage, ReplicationMessage, GossipServiceBase, HttpSendService, ReplicaService, LeaderInfoProvider and ClusterVNodeController.

Two fields change meaning rather than just moving:

- The client endpoints are the ADVERTISED addresses. MemberInfo keeps the untranslated address plus separate AdvertiseHostToClientAs and Advertise*PortToClientAs overrides, and LeaderInfoProvider applied them. MemberInfoLite does not carry the overrides, so ToLite applies them and every consumer takes the addresses as given.

- The internal secure/insecure pair collapses to one ReplicationEndPoint. A node configures exactly one of the pair, and a replica dials with its own TLS setting regardless of which the leader advertises, so ReplicaService.GetLeaderEndPoint had nothing left to choose between.

Removing GetLeaderEndPoint loses its "secure connections are required but the leader has no secure endpoint" diagnostic, which fired only when dialling the leader. ClusterMixedInternalTlsLogger replaces it from gossip: it reports every node that disagrees, before any connection is attempted, and does not depend on which node we happen to be following.

Also renames MemberInfoLite.Is to HasReplicationEndPoint, since its callers only ask whether a lost replication connection was the leader's, and parenthesises MemberInfo.Is and VNodeInfo.Is, where `endPoint != null && a || b` left the null guard covering only the first comparison - and MemberInfo.Is would then throw rather than return false, because EndPointEqualityComparer.Equals dereferences both arguments.