### PR TITLE
[DB-2215] Integrate ClusterVNode with KPlane

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -15,11 +15,11 @@
     <PackageVersion Include="Cloud.Unum.USearch" Version="2.23.0" />
     <PackageVersion Include="DiffEngine" Version="16.7.1" />
     <PackageVersion Include="Dapper" Version="2.1.66" />
-		<PackageVersion Include="DotNext" Version="6.7.1" />
-    <PackageVersion Include="DotNext.IO" Version="6.7.1" />
-    <PackageVersion Include="DotNext.Threading" Version="6.7.1" />
-    <PackageVersion Include="DotNext.Unsafe" Version="6.7.1" />
-    <PackageVersion Include="DotNext.Net.Cluster" Version="6.7.1" />
+		<PackageVersion Include="DotNext" Version="6.7.2" />
+    <PackageVersion Include="DotNext.IO" Version="6.7.2" />
+    <PackageVersion Include="DotNext.Threading" Version="6.7.2" />
+    <PackageVersion Include="DotNext.Unsafe" Version="6.7.2" />
+    <PackageVersion Include="DotNext.Net.Cluster" Version="6.7.2" />
     <PackageVersion Include="Ductus.FluentDocker" Version="2.85.0" />
     <PackageVersion Include="Ductus.FluentDocker.XUnit" Version="2.85.0" />
     <PackageVersion Include="DuckDB.NET.Data.Full" Version="1.5.0" />

--- a/src/KurrentDB.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/LegacyAuthorizationWithStreamAuthorizationDisabledProviderFactory.cs
+++ b/src/KurrentDB.Auth.LegacyAuthorizationWithStreamAuthorizationDisabled/LegacyAuthorizationWithStreamAuthorizationDisabledProviderFactory.cs
@@ -50,6 +50,8 @@ public class LegacyAuthorizationWithStreamAuthorizationDisabledProviderFactory :
 		policy.AllowAnonymous(Operations.Node.Gossip.Read);
 		policy.AllowAnonymous(Operations.Node.Gossip.ClientRead);
 		policy.Add(Operations.Node.Gossip.Update, isSystem);
+		policy.Add(Operations.Node.KontrolPlane.Access, isSystem);
+		policy.Add(Operations.Node.DataPlane.Access, isSystem);
 
 		policy.AddMatchAnyAssertion(Operations.Node.Shutdown, Grant.Allow, OperationsOrAdmins);
 		policy.AddMatchAnyAssertion(Operations.Node.MergeIndexes, Grant.Allow, OperationsOrAdmins);

--- a/src/KurrentDB.Common.Tests/Utils/NodeSslOptionsTests.cs
+++ b/src/KurrentDB.Common.Tests/Utils/NodeSslOptionsTests.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Net;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using KurrentDB.Common.Utils;
+
+namespace KurrentDB.Common.Tests.Utils;
+
+public class NodeSslOptionsTests {
+	[Fact]
+	public void targeted_options_name_the_peer_being_dialled() {
+		var options = NodeSslOptions.CreateTargetedClientOptions(
+			new DnsEndPoint("node1.example.com", 3111),
+			serverCertificateValidator: Accept,
+			clientCertificateSelector: NoCertificate,
+			enabledSslProtocols: NodeTlsPolicy.PinnedSslProtocols);
+
+		Assert.Equal("node1.example.com", options.TargetHost);
+	}
+
+	[Fact]
+	public void a_dns_discovered_peer_is_dialled_by_ip_and_may_present_the_cluster_name() {
+		string[] otherNames = [];
+		var options = NodeSslOptions.CreateTargetedClientOptions(
+			new IPWithClusterDnsEndPoint(IPAddress.Loopback, "cluster.example.com", 3111),
+			serverCertificateValidator: (_, _, _, names) => {
+				otherNames = names;
+				return (true, null!);
+			},
+			clientCertificateSelector: NoCertificate,
+			enabledSslProtocols: NodeTlsPolicy.PinnedSslProtocols);
+
+		// The address we dial is the resolved one, but the certificate names the cluster
+		Assert.Equal("127.0.0.1", options.TargetHost);
+
+		options.RemoteCertificateValidationCallback!(this, null, null, SslPolicyErrors.None);
+		Assert.Equal(["cluster.example.com"], otherNames);
+	}
+
+	// SocketsHttpHandler clones these per host and fills in the target host itself, so there is nothing
+	// here to name the peer. Anything else that dialled with these would not check the name at all.
+	[Fact]
+	public void untargeted_options_name_no_peer() {
+		var options = NodeSslOptions.CreateUntargetedClientOptions(
+			serverCertificateValidator: Accept,
+			clientCertificateSelector: NoCertificate,
+			additionalCertificateNames: null,
+			enabledSslProtocols: NodeTlsPolicy.SystemSslProtocols);
+
+		Assert.Null(options.TargetHost);
+	}
+
+	[Theory]
+	[InlineData(SslProtocols.None)]
+	[InlineData(SslProtocols.Tls12 | SslProtocols.Tls13)]
+	public void the_enabled_protocols_are_the_ones_asked_for(SslProtocols enabledSslProtocols) {
+		var options = NodeSslOptions.CreateTargetedClientOptions(
+			new DnsEndPoint("node1.example.com", 3111),
+			serverCertificateValidator: Accept,
+			clientCertificateSelector: NoCertificate,
+			enabledSslProtocols: enabledSslProtocols);
+
+		Assert.Equal(enabledSslProtocols, options.EnabledSslProtocols);
+	}
+
+	private static (bool, string) Accept(
+		X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors, string[] otherNames)
+		=> (true, null!);
+
+	private static X509Certificate NoCertificate() => null!;
+}

--- a/src/KurrentDB.Common/Utils/CertificateExtensions.cs
+++ b/src/KurrentDB.Common/Utils/CertificateExtensions.cs
@@ -188,6 +188,11 @@ public static class CertificateExtensions {
 	}
 
 	public static IDisposable ConvertToCertificate2(this X509Certificate certificate, out X509Certificate2 certificate2) {
+		if (certificate is null) {
+			certificate2 = null;
+			return null;
+		}
+
 		if (certificate is X509Certificate2 c2) {
 			certificate2 = c2;
 			return null;

--- a/src/KurrentDB.Common/Utils/NodeSslOptions.cs
+++ b/src/KurrentDB.Common/Utils/NodeSslOptions.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+
+namespace KurrentDB.Common.Utils;
+
+/// <summary>
+/// TLS options for talking to other nodes in the cluster, whoever is doing the talking: the node's
+/// gRPC clients build a <see cref="System.Net.Http.SocketsHttpHandler"/> around the client options,
+/// and the Kontrol Plane's Raft transport takes both halves directly.
+/// </summary>
+public static class NodeSslOptions {
+	/// <summary>
+	/// Options for connecting to another node: present this node's certificate, and validate the
+	/// certificate the peer presents.
+	/// </summary>
+	/// <param name="additionalCertificateNames">
+	/// Names the peer's certificate may carry in addition to the address we dialled, from
+	/// <see cref="EndpointExtensions.GetOtherNames"/>. Only DNS-discovered endpoints have any, so
+	/// null is the usual value for statically configured peers.
+	/// </param>
+	/// <param name="enabledSslProtocols">
+	/// <see cref="NodeTlsPolicy.PinnedSslProtocols"/> or
+	/// <see cref="NodeTlsPolicy.SystemSslProtocols"/>. Explicit because the two are a real
+	/// choice: pinning excludes a protocol the system would allow, and offers one it has disabled.
+	/// </param>
+	public static SslClientAuthenticationOptions CreateClientOptions(
+		CertificateDelegates.ServerCertificateValidator serverCertificateValidator,
+		Func<X509Certificate> clientCertificateSelector,
+		string[] additionalCertificateNames,
+		SslProtocols enabledSslProtocols) => new() {
+
+		EnabledSslProtocols = enabledSslProtocols,
+		CertificateRevocationCheckMode = NodeTlsPolicy.CertificateRevocationCheckMode,
+		RemoteCertificateValidationCallback = NodeTlsPolicy.ForServerCertificate(
+			serverCertificateValidator,
+			() => additionalCertificateNames),
+		LocalCertificateSelectionCallback = (_, _, _, _, _) => clientCertificateSelector(),
+	};
+
+	/// <summary>
+	/// Options for accepting a connection from another node: present this node's certificate, and
+	/// require and validate the certificate the peer presents.
+	/// </summary>
+	public static SslServerAuthenticationOptions CreateServerOptions(
+		CertificateDelegates.ClientCertificateValidator clientCertificateValidator,
+		Func<X509Certificate> serverCertificateSelector) => new() {
+
+		ClientCertificateRequired = true,
+		EnabledSslProtocols = NodeTlsPolicy.PinnedSslProtocols,
+		CertificateRevocationCheckMode = NodeTlsPolicy.CertificateRevocationCheckMode,
+		AllowRenegotiation = NodeTlsPolicy.AllowRenegotiation,
+		ServerCertificateSelectionCallback = (_, _) => serverCertificateSelector(),
+		RemoteCertificateValidationCallback = NodeTlsPolicy.ForClientCertificate(clientCertificateValidator),
+	};
+}

--- a/src/KurrentDB.Common/Utils/NodeSslOptions.cs
+++ b/src/KurrentDB.Common/Utils/NodeSslOptions.cs
@@ -2,6 +2,7 @@
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
 using System;
+using System.Net;
 using System.Net.Security;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
@@ -15,11 +16,10 @@ namespace KurrentDB.Common.Utils;
 /// </summary>
 public static class NodeSslOptions {
 	/// <summary>
-	/// Options for connecting to another node: present this node's certificate, and validate the
-	/// certificate the peer presents.
+	/// Options for connecting to another node, for transports that set the target host themselves.
 	/// </summary>
 	/// <param name="additionalCertificateNames">
-	/// Names the peer's certificate may carry in addition to the address we dialled, from
+	/// Names the peer's certificate may carry in addition to the target host, from
 	/// <see cref="EndpointExtensions.GetOtherNames"/>. Only DNS-discovered endpoints have any, so
 	/// null is the usual value for statically configured peers.
 	/// </param>
@@ -28,7 +28,7 @@ public static class NodeSslOptions {
 	/// <see cref="NodeTlsPolicy.SystemSslProtocols"/>. Explicit because the two are a real
 	/// choice: pinning excludes a protocol the system would allow, and offers one it has disabled.
 	/// </param>
-	public static SslClientAuthenticationOptions CreateClientOptions(
+	public static SslClientAuthenticationOptions CreateUntargetedClientOptions(
 		CertificateDelegates.ServerCertificateValidator serverCertificateValidator,
 		Func<X509Certificate> clientCertificateSelector,
 		string[] additionalCertificateNames,
@@ -41,6 +41,27 @@ public static class NodeSslOptions {
 			() => additionalCertificateNames),
 		LocalCertificateSelectionCallback = (_, _, _, _, _) => clientCertificateSelector(),
 	};
+
+	/// <summary>
+	/// Options for connecting to one particular node, whose certificate is expected to name it.
+	/// </summary>
+	/// <param name="target">The address being dialled. Its host is the name the peer's certificate
+	/// has to carry, and its other names are the ones it may carry instead.</param>
+	public static SslClientAuthenticationOptions CreateTargetedClientOptions(
+		EndPoint target,
+		CertificateDelegates.ServerCertificateValidator serverCertificateValidator,
+		Func<X509Certificate> clientCertificateSelector,
+		SslProtocols enabledSslProtocols) {
+
+		var options = CreateUntargetedClientOptions(
+			serverCertificateValidator: serverCertificateValidator,
+			clientCertificateSelector: clientCertificateSelector,
+			additionalCertificateNames: target.GetOtherNames(),
+			enabledSslProtocols: enabledSslProtocols);
+
+		options.TargetHost = target.GetHost();
+		return options;
+	}
 
 	/// <summary>
 	/// Options for accepting a connection from another node: present this node's certificate, and

--- a/src/KurrentDB.Common/Utils/NodeTlsPolicy.cs
+++ b/src/KurrentDB.Common/Utils/NodeTlsPolicy.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using Serilog;
+
+namespace KurrentDB.Common.Utils;
+
+/// <summary>
+/// The TLS settings this node applies to connections it makes to, or accepts from, other nodes in
+/// the cluster, whichever transport carries them: the internal TCP replication channel, the node's
+/// gRPC clients, and the Kontrol Plane's Raft transport.
+/// </summary>
+/// <remarks>
+/// Here rather than in each handshake so that the paths cannot drift apart - in particular so that
+/// no one path can quietly end up accepting an older protocol than the others, or validating a peer
+/// certificate on different terms. What legitimately differs between handshakes - which protocols
+/// are advertised, whether a peer certificate is required - is still chosen per handshake, but from
+/// the values named here.
+/// </remarks>
+public static class NodeTlsPolicy {
+	private static readonly ILogger Log = Serilog.Log.ForContext(typeof(NodeTlsPolicy));
+
+	/// <summary>
+	/// The protocols to offer where we control both ends of the connection and can require them.
+	/// </summary>
+	public const SslProtocols PinnedSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13;
+
+	/// <summary>
+	/// Defers the choice to the machine's own crypto policy, so that an operator disabling a protocol
+	/// system-wide is obeyed and a newer one is picked up without a code change. The right choice for
+	/// listeners and clients that other people's software connects to or through.
+	/// </summary>
+	public const SslProtocols SystemSslProtocols = SslProtocols.None;
+
+	/// <summary>
+	/// Node certificates are validated against the configured intermediates and trusted roots.
+	/// Revocation lists are not consulted, since nodes are not expected to be able to reach them.
+	/// </summary>
+	public const X509RevocationMode CertificateRevocationCheckMode = X509RevocationMode.NoCheck;
+
+	/// <summary>
+	/// The same policy as <see cref="CertificateRevocationCheckMode"/>, for the authentication
+	/// overloads that take a flag rather than a mode.
+	/// </summary>
+	public const bool CheckCertificateRevocation = false;
+
+	public const bool AllowRenegotiation = false;
+
+	/// <summary>
+	/// Validates the certificate presented by the node we have connected to.
+	/// </summary>
+	/// <param name="additionalCertificateNames">
+	/// Names the peer's certificate may carry besides the address we dialled. Resolved per callback,
+	/// because callers such as HttpSendService follow leadership as it moves.
+	/// </param>
+	public static RemoteCertificateValidationCallback ForServerCertificate(
+		CertificateDelegates.ServerCertificateValidator validator,
+		Func<string[]> additionalCertificateNames) =>
+
+		(_, certificate, chain, sslPolicyErrors) => {
+			var (isValid, error) = validator(certificate, chain, sslPolicyErrors, additionalCertificateNames());
+			if (!isValid && error != null) {
+				Log.Error("Server certificate validation error: {e}", error);
+			}
+
+			return isValid;
+		};
+
+	/// <summary>
+	/// Validates the certificate presented by whoever has connected to us.
+	/// </summary>
+	public static RemoteCertificateValidationCallback ForClientCertificate(
+		CertificateDelegates.ClientCertificateValidator validator) =>
+
+		(_, certificate, chain, sslPolicyErrors) => {
+			var (isValid, error) = validator(certificate, chain, sslPolicyErrors);
+			if (!isValid && error != null) {
+				Log.Error("Client certificate validation error: {e}", error);
+			}
+
+			return isValid;
+		};
+}

--- a/src/KurrentDB.Core.Testing/Helpers/MiniClusterNode.cs
+++ b/src/KurrentDB.Core.Testing/Helpers/MiniClusterNode.cs
@@ -70,6 +70,10 @@ public class MiniClusterNode<TLogFormat, TStreamId> {
 		bool enableTrustedAuth = false, int memTableSize = 1000, bool inMemDb = true,
 		bool disableFlushToDisk = false, bool readOnlyReplica = false, int nodePriority = 0,
 		bool disableTls = false, string clusterSecret = "",
+		bool kontrolPlaneMode = false,
+		int kontrollerPort = 0,
+		EndPoint[] kontrolPlaneBootstrapSeed = null,
+		int clusterSize = 3,
 		string intHostAdvertiseAs = null, IExpiryStrategy expiryStrategy = null) {
 		if (RuntimeInformation.IsOSX) {
 			AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport",
@@ -111,7 +115,7 @@ public class MiniClusterNode<TLogFormat, TStreamId> {
 				DiscoverViaDns = false,
 				ClusterDns = string.Empty,
 				GossipSeed = gossipSeeds,
-				ClusterSize = 3,
+				ClusterSize = clusterSize,
 				NodePriority = nodePriority,
 				ClusterSecret = clusterSecret,
 				GossipIntervalMs = 2_000,
@@ -151,6 +155,16 @@ public class MiniClusterNode<TLogFormat, TStreamId> {
 			},
 			Projection = new() {
 				RunProjections = ProjectionType.None
+			},
+			// A node in Kontrol Plane mode is both planes: it runs a Kontroller and has its own leader
+			// appointed by the Kontrol Plane. Both flags off is the legacy elections mechanism, which is
+			// what every other cluster test wants. No KontrolPlaneApiSeed is needed because a node that
+			// runs a Kontroller bootstraps against its own API and is redirected to the leader.
+			KontrolPlane = new() {
+				IsKontrolPlaneNode = kontrolPlaneMode,
+				IsDataPlaneNode = kontrolPlaneMode,
+				KontrollerPort = kontrollerPort,
+				KontrolPlaneBootstrapSeed = kontrolPlaneBootstrapSeed ?? [],
 			},
 			PlugableComponents = subsystems
 		};

--- a/src/KurrentDB.Core.Testing/Helpers/MiniNode.cs
+++ b/src/KurrentDB.Core.Testing/Helpers/MiniNode.cs
@@ -101,6 +101,7 @@ public class MiniNode<TLogFormat, TStreamId> : MiniNode, IAsyncDisposable {
 		int maxAppendEventSize = TFConsts.EffectiveMaxLogRecordSize,
 		bool disableTls = false,
 		bool insecure = false,
+		bool kontrolPlaneMode = false,
 		SecondaryIndexReaders secondaryIndexReaders = null) {
 
 		_httpClientTimeoutSec = httpClientTimeoutSec;
@@ -113,6 +114,7 @@ public class MiniNode<TLogFormat, TStreamId> : MiniNode, IAsyncDisposable {
 		int extTcpPort = tcpPort ?? PortsHelper.GetAvailablePort(ip);
 		int httpEndPointPort = httpPort ?? PortsHelper.GetAvailablePort(ip);
 		int intTcpPort = PortsHelper.GetAvailablePort(ip);
+		int kontrollerPort = PortsHelper.GetAvailablePort(ip);
 
 		if (string.IsNullOrEmpty(dbPath)) {
 			DbPath = Path.Combine(pathname,
@@ -145,11 +147,16 @@ public class MiniNode<TLogFormat, TStreamId> : MiniNode, IAsyncDisposable {
 				EnableAtomPubOverHttp = true
 			},
 			Cluster = new() {
-				ClusterSecret = disableTls && !insecure ? "we enjoy network partitions for the peace and quiet" : "",
+				ClusterSecret = disableTls && !insecure ? "we-enjoy-network-partitions-for-the-peace-and-quiet" : "",
 				DiscoverViaDns = false,
 				ReadOnlyReplica = isReadOnlyReplica,
 				Archiver = false,
 				StreamInfoCacheCapacity = 10_000
+			},
+			KontrolPlane = new() {
+				IsKontrolPlaneNode = kontrolPlaneMode,
+				IsDataPlaneNode = kontrolPlaneMode,
+				KontrollerPort = kontrollerPort,
 			},
 			Database = new() {
 				ChunkSize = chunkSize,

--- a/src/KurrentDB.Core.Tests/Authorization/LegacyPolicyVerification.cs
+++ b/src/KurrentDB.Core.Tests/Authorization/LegacyPolicyVerification.cs
@@ -370,6 +370,8 @@ public class LegacyPolicyVerification {
 			yield return CreateOperation(Operations.Node.Elections.LeaderIsResigning);
 			yield return CreateOperation(Operations.Node.Elections.LeaderIsResigningOk);
 			yield return CreateOperation(Operations.Node.Gossip.Read);
+			yield return CreateOperation(Operations.Node.KontrolPlane.Access);
+			yield return CreateOperation(Operations.Node.DataPlane.Access);
 		}
 
 		IEnumerable<(Operation, string, StorageMessage.EffectiveAcl)> AdminOperations() {

--- a/src/KurrentDB.Core.Tests/Integration/cluster_in_kontrol_plane_mode.cs
+++ b/src/KurrentDB.Core.Tests/Integration/cluster_in_kontrol_plane_mode.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Linq;
+using System.Net;
+using KurrentDB.Core.Data;
+using KurrentDB.Core.Tests.Helpers;
+using NUnit.Framework;
+
+namespace KurrentDB.Core.Tests.Integration;
+
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+public class cluster_in_kontrol_plane_mode<TLogFormat, TStreamId> : specification_with_cluster<TLogFormat, TStreamId> {
+	// In Kontrol Plane mode the elections service is not constructed at all, so a cluster that reaches
+	// Leader and Follower can only have got there by being appointed.
+	[Test]
+	public void the_kontrol_plane_appoints_one_leader_and_the_rest_follow() {
+		AssertEx.IsOrBecomesTrue(
+			() => _nodes.Count(x => x.NodeState is VNodeState.Leader) == 1
+			   && _nodes.Count(x => x.NodeState is VNodeState.Follower) == 2,
+			timeout: TimeSpan.FromSeconds(60),
+			onFail: () => {
+				TestContext.Out.WriteLine($"Node states: {States()}");
+				MiniNodeLogging.WriteLogs();
+			},
+			msg: "Expected one leader and two followers");
+	}
+
+	protected override MiniClusterNode<TLogFormat, TStreamId> CreateNode(
+		int index, Endpoints endpoints, EndPoint[] gossipSeeds, bool wait = true) => new(
+			pathname: PathName,
+			debugIndex: index,
+			internalTcp: endpoints.InternalTcp,
+			externalTcp: endpoints.ExternalTcp,
+			httpEndPoint: endpoints.HttpEndPoint,
+			subsystems: [],
+			gossipSeeds: gossipSeeds,
+			inMemDb: false,
+			kontrolPlaneMode: true,
+			kontrollerPort: endpoints.Kontroller.Port,
+			kontrolPlaneBootstrapSeed: _nodeEndpoints
+				.Where((_, i) => i != index)
+				.Select(x => (EndPoint)x.Kontroller)
+				.ToArray());
+
+	private string States() => string.Join(", ", _nodes.Select(x => x.NodeState));
+}

--- a/src/KurrentDB.Core.Tests/Integration/single_node_in_kontrol_plane_mode.cs
+++ b/src/KurrentDB.Core.Tests/Integration/single_node_in_kontrol_plane_mode.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using KurrentDB.Core.Bus;
+using KurrentDB.Core.Data;
+using KurrentDB.Core.Messages;
+using KurrentDB.Core.Tests.Helpers;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+
+namespace KurrentDB.Core.Tests.Integration;
+
+// MiniClusterNode rather than MiniNode: MiniNode serves HTTP through an in-memory TestServer, and the
+// Kontrol Plane dials its own gRPC API over a real socket, so there would be nothing listening.
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+public class single_node_in_kontrol_plane_mode<TLogFormat, TStreamId> : SpecificationWithDirectoryPerTestFixture {
+	private MiniClusterNode<TLogFormat, TStreamId> _node;
+	private bool _electionsRan;
+
+	[OneTimeSetUp]
+	public override async Task TestFixtureSetUp() {
+		await base.TestFixtureSetUp();
+		MiniNodeLogging.Setup();
+
+		try {
+			var ip = IPAddress.Loopback;
+			_node = new MiniClusterNode<TLogFormat, TStreamId>(
+				PathName,
+				debugIndex: 0,
+				internalTcp: new(ip, PortsHelper.GetAvailablePort(ip)),
+				externalTcp: new(ip, PortsHelper.GetAvailablePort(ip)),
+				httpEndPoint: new(ip, PortsHelper.GetAvailablePort(ip)),
+				gossipSeeds: [],
+				// Validation rejects an in-memory database for a node taking part in either plane
+				inMemDb: false,
+				kontrolPlaneMode: true,
+				kontrollerPort: PortsHelper.GetAvailablePort(ip),
+				// A cluster of one is its own Kontrol Plane, so it cold starts and needs no seed
+				clusterSize: 1);
+
+			_node.Node.MainBus.Subscribe(new AdHocHandler<ElectionMessage.ElectionsDone>(_ =>
+				_electionsRan = true));
+
+			await _node.Start();
+
+			// Started completes when a node becomes leader/follower/ror
+			await _node.Started.WithTimeout(TimeSpan.FromMinutes(1), onFail: MiniNodeLogging.WriteLogs);
+		} catch {
+			MiniNodeLogging.WriteLogs();
+			throw;
+		}
+	}
+
+	[Test]
+	public void the_node_is_appointed_leader() =>
+		Assert.AreEqual(VNodeState.Leader, _node.NodeState);
+
+	// The observable difference from legacy mode: a single node on elections still holds one and elects
+	// itself, whereas here the node's own Kontrol Plane appoints it.
+	[Test]
+	public void no_election_is_held() =>
+		Assert.IsFalse(_electionsRan, "An election was held, so the node is not using the Kontrol Plane");
+
+	// Proves the appointed leader can actually write, rather than only reporting that it leads
+	[Test]
+	public async Task the_admin_user_is_created() =>
+		await _node.AdminUserCreated.WithTimeout(TimeSpan.FromMinutes(1), onFail: MiniNodeLogging.WriteLogs);
+
+	[TearDown]
+	public void AfterEachTest() {
+		if (TestContext.CurrentContext.Result.Outcome.Status is TestStatus.Failed)
+			MiniNodeLogging.WriteLogs();
+	}
+
+	[OneTimeTearDown]
+	public override async Task TestFixtureTearDown() {
+		if (_node is not null)
+			await _node.Shutdown();
+
+		MiniNodeLogging.Clear();
+		await base.TestFixtureTearDown();
+	}
+}

--- a/src/KurrentDB.Core.Tests/Integration/specification_with_cluster.cs
+++ b/src/KurrentDB.Core.Tests/Integration/specification_with_cluster.cs
@@ -27,11 +27,13 @@ public abstract class specification_with_cluster<TLogFormat, TStreamId> : Specif
 		public readonly IPEndPoint InternalTcp;
 		public readonly IPEndPoint ExternalTcp;
 		public readonly IPEndPoint HttpEndPoint;
+		public readonly IPEndPoint Kontroller;
 
 		public IEnumerable<int> Ports() {
 			yield return InternalTcp.Port;
 			yield return ExternalTcp.Port;
 			yield return HttpEndPoint.Port;
+			yield return Kontroller.Port;
 		}
 
 		private readonly List<Socket> _sockets;
@@ -53,9 +55,14 @@ public abstract class specification_with_cluster<TLogFormat, TStreamId> : Specif
 			httpEndPoint.Bind(defaultLoopBack);
 			_sockets.Add(httpEndPoint);
 
+			var kontroller = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+			kontroller.Bind(defaultLoopBack);
+			_sockets.Add(kontroller);
+
 			InternalTcp = CopyEndpoint((IPEndPoint)internalTcp.LocalEndPoint);
 			ExternalTcp = CopyEndpoint((IPEndPoint)externalTcp.LocalEndPoint);
 			HttpEndPoint = CopyEndpoint((IPEndPoint)httpEndPoint.LocalEndPoint);
+			Kontroller = CopyEndpoint((IPEndPoint)kontroller.LocalEndPoint);
 		}
 
 		public void DisposeSockets() {

--- a/src/KurrentDB.Core.Tests/Services/GossipService/NodeGossipServiceTests.cs
+++ b/src/KurrentDB.Core.Tests/Services/GossipService/NodeGossipServiceTests.cs
@@ -917,6 +917,32 @@ public class when_elections_are_done : NodeGossipServiceTestFixture {
 	}
 }
 
+public class when_a_leader_is_appointed : NodeGossipServiceTestFixture {
+	protected override Message[] Given() =>
+		GivenSystemInitializedWithKnownGossipSeedSources(
+			new GossipMessage.GossipReceived(new NoopEnvelope(), new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow,
+						nodeState: VNodeState.Initializing),
+					MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow, nodeState: VNodeState.Initializing),
+					MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow,
+						nodeState: VNodeState.Initializing)),
+				_nodeTwo.HttpEndPoint)
+		);
+
+	protected override Message When() =>
+		new ElectionMessage.LeaderAppointed(0,
+			MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow, nodeState: VNodeState.Leader).ToLite());
+
+	[Test]
+	public void should_set_leader_node_and_other_nodes_to_unknown() {
+		ExpectMessages(
+			new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoForVNode(_currentNode, _timeProvider.UtcNow, nodeState: VNodeState.Unknown),
+				MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow, nodeState: VNodeState.Leader),
+				MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow, nodeState: VNodeState.Unknown))));
+	}
+}
+
 public class when_updating_node_priority : NodeGossipServiceTestFixture {
 	private readonly int _nodePriority = new Random().Next();
 	protected override Message[] Given() => GivenSystemInitializedWithKnownGossipSeedSources();

--- a/src/KurrentDB.Core.Tests/Services/VNode/InaugurationManager/given_waiting_for_chaser_after_leader_appointed.cs
+++ b/src/KurrentDB.Core.Tests/Services/VNode/InaugurationManager/given_waiting_for_chaser_after_leader_appointed.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using KurrentDB.Core.Messages;
+using NUnit.Framework;
+
+namespace KurrentDB.Core.Tests.Services.VNode.InaugurationManager;
+
+// As given_waiting_for_chaser, but the leader was appointed by the Kontrol Plane rather than
+// elected. The epoch to write comes from a different field on a different message, so it is worth
+// pinning separately.
+[TestFixture]
+public class given_waiting_for_chaser_after_leader_appointed : InaugurationManagerTests {
+	protected override void Given() {
+		_sut.Handle(new ElectionMessage.LeaderAppointed(_epochNumber, _leader.ToLite()));
+		_sut.Handle(new SystemMessage.BecomePreLeader(_correlationId1));
+		_publisher.Messages.Clear();
+	}
+
+	[Test]
+	public void when_chaser_caught_up_should_write_the_appointed_epoch() {
+		When(new SystemMessage.ChaserCaughtUp(_correlationId1));
+		Assert.AreEqual(1, _publisher.Messages.Count);
+		var writeEpoch = AssertEx.IsType<SystemMessage.WriteEpoch>(_publisher.Messages[0]);
+		Assert.AreEqual(_epochNumber, writeEpoch.EpochNumber);
+	}
+
+	[Test]
+	public void when_chaser_caught_up_with_unknown_correlation_id() {
+		When(new SystemMessage.ChaserCaughtUp(_correlationId2));
+		Assert.IsEmpty(_publisher.Messages);
+	}
+
+	[Test]
+	public void when_become_other_node_state() {
+		When(new SystemMessage.BecomeUnknown(Guid.NewGuid()));
+		AssertInitial();
+	}
+}

--- a/src/KurrentDB.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsValidatorTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsValidatorTests.cs
@@ -321,6 +321,31 @@ public class ClusterVNodeOptionsValidatorTests {
 		Validate(options, expectedValid);
 	}
 
+	[Theory]
+	[InlineData("secret", true)]
+	[InlineData("a-perfectly.ordinary_secret~09+/=", true)]
+	[InlineData("MTI0NTY3ODkw+/aA==", true)]   // base64, the shape Basic auth uses
+	[InlineData("a=b", true)]                  // a name=value pair is legal too
+	[InlineData("sdf,", false)]
+	[InlineData("ab,cd", false)]
+	[InlineData("two words", false)]
+	[InlineData("trailing ", false)]
+	[InlineData("quote\"inside", false)]
+	[InlineData("new\nline", false)]
+	public void cluster_secret_characters_are_restricted(string clusterSecret, bool expectedValid) {
+		var options = new ClusterVNodeOptions {
+			Application = new() {
+				DisableTls = true,
+			},
+			Cluster = new() {
+				ClusterSize = 3,
+				ClusterSecret = clusterSecret,
+			},
+		};
+
+		Validate(options, expectedValid);
+	}
+
 	private static readonly EndPoint[] Seed = [new IPEndPoint(IPAddress.Loopback, 3111)];
 
 	private static void Validate(ClusterVNodeOptions options, bool expectedValid) {

--- a/src/KurrentDB.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsValidatorTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsValidatorTests.cs
@@ -2,6 +2,7 @@
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
 using System;
+using System.Net;
 using KurrentDB.Common.Exceptions;
 using Xunit;
 
@@ -157,6 +158,178 @@ public class ClusterVNodeOptionsValidatorTests {
 			When();
 		} else {
 			Assert.Throws<ApplicationInitializationException>(When);
+		}
+	}
+
+	[Theory]
+	// A read-only replica takes no part in electing a leader, so it cannot be a Kontrol Plane node
+	[InlineData(true, true, true, false)]
+	// but it can be a Data Plane node, which is how a replica joins a Kontrol Plane cluster
+	[InlineData(true, false, true, true)]
+	// and a regular node is either both or neither
+	[InlineData(false, true, true, true)]
+	[InlineData(false, false, false, true)]
+	public void read_only_replica_cannot_be_a_kontrol_plane_node(
+		bool readOnlyReplica, bool isKontrolPlaneNode, bool isDataPlaneNode, bool expectedValid) {
+		var options = new ClusterVNodeOptions {
+			Cluster = new() {
+				ClusterSize = 3,
+				ReadOnlyReplica = readOnlyReplica,
+			},
+			KontrolPlane = new() {
+				IsKontrolPlaneNode = isKontrolPlaneNode,
+				IsDataPlaneNode = isDataPlaneNode,
+				KontrolPlaneBootstrapSeed = Seed,
+				KontrolPlaneApiSeed = Seed,
+			},
+		};
+
+		Validate(options, expectedValid);
+	}
+
+	[Theory]
+	// Both planes, or neither
+	[InlineData(true, true, false, true)]
+	[InlineData(false, false, false, true)]
+	// One without the other is not supported yet
+	[InlineData(true, false, false, false)]
+	[InlineData(false, true, false, false)]
+	// except on a read-only replica, which can only ever be a Data Plane node
+	[InlineData(false, true, true, true)]
+	public void a_node_participates_in_both_planes_or_neither(
+		bool isKontrolPlaneNode, bool isDataPlaneNode, bool readOnlyReplica, bool expectedValid) {
+		var options = new ClusterVNodeOptions {
+			Cluster = new() {
+				ClusterSize = 3,
+				ReadOnlyReplica = readOnlyReplica,
+			},
+			KontrolPlane = new() {
+				IsKontrolPlaneNode = isKontrolPlaneNode,
+				IsDataPlaneNode = isDataPlaneNode,
+				KontrolPlaneBootstrapSeed = Seed,
+				KontrolPlaneApiSeed = Seed,
+			},
+		};
+
+		Validate(options, expectedValid);
+	}
+
+	[Theory]
+	// Without a seed the Kontrol Plane nodes cannot find each other
+	[InlineData(3, false, false)]
+	[InlineData(3, true, true)]
+	// A single node is its own Kontrol Plane, so it needs no seed
+	[InlineData(1, false, true)]
+	[InlineData(1, true, true)]
+	public void kontrol_plane_node_in_a_cluster_requires_a_bootstrap_seed(
+		int clusterSize, bool hasBootstrapSeed, bool expectedValid) {
+		var options = new ClusterVNodeOptions {
+			Cluster = new() {
+				ClusterSize = clusterSize,
+			},
+			KontrolPlane = new() {
+				IsKontrolPlaneNode = true,
+				IsDataPlaneNode = true,
+				KontrolPlaneBootstrapSeed = hasBootstrapSeed ? Seed : [],
+			},
+		};
+
+		Validate(options, expectedValid);
+	}
+
+	[Theory]
+	// A replica runs no Kontroller, so it has nothing to bootstrap against but the seed
+	[InlineData(false, false)]
+	[InlineData(true, true)]
+	public void read_only_replica_requires_an_api_seed(bool hasApiSeed, bool expectedValid) {
+		var options = new ClusterVNodeOptions {
+			Cluster = new() {
+				ClusterSize = 3,
+				ReadOnlyReplica = true,
+			},
+			KontrolPlane = new() {
+				IsDataPlaneNode = true,
+				KontrolPlaneApiSeed = hasApiSeed ? Seed : [],
+			},
+		};
+
+		Validate(options, expectedValid);
+	}
+
+	[Theory]
+	[InlineData(5000, 6000, true)]
+	[InlineData(6000, 6000, false)]
+	[InlineData(7000, 6000, false)]
+	public void election_timeout_lower_bound_must_be_below_the_upper_bound(
+		int lowerMs, int upperMs, bool expectedValid) {
+		var options = new ClusterVNodeOptions {
+			KontrolPlane = new() {
+				KontrolPlaneLowerElectionTimeoutMs = lowerMs,
+				KontrolPlaneUpperElectionTimeoutMs = upperMs,
+			},
+		};
+
+		Validate(options, expectedValid);
+	}
+
+	[Theory]
+	[InlineData(0, 6000, false)]
+	[InlineData(-1, 6000, false)]
+	[InlineData(5000, 0, false)]
+	[InlineData(5000, 6000, true)]
+	public void timeouts_must_be_positive(int lowerMs, int appointmentMs, bool expectedValid) {
+		var options = new ClusterVNodeOptions {
+			KontrolPlane = new() {
+				KontrolPlaneLowerElectionTimeoutMs = lowerMs,
+				KontrolPlaneUpperElectionTimeoutMs = 10_000,
+				KontrolPlaneAppointmentTimeoutMs = appointmentMs,
+			},
+		};
+
+		Validate(options, expectedValid);
+	}
+
+	[Theory]
+	// The Kontrol Plane keeps a durable record of a node's epoch and identity, so a node taking part in
+	// either plane cannot discard its database on restart
+	[InlineData(true, true, true, false)]
+	// A read-only replica takes part too: it announces itself and is recorded like any other node
+	[InlineData(true, false, true, false)]
+	// A node on legacy elections is in no such record anywhere, so it may
+	[InlineData(true, false, false, true)]
+	// And a persistent database is fine in either plane
+	[InlineData(false, true, true, true)]
+	public void cluster_using_kontrol_plane_requires_a_persistent_database(
+		bool memDb, bool isKontrolPlaneNode, bool isDataPlaneNode, bool expectedValid) {
+		var options = new ClusterVNodeOptions {
+			Cluster = new() {
+				ClusterSize = 3,
+				// The only node that can be a Data Plane node without being a Kontrol Plane one
+				ReadOnlyReplica = isDataPlaneNode && !isKontrolPlaneNode,
+			},
+			Database = new() {
+				MemDb = memDb,
+			},
+			KontrolPlane = new() {
+				IsKontrolPlaneNode = isKontrolPlaneNode,
+				IsDataPlaneNode = isDataPlaneNode,
+				KontrolPlaneBootstrapSeed = Seed,
+				KontrolPlaneApiSeed = Seed,
+			},
+		};
+
+		Validate(options, expectedValid);
+	}
+
+	private static readonly EndPoint[] Seed = [new IPEndPoint(IPAddress.Loopback, 3111)];
+
+	private static void Validate(ClusterVNodeOptions options, bool expectedValid) {
+		void When() => ClusterVNodeOptionsValidator.Validate(options);
+
+		if (expectedValid) {
+			When();
+		} else {
+			Assert.Throws<InvalidConfigurationException>(When);
 		}
 	}
 }

--- a/src/KurrentDB.Core.XUnit.Tests/Configuration/Sources/DefaultValuesConfigurationSourceTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Configuration/Sources/DefaultValuesConfigurationSourceTests.cs
@@ -14,7 +14,10 @@ public class DefaultValuesConfigurationSourceTests {
 	public void Adds() {
 		// Arrange
 		var defaults = ClusterVNodeOptions.DefaultValues
-			.Where(x => x.Key is not nameof(ClusterVNodeOptions.ClusterOptions.GossipSeed))
+			.Where(x => x.Key
+				is not nameof(ClusterVNodeOptions.ClusterOptions.GossipSeed)
+				and not nameof(ClusterVNodeOptions.KontrolPlaneOptions.KontrolPlaneBootstrapSeed)
+				and not nameof(ClusterVNodeOptions.KontrolPlaneOptions.KontrolPlaneApiSeed))
 			.OrderBy(x => x.Key).ToList();
 
 		// Act

--- a/src/KurrentDB.Core.XUnit.Tests/Data/VNodeStateExtensionsTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Data/VNodeStateExtensionsTests.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using KurrentDB.Core.Data;
+using Xunit;
+
+namespace KurrentDB.Core.XUnit.Tests.Data;
+
+public class VNodeStateExtensionsTests {
+	// Every state, and what each predicate says about it. Exhaustive on purpose: adding a VNodeState
+	// without classifying it here fails all_states_are_classified below, which is the point. The
+	// Kontrol Plane's fence depends on the answer - a state wrongly reported as not replicating would
+	// be answered as frozen without the node having stopped.
+	private static readonly Dictionary<VNodeState, (bool IsReplica, bool ToOtherNodes, bool FromLeader)> Expected = new() {
+		[VNodeState.Initializing] = (false, false, false),
+		[VNodeState.DiscoverLeader] = (false, false, false),
+		[VNodeState.Unknown] = (false, false, false),
+		[VNodeState.PreReplica] = (false, false, true),
+		[VNodeState.CatchingUp] = (true, false, true),
+		[VNodeState.Clone] = (true, false, true),
+		[VNodeState.Follower] = (true, false, true),
+		[VNodeState.PreLeader] = (false, true, false),
+		[VNodeState.Leader] = (false, true, false),
+		[VNodeState.Manager] = (false, false, false),
+		[VNodeState.ShuttingDown] = (false, false, false),
+		[VNodeState.Shutdown] = (false, false, false),
+		[VNodeState.ReadOnlyLeaderless] = (false, false, false),
+		[VNodeState.PreReadOnlyReplica] = (false, false, true),
+		[VNodeState.ReadOnlyReplica] = (true, false, true),
+		[VNodeState.ResigningLeader] = (false, true, false),
+	};
+
+	public static TheoryData<VNodeState> States {
+		get {
+			var data = new TheoryData<VNodeState>();
+			foreach (var state in Expected.Keys)
+				data.Add(state);
+
+			return data;
+		}
+	}
+
+	[Theory]
+	[MemberData(nameof(States))]
+	public void classifies_each_state(VNodeState state) {
+		var expected = Expected[state];
+
+		Assert.Equal(expected.IsReplica, state.IsReplica());
+		Assert.Equal(expected.ToOtherNodes, state.CanReplicateToOtherNodes());
+		Assert.Equal(expected.FromLeader, state.CanReplicateFromLeader());
+	}
+
+	[Fact]
+	public void all_states_are_classified() {
+		// MaxValue aliases ResigningLeader, hence Distinct.
+		var declared = Enum.GetValues<VNodeState>().Distinct().ToHashSet();
+
+		Assert.Equal(declared, Expected.Keys.ToHashSet());
+	}
+
+	[Theory]
+	[MemberData(nameof(States))]
+	public void no_state_replicates_in_both_directions(VNodeState state) {
+		// The leadership edge in ClusterVNodeController's State setter watches only
+		// CanReplicateToOtherNodes. A state that was both would end leadership while the node was
+		// still receiving replication.
+		Assert.False(state.CanReplicateToOtherNodes() && state.CanReplicateFromLeader());
+	}
+
+	[Theory]
+	[MemberData(nameof(States))]
+	public void replicas_receive_replication(VNodeState state) {
+		// IsReplica is the subset of CanReplicateFromLeader that has finished subscribing, so it
+		// cannot contain a state that does not replicate from the leader at all.
+		if (state.IsReplica())
+			Assert.True(state.CanReplicateFromLeader());
+	}
+}

--- a/src/KurrentDB.Core.XUnit.Tests/Metrics/ElectionsCounterTrackerTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Metrics/ElectionsCounterTrackerTests.cs
@@ -17,6 +17,7 @@ namespace KurrentDB.Core.XUnit.Tests.Metrics;
 public class ElectionsCounterTrackerTests : IDisposable {
 	private Scope _disposables = new();
 	private readonly ElectionMessage.ElectionsDone _electionsDoneMessage;
+	private readonly ElectionMessage.LeaderAppointed _leaderAppointedMessage;
 
 	public ElectionsCounterTrackerTests() {
 		var endPoint = new DnsEndPoint("127.0.0.1", 1113);
@@ -25,6 +26,7 @@ public class ElectionsCounterTrackerTests : IDisposable {
 			endPoint, endPoint, endPoint, endPoint, endPoint,
 			null, 0, 0, 0, false);
 		_electionsDoneMessage = new ElectionMessage.ElectionsDone(1, 1, memberInfo.ToLite());
+		_leaderAppointedMessage = new ElectionMessage.LeaderAppointed(1, memberInfo.ToLite());
 	}
 
 	public void Dispose() {
@@ -64,6 +66,25 @@ public class ElectionsCounterTrackerTests : IDisposable {
 		sut.Handle(_electionsDoneMessage);
 
 		AssertMeasurements(listener, AssertMeasurement(5));
+	}
+
+	[Fact]
+	public void test_election_count_for_one_appointment() {
+		var (sut, listener) = GenSut();
+		sut.Handle(_leaderAppointedMessage);
+
+		AssertMeasurements(listener, AssertMeasurement(1));
+	}
+
+	// An appointment is an election as far as the metric is concerned, so the two sources add up.
+	[Fact]
+	public void test_election_count_for_elections_and_appointments() {
+		var (sut, listener) = GenSut();
+		sut.Handle(_electionsDoneMessage);
+		sut.Handle(_leaderAppointedMessage);
+		sut.Handle(_leaderAppointedMessage);
+
+		AssertMeasurements(listener, AssertMeasurement(3));
 	}
 
 	static Action<TestMeterListener<long>.TestMeasurement> AssertMeasurement(

--- a/src/KurrentDB.Core.XUnit.Tests/Services/VNode/DatabaseStateHandlerTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Services/VNode/DatabaseStateHandlerTests.cs
@@ -1,0 +1,333 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using KurrentDB.Core.Messages;
+using KurrentDB.Core.Messaging;
+using KurrentDB.Core.Services.Storage.EpochManager;
+using KurrentDB.Core.Services.VNode;
+using KurrentDB.Core.Tests.Fakes;
+using KurrentDB.Core.TransactionLog.Checkpoint;
+using KurrentDB.Core.TransactionLog.LogRecords;
+using KurrentDB.KontrolPlane;
+using Xunit;
+
+namespace KurrentDB.Core.XUnit.Tests.Services.VNode;
+
+public class DatabaseStateHandlerTests {
+	private static readonly Guid ThisInstanceId = Guid.Parse("00000000-0000-0000-0000-0000000000a1");
+	private static readonly Guid LeaderInstanceId = Guid.Parse("00000000-0000-0000-0000-0000000000a2");
+	private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+	private const int NodePriority = 3;
+	private const ulong Epoch = 5;
+
+	private readonly FakePublisher _publisher = new();
+	private readonly StubEpochManager _epochManager = new();
+	private readonly InMemoryCheckpoint _writerCheckpoint = new();
+	private readonly InMemoryCheckpoint _chaserCheckpoint = new();
+
+	private DatabaseStateHandler CreateSut(bool readOnlyReplica = false, bool systemStarted = true) {
+		var sut = new DatabaseStateHandler(
+			mainQueue: _publisher,
+			epochManager: _epochManager,
+			writerCheckpoint: _writerCheckpoint,
+			chaserCheckpoint: _chaserCheckpoint,
+			currentNode: CurrentNode(readOnlyReplica),
+			nodePriority: NodePriority);
+
+		// The handler holds appointments back until the node has started, so tests that drive an
+		// appointment need this. Pass false to exercise the holding back itself.
+		if (systemStarted)
+			sut.Handle(new SystemMessage.SystemStart());
+
+		return sut;
+	}
+
+	private static DatabaseNode CurrentNode(bool readOnlyReplica = false) => new() {
+		DatabaseId = Database.MainDatabaseId,
+		Address = new DnsEndPoint("this-node", 1113),
+		ReplicationProtocolAddress = new DnsEndPoint("this-node", 1112),
+		InstanceId = ThisInstanceId,
+		Role = readOnlyReplica ? DatabaseNodeRole.ReadOnlyReplica : DatabaseNodeRole.Regular,
+	};
+
+	private static DatabaseNode LeaderNode() => new() {
+		DatabaseId = Database.MainDatabaseId,
+		Address = new DnsEndPoint("leader", 2113),
+		ReplicationProtocolAddress = new DnsEndPoint("leader", 2112),
+		InstanceId = LeaderInstanceId,
+	};
+
+	private static Database MainDatabase() => new() { Id = Database.MainDatabaseId, Epoch = Epoch };
+
+	private static DatabaseCluster MainCluster() => new() { Id = Database.MainDatabaseId, Epoch = Epoch };
+
+	// RunLeadershipAsync does not consume the change stream yet.
+	private static async IAsyncEnumerable<DatabaseCluster> NoChanges() {
+		await Task.CompletedTask;
+		yield break;
+	}
+
+	// FakePublisher's list is written by the handler's task, so index rather than enumerate.
+	private async Task<T> WaitForPublished<T>() where T : Message {
+		var deadline = DateTime.UtcNow + Timeout;
+		while (DateTime.UtcNow < deadline) {
+			if (FindPublished<T>() is { } match)
+				return match;
+
+			await Task.Delay(10);
+		}
+
+		Assert.Fail($"{typeof(T).Name} was never published.");
+		return null;
+	}
+
+	// The controller answers Freeze once it has taken the node out of service. Freeze now blocks on
+	// that reply, so a test that lets a handler unwind has to play that part.
+	private async Task AnswerFreeze() =>
+		(await WaitForPublished<SystemMessage.Freeze>()).Envelope.ReplyWith(SystemMessage.Frozen.Instance);
+
+	private T FindPublished<T>() where T : Message {
+		for (var i = 0; i < _publisher.Messages.Count; i++) {
+			if (_publisher.Messages[i] is T match)
+				return match;
+		}
+
+		return null;
+	}
+
+	[Fact]
+	public async Task reports_the_unflushed_checkpoints() {
+		// Written but not flushed: reading the flushed value would report 0 for both.
+		_writerCheckpoint.Write(500);
+		_chaserCheckpoint.Write(400);
+
+		var state = await CreateSut().GetReplicaStateAsync(CancellationToken.None);
+
+		Assert.Equal(500, state.WriterCheckpoint);
+		Assert.Equal(400, state.ChaserCheckpoint);
+	}
+
+	[Fact]
+	public async Task reports_epoch_zero_when_no_epoch_has_been_written() {
+		// The epoch manager reports -1, which the Kontrol Plane's unsigned epoch cannot express.
+		var state = await CreateSut().GetReplicaStateAsync(CancellationToken.None);
+
+		Assert.Equal(0UL, state.Epoch);
+	}
+
+	[Fact]
+	public async Task reports_the_last_written_epoch() {
+		_epochManager.LastEpochNumber = 7;
+
+		var state = await CreateSut().GetReplicaStateAsync(CancellationToken.None);
+
+		Assert.Equal(7UL, state.Epoch);
+	}
+
+	[Fact]
+	public async Task reports_this_nodes_ephemeral_instance_id() {
+		// The Kontrol Plane matches this against the appointment on renewal, so that a node which has
+		// restarted cannot inherit the appointment made for its pre-restart self.
+		var state = await CreateSut().GetReplicaStateAsync(CancellationToken.None);
+
+		Assert.Equal(ThisInstanceId, state.InstanceId);
+		Assert.NotEqual(LeaderInstanceId, state.InstanceId);
+	}
+
+	[Fact]
+	public async Task reports_the_node_priority() {
+		var sut = CreateSut();
+
+		var initial = await sut.GetReplicaStateAsync(CancellationToken.None);
+		Assert.Equal(NodePriority, initial.Priority);
+
+		sut.Handle(new ClientMessage.SetNodePriority(9));
+
+		var updated = await sut.GetReplicaStateAsync(CancellationToken.None);
+		Assert.Equal(9, updated.Priority);
+	}
+
+	[Fact]
+	public async Task setting_the_node_priority_tells_gossip() {
+		// ElectionsService is not constructed under the Kontrol Plane, so this handler is what keeps
+		// the admin endpoints working - for gossip's copy of the priority as well as our own.
+		var sut = CreateSut();
+
+		sut.Handle(new ClientMessage.SetNodePriority(9));
+
+		var updated = await WaitForPublished<GossipMessage.UpdateNodePriority>();
+		Assert.Equal(9, updated.NodePriority);
+	}
+
+	[Fact]
+	public async Task holds_the_appointment_back_until_the_node_has_started() {
+		// LeaderAppointed is not registered in Initializing, so an appointment published before the node
+		// leaves it is dropped and nothing retries it.
+		var sut = CreateSut(systemStarted: false);
+		using var cts = new CancellationTokenSource();
+
+		var replicating = sut.RunReplicationAsync(MainDatabase(), LeaderNode(), cts.Token);
+
+		await Task.Delay(50);
+		Assert.Null(FindPublished<ElectionMessage.LeaderAppointed>());
+
+		sut.Handle(new SystemMessage.SystemStart());
+		await WaitForPublished<ElectionMessage.LeaderAppointed>();
+
+		await cts.CancelAsync();
+		await AnswerFreeze();
+		await replicating.WaitAsync(Timeout);
+	}
+
+	[Fact]
+	public async Task announces_the_appointed_leader_before_replicating() {
+		var sut = CreateSut();
+		using var cts = new CancellationTokenSource();
+
+		var replicating = sut.RunReplicationAsync(MainDatabase(), LeaderNode(), cts.Token);
+
+		var appointed = await WaitForPublished<ElectionMessage.LeaderAppointed>();
+		Assert.Equal((int)Epoch, appointed.EpochNumber);
+		Assert.Equal(LeaderInstanceId, appointed.Leader.InstanceId);
+		Assert.Equal(LeaderNode().ReplicationProtocolAddress, appointed.Leader.ReplicationEndPoint);
+
+		await cts.CancelAsync();
+		await AnswerFreeze();
+		await replicating.WaitAsync(Timeout);
+	}
+
+	[Fact]
+	public async Task freezes_when_replication_ends() {
+		var sut = CreateSut();
+		using var cts = new CancellationTokenSource();
+
+		var replicating = sut.RunReplicationAsync(MainDatabase(), LeaderNode(), cts.Token);
+		await WaitForPublished<ElectionMessage.LeaderAppointed>();
+		await cts.CancelAsync();
+
+		// It asks to be taken out of service, and does not return until that has been answered - so
+		// the caller knows the node has stopped, not merely that it was asked to.
+		var freeze = await WaitForPublished<SystemMessage.Freeze>();
+		await Task.Delay(50);
+		Assert.False(replicating.IsCompleted);
+
+		freeze.Envelope.ReplyWith(SystemMessage.Frozen.Instance);
+		await replicating.WaitAsync(Timeout);
+	}
+
+	[Fact]
+	public async Task does_not_wait_for_the_freeze_when_shutting_down() {
+		// Waiting would hang the host's shutdown: DatabaseManager.StopAsync awaits this, and by then
+		// BecomeShutdown may have stopped the main queue, so nothing is left to answer. Giving up is
+		// safe because BecomeShuttingDown has already taken the node out of the acking states.
+		var sut = CreateSut();
+		using var cts = new CancellationTokenSource();
+
+		var replicating = sut.RunReplicationAsync(MainDatabase(), LeaderNode(), cts.Token);
+		await WaitForPublished<ElectionMessage.LeaderAppointed>();
+
+		sut.Handle(new SystemMessage.BecomeShuttingDown(Guid.NewGuid(), exitProcess: false, shutdownHttp: false));
+		await cts.CancelAsync();
+
+		// Completes even though nobody answers the Freeze.
+		await replicating.WaitAsync(Timeout);
+		Assert.NotNull(FindPublished<SystemMessage.Freeze>());
+	}
+
+	[Fact]
+	public async Task read_only_replica_does_not_freeze_when_replication_ends() {
+		// A read-only replica is never fenced, so it has nothing to prove by stopping - and staying
+		// connected lets the next appointment swap the leader over directly.
+		var sut = CreateSut(readOnlyReplica: true);
+		using var cts = new CancellationTokenSource();
+
+		var replicating = sut.RunReplicationAsync(MainDatabase(), LeaderNode(), cts.Token);
+		await WaitForPublished<ElectionMessage.LeaderAppointed>();
+		await cts.CancelAsync();
+
+		await replicating.WaitAsync(Timeout);
+		Assert.Null(FindPublished<SystemMessage.Freeze>());
+	}
+
+	[Fact]
+	public async Task announces_itself_as_leader() {
+		var sut = CreateSut();
+		using var cts = new CancellationTokenSource();
+
+		var leading = sut.RunLeadershipAsync(MainCluster(), NoChanges(), cts.Token);
+
+		var appointed = await WaitForPublished<ElectionMessage.LeaderAppointed>();
+		Assert.Equal((int)Epoch, appointed.EpochNumber);
+		Assert.Equal(ThisInstanceId, appointed.Leader.InstanceId);
+
+		await cts.CancelAsync();
+		await AnswerFreeze();
+		await AssertCompletes(leading);
+	}
+
+	[Fact]
+	public async Task leadership_continues_until_the_appointment_is_answered() {
+		var sut = CreateSut();
+		using var cts = new CancellationTokenSource();
+
+		var leading = sut.RunLeadershipAsync(MainCluster(), NoChanges(), cts.Token);
+		var appointed = await WaitForPublished<ElectionMessage.LeaderAppointed>();
+
+		await Task.Delay(50);
+		Assert.False(leading.IsCompleted);
+
+		// Answering is how the controller reports that the node has left the leader states.
+		appointed.Envelope.ReplyWith(ElectionMessage.LeadershipEnded.Instance);
+
+		// Completes on its own, without the token being cancelled.
+		await AnswerFreeze();
+		await leading.WaitAsync(Timeout);
+		Assert.False(cts.IsCancellationRequested);
+	}
+
+	[Fact]
+	public async Task leadership_ends_when_cancelled() {
+		var sut = CreateSut();
+		using var cts = new CancellationTokenSource();
+
+		var leading = sut.RunLeadershipAsync(MainCluster(), NoChanges(), cts.Token);
+		await WaitForPublished<ElectionMessage.LeaderAppointed>();
+
+		await cts.CancelAsync();
+		await AnswerFreeze();
+		await AssertCompletes(leading);
+	}
+
+	private static async Task AssertCompletes(Task task) {
+		try {
+			await task.WaitAsync(Timeout);
+		} catch (OperationCanceledException) {
+			// the handler may surface the cancellation or swallow it; both end the appointment
+		}
+
+		Assert.True(task.IsCompleted);
+	}
+
+	// The handler only ever reads LastEpochNumber.
+	private sealed class StubEpochManager : IEpochManager {
+		public int LastEpochNumber { get; set; } = -1;
+
+		public ValueTask Init(CancellationToken token) => throw new NotSupportedException();
+		public EpochRecord GetLastEpoch() => throw new NotSupportedException();
+		public ValueTask<IReadOnlyList<EpochRecord>> GetLastEpochs(int maxCount, CancellationToken token) =>
+			throw new NotSupportedException();
+		public ValueTask<EpochRecord> GetEpochAfter(int epochNumber, bool throwIfNotFound, CancellationToken token) =>
+			throw new NotSupportedException();
+		public ValueTask<bool> IsCorrectEpochAt(long epochPosition, int epochNumber, Guid epochId, CancellationToken token) =>
+			throw new NotSupportedException();
+		public ValueTask WriteNewEpoch(int epochNumber, CancellationToken token) => throw new NotSupportedException();
+		public ValueTask CacheEpoch(EpochRecord epoch, CancellationToken token) => throw new NotSupportedException();
+		public ValueTask<EpochRecord> TryTruncateBefore(long position, CancellationToken token) =>
+			throw new NotSupportedException();
+	}
+}

--- a/src/KurrentDB.Core.XUnit.Tests/Telemetry/TelemetryServiceTests.cs
+++ b/src/KurrentDB.Core.XUnit.Tests/Telemetry/TelemetryServiceTests.cs
@@ -164,9 +164,11 @@ public sealed class TelemetryServiceTests : IAsyncLifetime {
 		var _electionsDoneMessage = new ElectionMessage.ElectionsDone(1, mem1.EpochNumber, mem1.ToLite());
 		var _leaderFoundMessage = new LeaderDiscoveryMessage.LeaderFound(mem1.ToLite());
 		var _replicaStateMessage = new SystemMessage.BecomeReadOnlyReplica(mem1.InstanceId, mem1.ToLite());
+		var _leaderAppointedMessage = new ElectionMessage.LeaderAppointed(mem1.EpochNumber, mem1.ToLite());
 		_sut.Handle(_electionsDoneMessage);
 		_sut.Handle(_leaderFoundMessage);
 		_sut.Handle(_replicaStateMessage);
+		_sut.Handle(_leaderAppointedMessage);
 		Assert.IsType<TelemetryMessage.Collect>(schedule.ReplyMessage);
 		schedule.Reply();
 
@@ -204,6 +206,9 @@ public sealed class TelemetryServiceTests : IAsyncLifetime {
 
 		Assert.Equal(Guid.Parse(_sink.Data["cluster"]["leaderId"].ToString()), _replicaStateMessage.Leader.InstanceId);
 		Assert.Equal(Int32.Parse(_sink.Data["database"]["epochNumber"].ToString()), _replicaStateMessage.Leader.EpochNumber);
+
+		Assert.Equal(Guid.Parse(_sink.Data["cluster"]["leaderId"].ToString()), _leaderAppointedMessage.Leader.InstanceId);
+		Assert.Equal(Int32.Parse(_sink.Data["database"]["epochNumber"].ToString()), _leaderAppointedMessage.EpochNumber);
 
 		Assert.NotNull(_sink.Data["fakeComponent"]);
 	}

--- a/src/KurrentDB.Core/Authorization/AuthorizationPolicies/LegacyPolicySelectorFactory.cs
+++ b/src/KurrentDB.Core/Authorization/AuthorizationPolicies/LegacyPolicySelectorFactory.cs
@@ -86,6 +86,8 @@ public class LegacyPolicySelectorFactory : IPolicySelectorFactory {
 		policy.Add(Operations.Node.Elections.LeaderIsResigningOk, isSystem);
 		policy.Add(Operations.Node.Gossip.Update, isSystem);
 		policy.Add(Operations.Node.Gossip.Read, isSystem);
+		policy.Add(Operations.Node.KontrolPlane.Access, isSystem);
+		policy.Add(Operations.Node.DataPlane.Access, isSystem);
 
 		policy.AddMatchAnyAssertion(Operations.Node.Shutdown, Grant.Allow, OperationsOrAdmins);
 		policy.AddMatchAnyAssertion(Operations.Node.ReloadConfiguration, Grant.Allow, OperationsOrAdmins);

--- a/src/KurrentDB.Core/Cluster/DataPlaneClient.cs
+++ b/src/KurrentDB.Core/Cluster/DataPlaneClient.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Net;
+using Grpc.Core;
+using KurrentDB.Core.Services.Transport.Http.NodeHttpClientFactory;
+using KurrentDB.Core.Settings;
+using KurrentDB.DataPlane.Transport.Grpc;
+
+namespace KurrentDB.Core.Cluster;
+
+class DataPlaneClient(INodeHttpClientFactory httpClientFactory, string uriScheme) : GrpcDataPlaneClient {
+	protected override IDisposable CreateChannel(EndPoint address, out CallInvoker invoker) {
+		var channel = httpClientFactory.CreateChannel(uriScheme, address);
+		invoker = channel.CreateCallInvoker().WithUnaryTimeout(ESConsts.KPlaneUnaryCallTimeoutMs);
+		return channel;
+	}
+}

--- a/src/KurrentDB.Core/Cluster/EventStoreClusterClient.cs
+++ b/src/KurrentDB.Core/Cluster/EventStoreClusterClient.cs
@@ -2,14 +2,11 @@
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
 using System;
-using System.Threading;
 using EventStore.Cluster;
 using Grpc.Net.Client;
-using KurrentDB.Common.Utils;
 using KurrentDB.Core.Bus;
 using KurrentDB.Core.Metrics;
 using KurrentDB.Core.Services.Transport.Http.NodeHttpClientFactory;
-using Serilog.Extensions.Logging;
 using EndPoint = System.Net.EndPoint;
 
 // ReSharper disable once CheckNamespace
@@ -39,15 +36,7 @@ public partial class EventStoreClusterClient : IDisposable {
 
 		_clusterDns = clusterDns;
 
-		var httpClient = nodeHttpClientFactory.CreateHttpClient(nodeEndPoint.GetOtherNames());
-		httpClient.Timeout = Timeout.InfiniteTimeSpan;
-		httpClient.DefaultRequestVersion = new Version(2, 0);
-
-		var address = new UriBuilder(uriScheme, nodeEndPoint.GetHost(), nodeEndPoint.GetPort()).Uri;
-		_channel = GrpcChannel.ForAddress(address, new GrpcChannelOptions {
-			HttpClient = httpClient,
-			LoggerFactory = new SerilogLoggerFactory()
-		});
+		_channel = nodeHttpClientFactory.CreateChannel(uriScheme, nodeEndPoint);
 		var callInvoker = _channel.CreateCallInvoker();
 		_gossipClient = new Gossip.GossipClient(callInvoker);
 		_electionsClient = new Elections.ElectionsClient(callInvoker);

--- a/src/KurrentDB.Core/Cluster/KontrolPlaneClient.cs
+++ b/src/KurrentDB.Core/Cluster/KontrolPlaneClient.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Net;
+using Grpc.Core;
+using KurrentDB.Core.Services.Transport.Http.NodeHttpClientFactory;
+using KurrentDB.Core.Settings;
+using KurrentDB.KontrolPlane.Transport.Grpc;
+
+namespace KurrentDB.Core.Cluster;
+
+class KontrolPlaneClient(INodeHttpClientFactory httpClientFactory, string uriScheme) : GrpcKontrolPlaneClient {
+	protected override IDisposable CreateChannel(EndPoint address, out CallInvoker invoker) {
+		var channel = httpClientFactory.CreateChannel(uriScheme, address);
+		invoker = channel.CreateCallInvoker().WithUnaryTimeout(ESConsts.KPlaneUnaryCallTimeoutMs);
+		return channel;
+	}
+}

--- a/src/KurrentDB.Core/ClusterVNode.cs
+++ b/src/KurrentDB.Core/ClusterVNode.cs
@@ -1729,19 +1729,19 @@ public class ClusterVNode<TStreamId> :
 			_mainBus.Subscribe<SystemMessage.SystemStart>(databaseStateHandler);
 			_mainBus.Subscribe<SystemMessage.BecomeShuttingDown>(databaseStateHandler);
 
+			// Bootstrap only: the first AnnounceDatabaseNode response replaces this list with the Kontrol
+			// Plane's own and redirects to its leader. A node running a Kontroller adds itself, so it can
+			// bootstrap before any peer is up and the set is never empty even with no seed configured.
+			var kontrolPlaneNodes = new HashSet<EndPoint>(options.KontrolPlane.KontrolPlaneApiSeed);
+			if (options.KontrolPlane.IsKontrolPlaneNode)
+				kontrolPlaneNodes.Add(memberInfoLite.HttpEndPoint);
+
 			_databaseManager = new(new() {
 				RenewalRate = ESConsts.KPlaneRenewalRate,
 			}) {
 				DatabaseHandler = databaseStateHandler,
 				KontrolPlane = new KontrolPlaneClient(_nodeHttpClientFactory, uriScheme) {
-					// Bootstrap only: the first AnnounceDatabaseNode response replaces this list with
-					// the Kontrol Plane's own and redirects to its leader. The gossip seeds are already
-					// the peers' gRPC endpoints, which is where KontrollerServer is served. This node is
-					// included so that the set is never empty - DNS discovery leaves GossipSeed empty -
-					// and so that bootstrap succeeds before any peer is up.
-					KontrolPlaneNodes = new HashSet<EndPoint>(options.KontrolPlane.KontrolPlaneApiSeed) {
-						memberInfoLite.HttpEndPoint,
-					},
+					KontrolPlaneNodes = kontrolPlaneNodes,
 				}
 			};
 		}

--- a/src/KurrentDB.Core/ClusterVNode.cs
+++ b/src/KurrentDB.Core/ClusterVNode.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -14,6 +16,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNext;
+using DotNext.Net.Security;
 using EventStore.Core.Cluster;
 using EventStore.Plugins.Authentication;
 using EventStore.Plugins.Authorization;
@@ -81,6 +84,9 @@ using KurrentDB.Core.TransactionLog.Scavenging.Stages;
 using KurrentDB.Core.Transforms;
 using KurrentDB.Core.Transforms.Identity;
 using KurrentDB.Core.Util;
+using KurrentDB.DataPlane;
+using KurrentDB.KontrolPlane;
+using KurrentDB.KontrolPlane.Raft;
 using KurrentDB.Licensing;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Data.Sqlite;
@@ -217,6 +223,11 @@ public class ClusterVNode<TStreamId> :
 	private readonly Func<CancellationToken, ValueTask> _start;
 	private readonly INodeHttpClientFactory _nodeHttpClientFactory;
 	private readonly EventStoreClusterClientCache _eventStoreClusterClientCache;
+
+	// In KPlane mode these are null or not null according to what component(s) the node is running
+	// Outside of KPlane mode they are both null.
+	private readonly RaftKontroller _kontroller; // Kontrol plane component
+	private readonly DatabaseManager _databaseManager; // Data plane component
 
 	private int _stopCalled;
 	private int _reloadingConfig;
@@ -418,10 +429,6 @@ public class ClusterVNode<TStreamId> :
 						throw;
 					}
 				}
-
-				var kontrollerPath = Path.Combine(dbPath, ESConsts.KontrollerDirectoryName);
-
-
 
 				var indexPath = options.Database.Index ?? Path.Combine(dbPath, ESConsts.DefaultIndexDirectoryName);
 				Log.Information("Index Path set to {indexPath}", indexPath);
@@ -951,22 +958,6 @@ public class ClusterVNode<TStreamId> :
 				options.Interface.AdvertiseHostToClientAs, options.Interface.AdvertiseNodePortToClientAs,
 				nodeTcpOptions?.NodeTcpPortAdvertiseAs ?? 0);
 		}
-
-		// static (IPEndPoint ListenAddr, EndPoint PublicAddr) GetKontrollerHostingOptions(
-		// 	ClusterVNodeOptions.InterfaceOptions options) {
-		// 	var kontrollerListenAddr = new IPEndPoint(options.NodeIp, options.KontrollerPort);
-		// 	var kontrollerPublicPort = options.AdvertiseKontrollerPortAs > 0
-		// 		? options.AdvertiseKontrollerPortAs
-		// 		: kontrollerListenAddr.Port;
-		//
-		// 	EndPoint kontrollerPublicAddr = options.KontrollerHostAdvertiseAs is { Length: > 0 } kontrollerHost
-		// 		? IPAddress.TryParse(kontrollerHost, out var publicIp)
-		// 			? new IPEndPoint(publicIp, kontrollerPublicPort)
-		// 			: new DnsEndPoint(kontrollerHost, kontrollerPublicPort)
-		// 		: kontrollerListenAddr;
-		//
-		// 	return (kontrollerListenAddr, kontrollerPublicAddr);
-		// }
 
 		_httpService = new KestrelHttpService(ServiceAccessibility.Public, _mainQueue, new TrieUriRouter(), options.Application.LogHttpRequests,
 			string.IsNullOrEmpty(GossipAdvertiseInfo.AdvertiseHostToClientAs) ? GossipAdvertiseInfo.AdvertiseExternalHostAs : GossipAdvertiseInfo.AdvertiseHostToClientAs,
@@ -1578,7 +1569,7 @@ public class ClusterVNode<TStreamId> :
 		}
 
 		// ELECTIONS
-		if (!NodeInfo.IsReadOnlyReplica) {
+		if (!NodeInfo.IsReadOnlyReplica && !options.ClusterIsUsingKontrolPlane) {
 			var electionsService = new ElectionsService(
 				_mainQueue,
 				memberInfo,
@@ -1638,6 +1629,123 @@ public class ClusterVNode<TStreamId> :
 		_mainBus.Subscribe<ElectionMessage.ElectionsDone>(gossip);
 		_mainBus.Subscribe<ElectionMessage.LeaderAppointed>(gossip);
 
+		// KONTROL PLANE
+		var kontrollerPath = Path.Combine(dbConfig.Path, ESConsts.KontrollerDirectoryName);
+
+		if (options.KontrolPlane.IsKontrolPlaneNode) {
+			var raftPublicAddress = GetKontrollerPublicEndpoint();
+			EndPoint GetKontrollerPublicEndpoint() {
+				var port = options.KontrolPlane.KontrollerPortAdvertiseAs > 0
+					? options.KontrolPlane.KontrollerPortAdvertiseAs
+					: options.KontrolPlane.KontrollerPort;
+
+				var kontrollerHostToAdvertise = options.KontrolPlane.KontrollerHostAdvertiseAs is { Length: > 0 } kontrollerHostAdvertiseAs
+					? kontrollerHostAdvertiseAs
+					: GossipAdvertiseInfo.HttpEndPoint.Host;
+
+				EndPoint kontrollerPublicAddr = IPAddress.TryParse(kontrollerHostToAdvertise, out var publicIp)
+					? new IPEndPoint(publicIp, port)
+					: new DnsEndPoint(kontrollerHostToAdvertise, port);
+
+				return kontrollerPublicAddr;
+			}
+
+			_kontroller = new(new() {
+				ApiPort = options.Interface.NodePortAdvertiseAs > 0
+					? options.Interface.NodePortAdvertiseAs
+					: options.Interface.NodePort,
+				ConnectionPoolCapacity = ESConsts.KPlaneConnectionPoolCapacity,
+				HeartbeatTimeout = TimeSpan.FromMilliseconds(options.KontrolPlane.KontrolPlaneAppointmentTimeoutMs),
+				ListenAddress = new IPEndPoint(options.Interface.NodeIp, options.KontrolPlane.KontrollerPort),
+				PublicAddress = raftPublicAddress, // other kplane nodes connect to this
+				LowerElectionTimeout = options.KontrolPlane.KontrolPlaneLowerElectionTimeoutMs,
+				UpperElectionTimeout = options.KontrolPlane.KontrolPlaneUpperElectionTimeoutMs,
+				MainDatabaseClusterSize = options.Cluster.ClusterSize, // bootstrapping only
+				// initial set of endpoints to reach kplane nodes including this node
+				// used only for bootstrapping the kplane on first startup
+				Nodes = isSingleNode
+					? []
+					: options.KontrolPlane.KontrolPlaneBootstrapSeed.ToImmutableHashSet().Add(raftPublicAddress),
+				PersistentStateRoot = kontrollerPath,
+				SnapshotDepth = ESConsts.KPlaneSnapshotDepth,
+				Tls = options.Application.TlsDisabled()
+					? null
+					: new KontrollerSslOptions(
+						createClientOptions: serverAddress =>
+							NodeSslOptions.CreateTargetedClientOptions(
+								target: serverAddress,
+								serverCertificateValidator: _internalServerCertificateValidator,
+								clientCertificateSelector: _certificateSelector,
+								enabledSslProtocols: NodeTlsPolicy.PinnedSslProtocols)) {
+						ServerOptions =
+							NodeSslOptions.CreateServerOptions(
+								clientCertificateValidator: _internalClientCertificateValidator,
+								serverCertificateSelector: _certificateSelector),
+					}
+			}) {
+				DataPlaneClientFactory = () => new DataPlaneClient(_nodeHttpClientFactory, uriScheme),
+			};
+		} else if (Directory.Exists(kontrollerPath)) {
+			// The Kontrol Plane only bootstraps against an already-populated database while its own
+			// epoch is 0: FenceDatabaseAsync then requires every node to answer, so it discovers epochs
+			// that were written but never replicated. Resuming from stale state skips that, and can
+			// settle on an epoch that a node not in the answering majority has already written - which
+			// that node can then never be appointed at, because WriteNewEpoch requires strictly greater.
+			//
+			// So a node that is not running a kontroller retires the state rather than leaving it to be
+			// picked up later. Retired rather than deleted so that it is recoverable.
+			var retiredPath = $"{kontrollerPath}-retired-" +
+				DateTime.UtcNow.ToString("yyyy-MM-dd'T'HHmmss'Z'", CultureInfo.InvariantCulture);
+
+			Log.Warning(
+				"This node is not a Kontrol Plane node but has Kontrol Plane state at {kontrollerPath}. Moving it to {retiredPath}",
+				kontrollerPath, retiredPath);
+
+			Directory.Move(kontrollerPath, retiredPath);
+		}
+
+		if (options.KontrolPlane.IsDataPlaneNode) {
+			var memberInfoLite = memberInfo.ToLite();
+			var databaseStateHandler = new DatabaseStateHandler(
+				mainQueue: _mainQueue,
+				epochManager: epochManager,
+				writerCheckpoint: Db.Config.WriterCheckpoint.AsReadOnly(),
+				chaserCheckpoint: Db.Config.ChaserCheckpoint.AsReadOnly(),
+				currentNode: new DatabaseNode {
+					DatabaseId = Database.MainDatabaseId,
+					Address = memberInfoLite.HttpEndPoint,
+					Role = options.Cluster.ReadOnlyReplica
+						? DatabaseNodeRole.ReadOnlyReplica
+						: DatabaseNodeRole.Regular,
+					ClientApiAddress = memberInfoLite.ClientHttpEndPoint,
+					ClientTcpApiPort = memberInfoLite.ClientTcpPort,
+					ClientTcpApiIsSecure = memberInfoLite.ClientTcpApiIsSecure,
+					ReplicationProtocolAddress = memberInfoLite.ReplicationEndPoint,
+					Version = VersionInfo.Version,
+					InstanceId = NodeInfo.InstanceId,
+				},
+				nodePriority: options.Cluster.NodePriority);
+			_mainBus.Subscribe<ClientMessage.SetNodePriority>(databaseStateHandler);
+			_mainBus.Subscribe<SystemMessage.SystemStart>(databaseStateHandler);
+			_mainBus.Subscribe<SystemMessage.BecomeShuttingDown>(databaseStateHandler);
+
+			_databaseManager = new(new() {
+				RenewalRate = ESConsts.KPlaneRenewalRate,
+			}) {
+				DatabaseHandler = databaseStateHandler,
+				KontrolPlane = new KontrolPlaneClient(_nodeHttpClientFactory, uriScheme) {
+					// Bootstrap only: the first AnnounceDatabaseNode response replaces this list with
+					// the Kontrol Plane's own and redirects to its leader. The gossip seeds are already
+					// the peers' gRPC endpoints, which is where KontrollerServer is served. This node is
+					// included so that the set is never empty - DNS discovery leaves GossipSeed empty -
+					// and so that bootstrap succeeds before any peer is up.
+					KontrolPlaneNodes = new HashSet<EndPoint>(options.KontrolPlane.KontrolPlaneApiSeed) {
+						memberInfoLite.HttpEndPoint,
+					},
+				}
+			};
+		}
+
 		var clusterStateChangeListener = new ClusterMultipleVersionsLogger();
 		_mainBus.Subscribe<GossipMessage.GossipUpdated>(clusterStateChangeListener);
 
@@ -1676,6 +1784,14 @@ public class ClusterVNode<TStreamId> :
 				.AddSingleton<IChunkRegistry<IChunkBlob>>(Db.Manager)
 				.AddSingleton<IVersionedFileNamingStrategy>(Db.Manager.FileSystem.LocalNamingStrategy)
 				.AddSingleton(dbConfig);
+
+			if (_kontroller is not null) {
+				services.AddSingleton<IKontroller>(_kontroller);
+			}
+
+			if (_databaseManager is not null) {
+				services.AddSingleton<DatabaseManager>(_databaseManager);
+			}
 
 			configureAdditionalNodeServices?.Invoke(services);
 			return services;
@@ -1736,6 +1852,12 @@ public class ClusterVNode<TStreamId> :
 
 			await storageWriter.Start(token);
 
+			if (_kontroller is not null)
+				await _kontroller.StartAsync(token);
+
+			if (_databaseManager is not null)
+				await _databaseManager.StartAsync(token);
+
 			_workersHandler.Start();
 			monitoringQueue.Start();
 			subscrQueue.Start();
@@ -1759,6 +1881,7 @@ public class ClusterVNode<TStreamId> :
 			ConfigureNodeServices,
 			ConfigureNode);
 
+		_mainBus.Subscribe<SystemMessage.SystemStart>(_startup);
 		_mainBus.Subscribe<SystemMessage.SystemReady>(_startup);
 		_mainBus.Subscribe<SystemMessage.BecomeShuttingDown>(_startup);
 
@@ -1870,6 +1993,15 @@ public class ClusterVNode<TStreamId> :
 		if (Interlocked.Exchange(ref _stopCalled, 1) == 1) {
 			Log.Warning("Stop was already called.");
 			return;
+		}
+
+		if (_databaseManager is not null) {
+			await _databaseManager.StopAsync(cancellationToken);
+		}
+
+		if (_kontroller is not null) {
+			await _kontroller.StopAsync(cancellationToken);
+			await _kontroller.DisposeAsync();
 		}
 
 		_mainQueue.Publish(new ClientMessage.RequestShutdown(false, true));
@@ -2078,4 +2210,12 @@ public class ClusterVNode<TStreamId> :
 
 	public override string ToString() =>
 		$"[{NodeInfo.InstanceId:B}, {NodeInfo.InternalTcp}, {NodeInfo.ExternalTcp}, {NodeInfo.HttpEndPoint}]";
+}
+
+file sealed class KontrollerSslOptions(
+	Func<EndPoint, SslClientAuthenticationOptions> createClientOptions)
+	: SslOptions {
+
+	public override SslClientAuthenticationOptions CreateClientOptions(EndPoint serverAddress) =>
+		createClientOptions(serverAddress);
 }

--- a/src/KurrentDB.Core/ClusterVNode.cs
+++ b/src/KurrentDB.Core/ClusterVNode.cs
@@ -830,6 +830,7 @@ public class ClusterVNode<TStreamId> :
 		_mainBus.Subscribe<SystemMessage.EpochWritten>(inaugurationManager);
 		_mainBus.Subscribe<SystemMessage.CheckInaugurationConditions>(inaugurationManager);
 		_mainBus.Subscribe<ElectionMessage.ElectionsDone>(inaugurationManager);
+		_mainBus.Subscribe<ElectionMessage.LeaderAppointed>(inaugurationManager);
 		_mainBus.Subscribe<ReplicationTrackingMessage.IndexedTo>(inaugurationManager);
 		_mainBus.Subscribe<ReplicationTrackingMessage.ReplicatedTo>(inaugurationManager);
 
@@ -1519,6 +1520,7 @@ public class ClusterVNode<TStreamId> :
 
 		// ELECTIONS TRACKER
 		_mainBus.Subscribe<ElectionMessage.ElectionsDone>(trackers.ElectionCounterTracker);
+		_mainBus.Subscribe<ElectionMessage.LeaderAppointed>(trackers.ElectionCounterTracker);
 
 		// TELEMETRY
 		var telemetryService = new TelemetryService(
@@ -1534,6 +1536,7 @@ public class ClusterVNode<TStreamId> :
 			_mainBus.Subscribe<SystemMessage.ReplicaStateMessage>(telemetryService);
 		_mainBus.Subscribe<SystemMessage.StateChangeMessage>(telemetryService);
 		_mainBus.Subscribe<ElectionMessage.ElectionsDone>(telemetryService);
+		_mainBus.Subscribe<ElectionMessage.LeaderAppointed>(telemetryService);
 		_mainBus.Subscribe<LeaderDiscoveryMessage.LeaderFound>(telemetryService);
 
 		// LEADER REPLICATION
@@ -1633,6 +1636,7 @@ public class ClusterVNode<TStreamId> :
 		_mainBus.Subscribe<GossipMessage.GetGossipFailed>(gossip);
 		_mainBus.Subscribe<GossipMessage.GetGossipReceived>(gossip);
 		_mainBus.Subscribe<ElectionMessage.ElectionsDone>(gossip);
+		_mainBus.Subscribe<ElectionMessage.LeaderAppointed>(gossip);
 
 		var clusterStateChangeListener = new ClusterMultipleVersionsLogger();
 		_mainBus.Subscribe<GossipMessage.GossipUpdated>(clusterStateChangeListener);

--- a/src/KurrentDB.Core/ClusterVNodeStartup.cs
+++ b/src/KurrentDB.Core/ClusterVNodeStartup.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.Metrics;
 using System.IO.Compression;
 using System.Linq;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Services.Transport.Grpc;
 using EventStore.Core.Services.Transport.Grpc.Cluster;
@@ -25,6 +26,8 @@ using KurrentDB.Core.Services.Transport.Grpc;
 using KurrentDB.Core.Services.Transport.Http;
 using KurrentDB.Core.TransactionLog.Checkpoint;
 using KurrentDB.Core.TransactionLog.Chunks;
+using KurrentDB.DataPlane.Transport.Grpc;
+using KurrentDB.KontrolPlane.Transport.Grpc;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
@@ -42,6 +45,7 @@ using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using Serilog;
 using AuthenticationMiddleware = KurrentDB.Core.Services.Transport.Http.AuthenticationMiddleware;
+using AuthorizationOperations = EventStore.Plugins.Authorization.Operations;
 using ClientGossip = EventStore.Core.Services.Transport.Grpc.Gossip;
 using ClusterGossip = EventStore.Core.Services.Transport.Grpc.Cluster.Gossip;
 using HttpMethod = KurrentDB.Transport.Http.HttpMethod;
@@ -54,6 +58,7 @@ namespace KurrentDB.Core;
 
 public class ClusterVNodeStartup<TStreamId>
 	: IInternalStartup,
+		IHandle<SystemMessage.SystemStart>,
 		IHandle<SystemMessage.SystemReady>,
 		IHandle<SystemMessage.BecomeShuttingDown> {
 	private readonly ClusterVNodeOptions _options;
@@ -70,7 +75,10 @@ public class ClusterVNodeStartup<TStreamId>
 	private readonly StatusCheck _statusCheck;
 	private readonly Func<IServiceCollection, IServiceCollection> _configureNodeServices;
 	private readonly Action<IApplicationBuilder> _configureNode;
+	private static readonly Operation KontrolPlaneOperation = new(AuthorizationOperations.Node.KontrolPlane.Access);
+	private static readonly Operation DataPlaneOperation = new(AuthorizationOperations.Node.DataPlane.Access);
 
+	private bool _initialized;
 	private bool _ready;
 	private readonly IAuthorizationProvider _authorizationProvider;
 	private readonly IPublisher _httpMessageHandler;
@@ -158,6 +166,16 @@ public class ClusterVNodeStartup<TStreamId>
 		app.MapGrpcService<ClientGossip>();
 		app.MapGrpcService<Monitoring>();
 		app.MapGrpcService<ServerFeatures>();
+
+		if (_options.KontrolPlane.IsKontrolPlaneNode)
+			app.MapGrpcService<GrpcKontrollerServer>().RequireAuthorization(RequireOperation(KontrolPlaneOperation));
+
+		if (_options.KontrolPlane.IsDataPlaneNode)
+			app.MapGrpcService<GrpcDataPlaneServer>().RequireAuthorization(RequireOperation(DataPlaneOperation));
+
+		Action<Microsoft.AspNetCore.Authorization.AuthorizationPolicyBuilder> RequireOperation(Operation operation) =>
+			policy => policy.RequireAssertion(async context =>
+				await _authorizationProvider.CheckAccessAsync(context.User, operation, CancellationToken.None));
 
 #if DEBUG
 		app.MapGrpcReflectionService();
@@ -292,6 +310,7 @@ public class ClusterVNodeStartup<TStreamId>
 		// gRPC
 		services
 			.AddSingleton<LogRetriesInterceptor>()
+			.AddSingleton(new NotReadyInterceptor(() => _initialized))
 			.AddGrpc(options => {
 				var hostEnvironment = services
 					.BuildServiceProvider()
@@ -314,6 +333,8 @@ public class ClusterVNodeStartup<TStreamId>
 					options.ResponseCompressionLevel = compressionLevel;
 				}
 			})
+			.AddServiceOptions<GrpcKontrollerServer>(options => options.Interceptors.Add<NotReadyInterceptor>())
+			.AddServiceOptions<GrpcDataPlaneServer>(options => options.Interceptors.Add<NotReadyInterceptor>())
 			.AddServiceOptions<Streams<TStreamId>>(options => options.MaxReceiveMessageSize = TFConsts.EffectiveMaxLogRecordSize);
 
 #if DEBUG
@@ -344,9 +365,14 @@ public class ClusterVNodeStartup<TStreamId>
 		}
 	}
 
+	public void Handle(SystemMessage.SystemStart _) => _initialized = true;
+
 	public void Handle(SystemMessage.SystemReady _) => _ready = true;
 
-	public void Handle(SystemMessage.BecomeShuttingDown _) => _ready = false;
+	public void Handle(SystemMessage.BecomeShuttingDown _) {
+		_initialized = false;
+		_ready = false;
+	}
 
 	private class StatusCheck(ClusterVNodeStartup<TStreamId> startup) {
 		private readonly ClusterVNodeStartup<TStreamId> _startup = startup ?? throw new ArgumentNullException(nameof(startup));

--- a/src/KurrentDB.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/KurrentDB.Core/Configuration/ClusterVNodeOptions.cs
@@ -12,7 +12,6 @@ using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
-using DotNext.Net.Cluster.Consensus.Raft;
 using EventStore.Plugins;
 using EventStore.Plugins.Subsystems;
 using KurrentDB.Common.Configuration;
@@ -310,12 +309,12 @@ public partial record ClusterVNodeOptions {
 		[Description("The lower bound, in ms, of the election timeout for the Kontrol Plane's own Raft " +
 					 "cluster. Each node picks a timeout at random between the lower and upper bounds."),
 		 Unit("ms")]
-		public int KontrolPlaneLowerElectionTimeoutMs { get; init; } = ElectionTimeout.Recommended.LowerValue * 2;
+		public int KontrolPlaneLowerElectionTimeoutMs { get; init; } = 700;
 
 		[Description("The upper bound, in ms, of the election timeout for the Kontrol Plane's own Raft " +
 					 "cluster. Each node picks a timeout at random between the lower and upper bounds."),
 		 Unit("ms")]
-		public int KontrolPlaneUpperElectionTimeoutMs { get; init; } = ElectionTimeout.Recommended.UpperValue * 2;
+		public int KontrolPlaneUpperElectionTimeoutMs { get; init; } = 1_000;
 
 		[Description("Kontrol Plane will appoint another database leader if the current leader does not " +
 					 "renew its appointment within this many milliseconds. Renewal rate is 50% of this."),

--- a/src/KurrentDB.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/KurrentDB.Core/Configuration/ClusterVNodeOptions.cs
@@ -12,6 +12,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
+using DotNext.Net.Cluster.Consensus.Raft;
 using EventStore.Plugins;
 using EventStore.Plugins.Subsystems;
 using KurrentDB.Common.Configuration;
@@ -42,6 +43,7 @@ public partial record ClusterVNodeOptions {
 	[OptionGroup] public CertificateOptions Certificate { get; init; } = new();
 	[OptionGroup] public CertificateFileOptions CertificateFile { get; init; } = new();
 	[OptionGroup] public CertificateStoreOptions CertificateStore { get; init; } = new();
+	[OptionGroup] public KontrolPlaneOptions KontrolPlane { get; init; } = new();
 	[OptionGroup] public ClusterOptions Cluster { get; init; } = new();
 	[OptionGroup] public DatabaseOptions Database { get; init; } = new();
 	[OptionGroup] public GrpcOptions Grpc { get; init; } = new();
@@ -80,6 +82,7 @@ public partial record ClusterVNodeOptions {
 			Certificate = configuration.BindOptions<CertificateOptions>(),
 			CertificateFile = configuration.BindOptions<CertificateFileOptions>(),
 			CertificateStore = configuration.BindOptions<CertificateStoreOptions>(),
+			KontrolPlane = configuration.BindOptions<KontrolPlaneOptions>(),
 			Cluster = configuration.BindOptions<ClusterOptions>(),
 			Database = configuration.BindOptions<DatabaseOptions>(),
 			Grpc = configuration.BindOptions<GrpcOptions>(),
@@ -277,6 +280,47 @@ public partial record ClusterVNodeOptions {
 
 		[Description("The trusted root certificate fingerprint/thumbprint.")]
 		public string TrustedRootCertificateThumbprint { get; init; } = string.Empty;
+	}
+
+	[Description("Kontrol Plane Options")]
+	public record KontrolPlaneOptions {
+		[Description($"Sets this node as a Kontrol Plane node. Defaults to false. " +
+					 $"If neither {nameof(IsKontrolPlaneNode)} nor {nameof(IsDataPlaneNode)} are true, the legacy elections mechanism is used.")]
+		public bool IsKontrolPlaneNode { get; init; } = false;
+
+		[Description($"Sets this node as a Data Plane node. Defaults to false. " +
+					 $"If neither {nameof(IsKontrolPlaneNode)} nor {nameof(IsDataPlaneNode)} are true, the legacy elections mechanism is used.")]
+		public bool IsDataPlaneNode { get; init; } = false;
+
+		[Description("The TCP port used by Kontrol Plane for replication.")]
+		public int KontrollerPort { get; init; } = 3113;
+
+		[Description("Host name other Kontrol Plane nodes can reach this one on.")]
+		public string? KontrollerHostAdvertiseAs { get; init; } = null;
+
+		[Description("Port other Kontrol Plane Nodes can reach this one on.")]
+		public int KontrollerPortAdvertiseAs { get; init; } = 0;
+
+		[Description("Kontrol Plane TCP endpoints for Kontrol Plane nodes to discover each other during bootstrapping.")]
+		public EndPoint[] KontrolPlaneBootstrapSeed { get; init; } = [];
+
+		[Description("Kontrol Plane gRPC API endpoints for discovery by Data Plane nodes.")]
+		public EndPoint[] KontrolPlaneApiSeed { get; init; } = [];
+
+		[Description("The lower bound, in ms, of the election timeout for the Kontrol Plane's own Raft " +
+					 "cluster. Each node picks a timeout at random between the lower and upper bounds."),
+		 Unit("ms")]
+		public int KontrolPlaneLowerElectionTimeoutMs { get; init; } = ElectionTimeout.Recommended.LowerValue * 2;
+
+		[Description("The upper bound, in ms, of the election timeout for the Kontrol Plane's own Raft " +
+					 "cluster. Each node picks a timeout at random between the lower and upper bounds."),
+		 Unit("ms")]
+		public int KontrolPlaneUpperElectionTimeoutMs { get; init; } = ElectionTimeout.Recommended.UpperValue * 2;
+
+		[Description("Kontrol Plane will appoint another database leader if the current leader does not " +
+					 "renew its appointment within this many milliseconds. Renewal rate is 50% of this."),
+		 Unit("ms")]
+		public int KontrolPlaneAppointmentTimeoutMs { get; init; } = 1_000;
 	}
 
 	[Description("Cluster Options")]
@@ -532,12 +576,6 @@ public partial record ClusterVNodeOptions {
 		[Description("The TCP port used by internal replication between nodes in the cluster.")]
 		public int ReplicationPort { get; init; } = 1112;
 
-		[Description("The TCP port used by Kontrol Plane for replication.")]
-		public int KontrollerPort { get; init; } = 3113;
-
-		[Description("Advertise the KPlane node's host name to other KPlane nodes")]
-		public string? KontrollerHostAdvertiseAs { get; init; }
-
 		[Description("Advertise the Node's host name to other nodes and external clients as.")]
 		public string? NodeHostAdvertiseAs { get; init; } = null;
 
@@ -549,9 +587,6 @@ public partial record ClusterVNodeOptions {
 
 		[Description("Advertise Node Port in Gossip to Client As.")]
 		public int AdvertiseNodePortToClientAs { get; init; } = 0;
-
-		[Description("Advertise KPlane Node Port to other KPlane nodes.")]
-		public int AdvertiseKontrollerPortAs { get; init; }
 
 		[Description("Advertise Http Port As.")]
 		public int NodePortAdvertiseAs { get; init; } = 0;

--- a/src/KurrentDB.Core/Configuration/ClusterVNodeOptionsExtensions.cs
+++ b/src/KurrentDB.Core/Configuration/ClusterVNodeOptionsExtensions.cs
@@ -283,4 +283,10 @@ public static class ClusterVNodeOptionsExtensions {
 				$"No trusted root certificate files were loaded from the specified path: {options.Certificate.TrustedRootCertificatesPath}");
 		return trustedRootCerts;
 	}
+
+	extension(ClusterVNodeOptions options) {
+		public bool ClusterIsUsingKontrolPlane =>
+			options.KontrolPlane.IsKontrolPlaneNode ||
+			options.KontrolPlane.IsDataPlaneNode;
+	}
 }

--- a/src/KurrentDB.Core/Configuration/ClusterVNodeOptionsValidator.cs
+++ b/src/KurrentDB.Core/Configuration/ClusterVNodeOptionsValidator.cs
@@ -185,6 +185,12 @@ public static class ClusterVNodeOptionsValidator {
 				$"Note that since TLS is disabled the secret will be sent in clear text.");
 		}
 
+		if (options.Application.UsesClusterSecret() && !UsesHeaderSupportedCharacters(options.Cluster.ClusterSecret)) {
+			throw new InvalidConfigurationException(
+				$"The {nameof(options.Cluster.ClusterSecret)} contains unsupported characters. Use only " +
+				$"letters, digits and the characters - . _ ~ + / =");
+		}
+
 		if (!options.Application.UsesClusterSecret() && !string.IsNullOrEmpty(options.Cluster.ClusterSecret)) {
 			Log.Warning(
 				"A {clusterSecret} has been configured but will have no effect. It is only used for inter-node " +
@@ -193,6 +199,20 @@ public static class ClusterVNodeOptionsValidator {
 		}
 
 		return;
+
+		// The secret travels as the parameter of an HTTP Authorization header - see NodeHttpClientFactory,
+		// which writes it, and ClusterSecretAuthenticationProvider, which reads it back - and as the expected
+		// secret of the internal TCP service. These are the characters RFC 9110 allows in that header slot.
+		static bool UsesHeaderSupportedCharacters(string secret) {
+			const string supportedPunctuation = "-._~+/=";
+
+			foreach (var c in secret) {
+				if (!char.IsAsciiLetterOrDigit(c) && !supportedPunctuation.Contains(c))
+					return false;
+			}
+
+			return true;
+		}
 
 		static void ValidateDistinctDirectories(params ReadOnlySpan<(string Name, string Path)> directories) {
 			var names = new Dictionary<string, string>(directories.Length, StringComparer.Ordinal);

--- a/src/KurrentDB.Core/Configuration/ClusterVNodeOptionsValidator.cs
+++ b/src/KurrentDB.Core/Configuration/ClusterVNodeOptionsValidator.cs
@@ -116,6 +116,63 @@ public static class ClusterVNodeOptionsValidator {
 				"The Archiver node must also be a Read Only Replica.");
 		}
 
+		if (options.Cluster is { ReadOnlyReplica: true } && options.KontrolPlane.IsKontrolPlaneNode) {
+			throw new InvalidConfigurationException(
+				"A Read Only Replica cannot also be a Kontrol Plane node.");
+		}
+
+		if (!options.Cluster.ReadOnlyReplica && (options.KontrolPlane.IsKontrolPlaneNode != options.KontrolPlane.IsDataPlaneNode)) {
+			throw new InvalidConfigurationException(
+				"To use Kontrol Plane, at the moment all cluster nodes must be both Kontrol Plane and Data Plane nodes.");
+		}
+
+		if (options.KontrolPlane.IsKontrolPlaneNode &&
+			options.Cluster.ClusterSize > 1 &&
+			options.KontrolPlane.KontrolPlaneBootstrapSeed is []) {
+			throw new InvalidConfigurationException(
+				$"A Kontrol Plane node in a cluster of more than one node requires a " +
+				$"{nameof(options.KontrolPlane.KontrolPlaneBootstrapSeed)} so that the Kontrol Plane nodes " +
+				$"can discover each other.");
+		}
+
+		if (options.ClusterIsUsingKontrolPlane && options.Database.MemDb) {
+			throw new InvalidConfigurationException(
+				$"MemDb is deprecated and not supported by Kontrol Plane clusters");
+		}
+
+		// A node that runs a Kontroller can bootstrap against itself: it announces to its own Kontrol
+		// Plane API, which redirects it to the leader. A Data Plane node that runs no Kontroller has
+		// nowhere to start from.
+		if (options.KontrolPlane is { IsDataPlaneNode: true, IsKontrolPlaneNode: false } &&
+			options.KontrolPlane.KontrolPlaneApiSeed is []) {
+			throw new InvalidConfigurationException(
+				$"A Data Plane node that is not also a Kontrol Plane node requires a " +
+				$"{nameof(options.KontrolPlane.KontrolPlaneApiSeed)} so that it can reach the Kontrol Plane.");
+		}
+
+		if (options.KontrolPlane.KontrolPlaneLowerElectionTimeoutMs <= 0) {
+			throw new InvalidConfigurationException(
+				$"{nameof(options.KontrolPlane.KontrolPlaneLowerElectionTimeoutMs)} must be greater than 0.");
+		}
+
+		if (options.KontrolPlane.KontrolPlaneUpperElectionTimeoutMs <= 0) {
+			throw new InvalidConfigurationException(
+				$"{nameof(options.KontrolPlane.KontrolPlaneUpperElectionTimeoutMs)} must be greater than 0.");
+		}
+
+		if (options.KontrolPlane.KontrolPlaneAppointmentTimeoutMs <= 0) {
+			throw new InvalidConfigurationException(
+				$"{nameof(options.KontrolPlane.KontrolPlaneAppointmentTimeoutMs)} must be greater than 0.");
+		}
+
+		if (options.KontrolPlane.KontrolPlaneLowerElectionTimeoutMs >=
+			options.KontrolPlane.KontrolPlaneUpperElectionTimeoutMs) {
+			throw new InvalidConfigurationException(
+				$"{nameof(options.KontrolPlane.KontrolPlaneLowerElectionTimeoutMs)} must be less than " +
+				$"{nameof(options.KontrolPlane.KontrolPlaneUpperElectionTimeoutMs)}. Each Kontrol Plane node " +
+				$"picks its election timeout at random between the two.");
+		}
+
 		if (options.Cluster.Archiver && options.Database.UnsafeIgnoreHardDelete) {
 			throw new InvalidConfigurationException(
 				"The Archiving feature is not compatible with UnsafeIgnoreHardDelete.");

--- a/src/KurrentDB.Core/Configuration/Sources/KurrentDBDefaultValuesConfigurationSource.cs
+++ b/src/KurrentDB.Core/Configuration/Sources/KurrentDBDefaultValuesConfigurationSource.cs
@@ -22,7 +22,10 @@ public class KurrentDefaultValuesConfigurationProvider(IEnumerable<KeyValuePair<
 	: MemoryConfigurationProvider(new() {
 		InitialData = initialData
 			// todo: something more permanent. exclude GossipSeed default because it overrides gossip seeds specified as arrays
-			.Where(kvp => kvp.Key is not nameof(ClusterVNodeOptions.Cluster.GossipSeed))
+			.Where(kvp => kvp.Key
+				is not nameof(ClusterVNodeOptions.Cluster.GossipSeed)
+				and not nameof(ClusterVNodeOptions.KontrolPlane.KontrolPlaneBootstrapSeed)
+				and not nameof(ClusterVNodeOptions.KontrolPlane.KontrolPlaneApiSeed))
 			.ToDictionary(
 			kvp => $"{KurrentConfigurationKeys.Prefix}:{kvp.Key}",
 			kvp => kvp.Value,

--- a/src/KurrentDB.Core/Data/VNodeState.cs
+++ b/src/KurrentDB.Core/Data/VNodeState.cs
@@ -5,11 +5,16 @@ using System.ComponentModel;
 
 namespace KurrentDB.Core.Data;
 
+// With KPlane the states and their semantics remain the same except that:
+//   1. Unknown does not trigger elections. KPlane will appoint a leader.
+//   2. DiscoverLeader is not used. KPlane will tell us who the leader is when it wants us to know.
+//   3. ResigningLeader is not used. It could be in the future.
+//
 //WARNING: new states must be added at the bottom of the enum otherwise it may break cluster and client compatibility
 public enum VNodeState {
 	Initializing = 0,
-	DiscoverLeader = 1,     // Checking if there is already a leader. If so become PreReplica, if not: start elections.
-	Unknown = 2,            // Triggers an election (it is Unknown who the leader is)
+	DiscoverLeader = 1,     // Check if there is already a leader according to gossip. If so become PreReplica, if not: start elections.
+	Unknown = 2,            // Unknown who the leader is. Used to trigger an election but not under KPlane.
 	PreReplica = 3,         // Elections done, we are in the quorum but not the leader elect.
 	CatchingUp = 4,         // PreReplica -> CatchingUp when we are subscribed to the leader
 	Clone = 5,              // CatchingUp -> Clone. Assigned this role by leader after we have caught up.
@@ -23,6 +28,10 @@ public enum VNodeState {
 	ReadOnlyLeaderless = 12, // RoR when leader is unknown
 	PreReadOnlyReplica = 13, // RoR when not yet subscribed to replication or lost subscription
 	ReadOnlyReplica = 14,    // RoR when subscribed. Equivalent of the Catching Up -> Clone -> Follower process.
+
+	// Not currently used in KPlane mode (it is not necessary for correcness),
+	// but as further work, when Freezing as leader we could transition through this state.
+	// The KPlane would need to fence the leader first and wait for a reply/timeout before fencing the others.
 	ResigningLeader = 15,
 
 	[EditorBrowsable(EditorBrowsableState.Never)]
@@ -34,4 +43,15 @@ public static class VNodeStateExtensions {
 		return state is VNodeState.CatchingUp or VNodeState.Clone or VNodeState.Follower
 			or VNodeState.ReadOnlyReplica;
 	}
+
+	public static bool CanReplicateToOtherNodes(this VNodeState state) => state
+		is VNodeState.PreLeader
+		or VNodeState.Leader
+		or VNodeState.ResigningLeader;
+
+	// This is the same partition ReplicaService switches on.
+	public static bool CanReplicateFromLeader(this VNodeState state) => state
+		is VNodeState.PreReplica
+		or VNodeState.PreReadOnlyReplica
+		|| state.IsReplica();
 }

--- a/src/KurrentDB.Core/Data/VNodeState.cs
+++ b/src/KurrentDB.Core/Data/VNodeState.cs
@@ -8,20 +8,21 @@ namespace KurrentDB.Core.Data;
 //WARNING: new states must be added at the bottom of the enum otherwise it may break cluster and client compatibility
 public enum VNodeState {
 	Initializing = 0,
-	DiscoverLeader = 1,
-	Unknown = 2,
-	PreReplica = 3,
-	CatchingUp = 4,
-	Clone = 5,
-	Follower = 6,
-	PreLeader = 7,
+	DiscoverLeader = 1,     // Checking if there is already a leader. If so become PreReplica, if not: start elections.
+	Unknown = 2,            // Triggers an election (it is Unknown who the leader is)
+	PreReplica = 3,         // Elections done, we are in the quorum but not the leader elect.
+	CatchingUp = 4,         // PreReplica -> CatchingUp when we are subscribed to the leader
+	Clone = 5,              // CatchingUp -> Clone. Assigned this role by leader after we have caught up.
+	Follower = 6,           // Follower. Assigned this role by leader.
+	PreLeader = 7,          // Elected leader but not leader yet.
 	Leader = 8,
-	Manager = 9,
+	Manager = 9,             // Defunct
 	ShuttingDown = 10,
 	Shutdown = 11,
-	ReadOnlyLeaderless = 12,
-	PreReadOnlyReplica = 13,
-	ReadOnlyReplica = 14,
+	// Leader does not assign the RoR specific states
+	ReadOnlyLeaderless = 12, // RoR when leader is unknown
+	PreReadOnlyReplica = 13, // RoR when not yet subscribed to replication or lost subscription
+	ReadOnlyReplica = 14,    // RoR when subscribed. Equivalent of the Catching Up -> Clone -> Follower process.
 	ResigningLeader = 15,
 
 	[EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/KurrentDB.Core/KurrentDB.Core.csproj
+++ b/src/KurrentDB.Core/KurrentDB.Core.csproj
@@ -46,7 +46,9 @@
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\KurrentDB.Common\KurrentDB.Common.csproj" />
+		<ProjectReference Include="..\KurrentDB.DataPlane\KurrentDB.DataPlane.csproj" />
 		<ProjectReference Include="..\KurrentDB.DuckDB\KurrentDB.DuckDB.csproj" />
+		<ProjectReference Include="..\KurrentDB.KontrolPlane\KurrentDB.KontrolPlane.csproj" />
 		<ProjectReference Include="..\KurrentDB.Licensing\KurrentDB.Licensing.csproj" />
 		<ProjectReference Include="..\KurrentDB.LogCommon\KurrentDB.LogCommon.csproj" />
 		<ProjectReference Include="..\KurrentDB.Logging\KurrentDB.Logging.csproj" />

--- a/src/KurrentDB.Core/Messages/ElectionMessage.cs
+++ b/src/KurrentDB.Core/Messages/ElectionMessage.cs
@@ -353,4 +353,27 @@ public static partial class ElectionMessage {
 			return $"---- ElectionsDone: installedView {InstalledView}, proposal number {ProposalNumber}, leader {Leader}";
 		}
 	}
+
+	// KPlane equivalent of ElectionsDone.
+	// When the appointed node is this one, Envelope is answered with LeadershipEnded once the node
+	// leaves the leader states again.
+	[DerivedMessage(CoreMessage.Election)]
+	public partial class LeaderAppointed(
+		int epochNumber,
+		MemberInfoLite leader,
+		IEnvelope<LeadershipEnded> envelope = null) : Message {
+
+		public int EpochNumber => epochNumber;
+		public MemberInfoLite Leader => leader;
+		public IEnvelope<LeadershipEnded> Envelope => envelope ?? NoopEnvelope.Instance;
+
+		public override string ToString() {
+			return $"---- LeaderAppointed: epoch number {EpochNumber}, leader {Leader}";
+		}
+	}
+
+	[DerivedMessage(CoreMessage.Election)]
+	public partial class LeadershipEnded : Message {
+		public static readonly LeadershipEnded Instance = new();
+	}
 }

--- a/src/KurrentDB.Core/Messages/ElectionMessage.cs
+++ b/src/KurrentDB.Core/Messages/ElectionMessage.cs
@@ -10,6 +10,12 @@ using KurrentDB.Core.Messaging;
 namespace KurrentDB.Core.Messages;
 
 public static partial class ElectionMessage {
+	// Triggered by
+	//  - Unknown node state
+	//  - Gossip says:
+	//      - Multiple live leaders
+	//      - 0 live leaders
+	//      - the node we think is the leader is no longer in a leader related state.
 	[DerivedMessage(CoreMessage.Election)]
 	public partial class StartElections : Message {
 		public override string ToString() {

--- a/src/KurrentDB.Core/Messages/GossipMessage.cs
+++ b/src/KurrentDB.Core/Messages/GossipMessage.cs
@@ -9,6 +9,8 @@ using KurrentDB.Core.Messaging;
 namespace KurrentDB.Core.Messages;
 
 public static partial class GossipMessage {
+	// Asks the GossipService to retrieve the seeds from the IGossipSeedSource
+	// (Config, DNS, etc)
 	[DerivedMessage(CoreMessage.Gossip)]
 	public partial class RetrieveGossipSeedSources : Message {
 	}
@@ -22,6 +24,7 @@ public static partial class GossipMessage {
 		}
 	}
 
+	// Periodic trigger to send some gossip
 	[DerivedMessage(CoreMessage.Gossip)]
 	public partial class Gossip : Message {
 		public readonly int GossipRound;
@@ -31,6 +34,8 @@ public static partial class GossipMessage {
 		}
 	}
 
+	// Sent to GossipService when receive gossip, either because we requested it
+	// or because another node just decided to send some.
 	[DerivedMessage(CoreMessage.Gossip)]
 	public partial class GossipReceived : Message {
 		public readonly IEnvelope Envelope;
@@ -44,6 +49,7 @@ public static partial class GossipMessage {
 		}
 	}
 
+	// Sent to the GossipService to retrieve the current gossip
 	[DerivedMessage(CoreMessage.Gossip)]
 	public partial class ReadGossip : Message {
 		public readonly IEnvelope Envelope;
@@ -53,6 +59,8 @@ public static partial class GossipMessage {
 		}
 	}
 
+	// Used to tell the GrpcSendService to send gossip somewhere
+	// And as an envelope reply to ReadGossip and GossipReceived
 	[DerivedMessage(CoreMessage.Gossip)]
 	public partial class SendGossip : Message {
 		public readonly ClusterInfo ClusterInfo;
@@ -64,6 +72,7 @@ public static partial class GossipMessage {
 		}
 	}
 
+	// Used to retrieve the current gossip on behalf of a client
 	[DerivedMessage(CoreMessage.Gossip)]
 	public partial class ClientGossip : Message {
 		public readonly IEnvelope Envelope;
@@ -73,6 +82,7 @@ public static partial class GossipMessage {
 		}
 	}
 
+	// Sent in response to ClientGossip
 	[DerivedMessage(CoreMessage.Gossip)]
 	public partial class SendClientGossip : Message {
 		public readonly ClientClusterInfo ClusterInfo;
@@ -82,6 +92,7 @@ public static partial class GossipMessage {
 		}
 	}
 
+	// Sent by the GossipServiceBase when the gossip as this node knows it has changed.
 	[DerivedMessage(CoreMessage.Gossip)]
 	public partial class GossipUpdated : Message {
 		public readonly ClusterInfo ClusterInfo;
@@ -91,6 +102,8 @@ public static partial class GossipMessage {
 		}
 	}
 
+	// Sent by EventStoreClusterClient when failing to SendGossip
+	// Handled by GossipServiceBase. Curiously not via reply envelope.
 	[DerivedMessage(CoreMessage.Gossip)]
 	public partial class GossipSendFailed : Message {
 		public readonly string Reason;
@@ -106,11 +119,14 @@ public static partial class GossipMessage {
 		}
 	}
 
+	// Sent by GossipServiceBase to get gossip from another node if the replication
+	// connection drops. Verifies if the node is still reachable.
 	[DerivedMessage(CoreMessage.Gossip)]
 	public partial class GetGossip : Message {
 		public GetGossip() { }
 	}
 
+	// Replication connection dropped, attempted to get gossip and failed.
 	[DerivedMessage(CoreMessage.Gossip)]
 	public partial class GetGossipFailed : Message {
 		public readonly string Reason;
@@ -126,6 +142,7 @@ public static partial class GossipMessage {
 		}
 	}
 
+	// Replication connection dropped, attempted to get gossip and suceeded.
 	[DerivedMessage(CoreMessage.Gossip)]
 	public partial class GetGossipReceived : Message {
 		public readonly ClusterInfo ClusterInfo;

--- a/src/KurrentDB.Core/Messages/SystemMessage.cs
+++ b/src/KurrentDB.Core/Messages/SystemMessage.cs
@@ -12,22 +12,31 @@ using EndPoint = System.Net.EndPoint;
 namespace KurrentDB.Core.Messages;
 
 public static partial class SystemMessage {
+	// Notice that the system is initializing
+	// Core services handle by initialising and sending ServiceInitialized
 	[DerivedMessage(CoreMessage.System)]
 	public partial class SystemInit : Message {
 	}
 
+	// After a select subset of core services are initialised we send this
+	// Notice that the system is starting
 	[DerivedMessage(CoreMessage.System)]
 	public partial class SystemStart : Message {
 	}
 
+	// Notice that we are ready to start subsystems
+	// - AuthenticationProvider is initialized
+	// - ClusterVNodeController is no longer in Initializing state
 	[DerivedMessage(CoreMessage.System)]
 	public partial class SystemCoreReady : Message {
 	}
 
+	// Notice that subsystems are started
 	[DerivedMessage(CoreMessage.System)]
 	public partial class SystemReady : Message {
 	}
 
+	// Core service response to SystemInit
 	[DerivedMessage(CoreMessage.System)]
 	public partial class ServiceInitialized : Message {
 		public readonly string ServiceName;

--- a/src/KurrentDB.Core/Messages/SystemMessage.cs
+++ b/src/KurrentDB.Core/Messages/SystemMessage.cs
@@ -64,6 +64,9 @@ public static partial class SystemMessage {
 	public partial class RequestQueueDrained : Message {
 	}
 
+	// These trigger state changes, they are not requests for state changes.
+	// These should only be emitted by the ClusterVNodeController so that it is
+	// in full control of the transitions.
 	[DerivedMessage]
 	public abstract partial class StateChangeMessage : Message {
 		public readonly Guid CorrelationId;
@@ -306,6 +309,17 @@ public static partial class SystemMessage {
 
 	[DerivedMessage(CoreMessage.System)]
 	public partial class NoQuorumMessage : Message {
+	}
+
+	// Asks the node to stop taking part in replication.
+	[DerivedMessage(CoreMessage.System)]
+	public partial class Freeze(IEnvelope<Frozen> envelope) : Message {
+		public IEnvelope<Frozen> Envelope => envelope;
+	}
+
+	[DerivedMessage(CoreMessage.System)]
+	public partial class Frozen : Message {
+		public static readonly Frozen Instance = new();
 	}
 
 	[DerivedMessage(CoreMessage.System)]

--- a/src/KurrentDB.Core/Messaging/NoopEnvelope.cs
+++ b/src/KurrentDB.Core/Messaging/NoopEnvelope.cs
@@ -4,6 +4,7 @@
 namespace KurrentDB.Core.Messaging;
 
 public class NoopEnvelope : IEnvelope {
+	public static readonly NoopEnvelope Instance = new();
 	public void ReplyWith<T>(T message) where T : Message {
 	}
 }

--- a/src/KurrentDB.Core/Metrics/ElectionsCounterTracker.cs
+++ b/src/KurrentDB.Core/Metrics/ElectionsCounterTracker.cs
@@ -6,7 +6,9 @@ using KurrentDB.Core.Messages;
 
 namespace KurrentDB.Core.Metrics;
 
-public interface IElectionCounterTracker : IHandle<ElectionMessage.ElectionsDone> {
+public interface IElectionCounterTracker :
+	IHandle<ElectionMessage.ElectionsDone>,
+	IHandle<ElectionMessage.LeaderAppointed> {
 }
 
 public class ElectionsCounterTracker : IElectionCounterTracker {
@@ -20,8 +22,15 @@ public class ElectionsCounterTracker : IElectionCounterTracker {
 		_electionsCounter.Add(1);
 	}
 
+	public void Handle(ElectionMessage.LeaderAppointed message) {
+		_electionsCounter.Add(1);
+	}
+
 	public class NoOp : IElectionCounterTracker {
 		public void Handle(ElectionMessage.ElectionsDone message) {
+		}
+
+		public void Handle(ElectionMessage.LeaderAppointed message) {
 		}
 	}
 }

--- a/src/KurrentDB.Core/Services/Gossip/GossipServiceBase.cs
+++ b/src/KurrentDB.Core/Services/Gossip/GossipServiceBase.cs
@@ -28,7 +28,8 @@ public abstract class GossipServiceBase : IHandle<SystemMessage.SystemInit>,
 	IHandle<SystemMessage.VNodeConnectionEstablished>,
 	IHandle<GossipMessage.GetGossipReceived>,
 	IHandle<GossipMessage.GetGossipFailed>,
-	IHandle<ElectionMessage.ElectionsDone> {
+	IHandle<ElectionMessage.ElectionsDone>,
+	IHandle<ElectionMessage.LeaderAppointed> {
 	public const int GossipRoundStartupThreshold = 20;
 	public static readonly TimeSpan DnsRetryTimeout = TimeSpan.FromMilliseconds(1000);
 	public static readonly TimeSpan GossipStartupInterval = TimeSpan.FromMilliseconds(100);
@@ -295,14 +296,22 @@ public abstract class GossipServiceBase : IHandle<SystemMessage.SystemInit>,
 	}
 
 	public void Handle(ElectionMessage.ElectionsDone message) {
+		OnLeaderDecided(message.Leader.InstanceId, "Elections Done");
+	}
+
+	public void Handle(ElectionMessage.LeaderAppointed message) {
+		OnLeaderDecided(message.Leader.InstanceId, "Leader Appointed");
+	}
+
+	private void OnLeaderDecided(Guid instanceId, string description) {
 		var oldCluster = _cluster;
 		_cluster = UpdateCluster(_cluster,
-			x => x.InstanceId == message.Leader.InstanceId
+			x => x.InstanceId == instanceId
 				? x.Updated(_timeProvider.UtcNow, VNodeState.Leader)
 				: x.Updated(_timeProvider.UtcNow, VNodeState.Unknown),
 			_timeProvider, _deadMemberRemovalPeriod, CurrentRole);
 		if (_cluster.HasChangedSince(oldCluster))
-			LogClusterChange(oldCluster, _cluster, "Elections Done");
+			LogClusterChange(oldCluster, _cluster, description);
 		_bus.Publish(new GossipMessage.GossipUpdated(_cluster));
 	}
 

--- a/src/KurrentDB.Core/Services/Gossip/GossipServiceBase.cs
+++ b/src/KurrentDB.Core/Services/Gossip/GossipServiceBase.cs
@@ -266,6 +266,7 @@ public abstract class GossipServiceBase : IHandle<SystemMessage.SystemInit>,
 		_bus.Publish(new GossipMessage.GossipUpdated(_cluster));
 	}
 
+	// Replication connection dropped so we tried to get gossip via grpc and couldn't.
 	public void Handle(GossipMessage.GetGossipFailed message) {
 		if (_state != GossipState.Working)
 			return;

--- a/src/KurrentDB.Core/Services/HttpSendService.cs
+++ b/src/KurrentDB.Core/Services/HttpSendService.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Security.Cryptography.X509Certificates;
 using KurrentDB.Common.Utils;
 using KurrentDB.Core.Bus;
 using KurrentDB.Core.Cluster;
@@ -37,15 +36,10 @@ public class HttpSendService : IHttpForwarder,
 
 		var socketsHttpHandler = new SocketsHttpHandler {
 			SslOptions = {
-				CertificateRevocationCheckMode = X509RevocationMode.NoCheck,
-				RemoteCertificateValidationCallback = (_, certificate, chain, errors) => {
-					var (isValid, error) = externServerCertValidator(certificate, chain, errors, _leaderInfo?.HttpEndPoint.GetOtherNames());
-					if (!isValid && error != null) {
-						Log.Error("Server certificate validation error: {e}", error);
-					}
-
-					return isValid;
-				}
+				CertificateRevocationCheckMode = NodeTlsPolicy.CertificateRevocationCheckMode,
+				RemoteCertificateValidationCallback = NodeTlsPolicy.ForServerCertificate(
+					externServerCertValidator,
+					() => _leaderInfo?.HttpEndPoint.GetOtherNames()),
 			},
 			PooledConnectionLifetime = ESConsts.HttpClientConnectionLifeTime
 		};

--- a/src/KurrentDB.Core/Services/Transport/Grpc/NotReadyInterceptor.cs
+++ b/src/KurrentDB.Core/Services/Transport/Grpc/NotReadyInterceptor.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+
+namespace KurrentDB.Core.Services.Transport.Grpc;
+
+/// <summary>
+/// Refuses calls until the node is ready to serve them, with the status peers retry on.
+/// </summary>
+/// <remarks>
+/// An interceptor rather than an endpoint filter: a filter runs outside the gRPC pipeline, so an
+/// <see cref="RpcException"/> thrown there is never translated into a gRPC status and reaches the
+/// caller as HTTP 500, which is indistinguishable from the node being broken.
+/// </remarks>
+class NotReadyInterceptor(Func<bool> isReady) : Interceptor {
+	public override Task<TResponse> UnaryServerHandler<TRequest, TResponse>(
+		TRequest request,
+		ServerCallContext context,
+		UnaryServerMethod<TRequest, TResponse> continuation) {
+
+		ThrowIfNotReady();
+		return base.UnaryServerHandler(request, context, continuation);
+	}
+
+	public override Task<TResponse> ClientStreamingServerHandler<TRequest, TResponse>(
+		IAsyncStreamReader<TRequest> requestStream,
+		ServerCallContext context,
+		ClientStreamingServerMethod<TRequest, TResponse> continuation) {
+
+		ThrowIfNotReady();
+		return base.ClientStreamingServerHandler(requestStream, context, continuation);
+	}
+
+	public override Task ServerStreamingServerHandler<TRequest, TResponse>(
+		TRequest request,
+		IServerStreamWriter<TResponse> responseStream,
+		ServerCallContext context,
+		ServerStreamingServerMethod<TRequest, TResponse> continuation) {
+
+		ThrowIfNotReady();
+		return base.ServerStreamingServerHandler(request, responseStream, context, continuation);
+	}
+
+	public override Task DuplexStreamingServerHandler<TRequest, TResponse>(
+		IAsyncStreamReader<TRequest> requestStream,
+		IServerStreamWriter<TResponse> responseStream,
+		ServerCallContext context,
+		DuplexStreamingServerMethod<TRequest, TResponse> continuation) {
+
+		ThrowIfNotReady();
+		return base.DuplexStreamingServerHandler(requestStream, responseStream, context, continuation);
+	}
+
+	private void ThrowIfNotReady() {
+		if (!isReady())
+			throw new RpcException(new Status(StatusCode.Unavailable, "The node is not ready yet."));
+	}
+}

--- a/src/KurrentDB.Core/Services/Transport/Http/NodeHttpClientFactory/NodeHttpClientFactory.cs
+++ b/src/KurrentDB.Core/Services/Transport/Http/NodeHttpClientFactory/NodeHttpClientFactory.cs
@@ -7,7 +7,6 @@ using System.Net.Http.Headers;
 using System.Security.Cryptography.X509Certificates;
 using KurrentDB.Common.Utils;
 using KurrentDB.Core.Settings;
-using Serilog;
 
 namespace KurrentDB.Core.Services.Transport.Http.NodeHttpClientFactory;
 
@@ -21,21 +20,12 @@ public class NodeHttpClientFactory(
 		HttpMessageHandler httpMessageHandler;
 		if (uriScheme == Uri.UriSchemeHttps) {
 			var socketsHttpHandler = new SocketsHttpHandler {
-				SslOptions = {
-					CertificateRevocationCheckMode = X509RevocationMode.NoCheck,
-					RemoteCertificateValidationCallback = (sender, certificate, chain, errors) => {
-						var (isValid, error) = nodeCertificateValidator(certificate, chain, errors, additionalCertificateNames);
-						if (!isValid && error != null) {
-							Log.Error("Server certificate validation error: {e}", error);
-						}
-
-						return isValid;
-					},
-					LocalCertificateSelectionCallback = delegate {
-						return clientCertificateSelector();
-					}
-				},
-				PooledConnectionLifetime = ESConsts.HttpClientConnectionLifeTime
+				SslOptions = NodeSslOptions.CreateClientOptions(
+					serverCertificateValidator: nodeCertificateValidator,
+					clientCertificateSelector: clientCertificateSelector,
+					additionalCertificateNames: additionalCertificateNames,
+					enabledSslProtocols: NodeTlsPolicy.SystemSslProtocols),
+				PooledConnectionLifetime = ESConsts.HttpClientConnectionLifeTime,
 			};
 
 			httpMessageHandler = socketsHttpHandler;

--- a/src/KurrentDB.Core/Services/Transport/Http/NodeHttpClientFactory/NodeHttpClientFactory.cs
+++ b/src/KurrentDB.Core/Services/Transport/Http/NodeHttpClientFactory/NodeHttpClientFactory.cs
@@ -20,7 +20,9 @@ public class NodeHttpClientFactory(
 		HttpMessageHandler httpMessageHandler;
 		if (uriScheme == Uri.UriSchemeHttps) {
 			var socketsHttpHandler = new SocketsHttpHandler {
-				SslOptions = NodeSslOptions.CreateClientOptions(
+				// TargetHost is provided later by SocketsHttpHandler according to the host of the request.
+				// We will accept the server identifying as that target or any of the additionalCertificateNames.
+				SslOptions = NodeSslOptions.CreateUntargetedClientOptions(
 					serverCertificateValidator: nodeCertificateValidator,
 					clientCertificateSelector: clientCertificateSelector,
 					additionalCertificateNames: additionalCertificateNames,

--- a/src/KurrentDB.Core/Services/Transport/Http/NodeHttpClientFactory/NodeHttpClientFactoryExtensions.cs
+++ b/src/KurrentDB.Core/Services/Transport/Http/NodeHttpClientFactory/NodeHttpClientFactoryExtensions.cs
@@ -17,6 +17,7 @@ public static class NodeHttpClientFactoryExtensions {
 		EndPoint address) {
 
 		var httpClient = httpClientFactory.CreateHttpClient(address.GetOtherNames());
+		// infinite so that streaming calls do not timeout. see also CallInvokerWithUnaryCallTimeout
 		httpClient.Timeout = Timeout.InfiniteTimeSpan;
 		httpClient.DefaultRequestVersion = new Version(2, 0);
 

--- a/src/KurrentDB.Core/Services/Transport/Http/NodeHttpClientFactory/NodeHttpClientFactoryExtensions.cs
+++ b/src/KurrentDB.Core/Services/Transport/Http/NodeHttpClientFactory/NodeHttpClientFactoryExtensions.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Net;
+using System.Threading;
+using Grpc.Net.Client;
+using KurrentDB.Common.Utils;
+using Serilog.Extensions.Logging;
+
+namespace KurrentDB.Core.Services.Transport.Http.NodeHttpClientFactory;
+
+public static class NodeHttpClientFactoryExtensions {
+	public static GrpcChannel CreateChannel(
+		this INodeHttpClientFactory httpClientFactory,
+		string uriScheme,
+		EndPoint address) {
+
+		var httpClient = httpClientFactory.CreateHttpClient(address.GetOtherNames());
+		httpClient.Timeout = Timeout.InfiniteTimeSpan;
+		httpClient.DefaultRequestVersion = new Version(2, 0);
+
+		return GrpcChannel.ForAddress(
+			new UriBuilder(uriScheme, address.GetHost(), address.GetPort()).Uri,
+			new GrpcChannelOptions {
+				HttpClient = httpClient,
+				DisposeHttpClient = true,
+				LoggerFactory = new SerilogLoggerFactory(),
+			});
+	}
+}

--- a/src/KurrentDB.Core/Services/VNode/ClusterVNodeController.cs
+++ b/src/KurrentDB.Core/Services/VNode/ClusterVNodeController.cs
@@ -44,9 +44,21 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 	private VNodeState State {
 		get => _state;
 		set {
+			if (_state.CanReplicateToOtherNodes() &&
+				!value.CanReplicateToOtherNodes())
+				EndLeadership();
+
 			_state = value;
 			_statusTracker.OnStateChange(value);
 		}
+	}
+
+	private IEnvelope<ElectionMessage.LeadershipEnded> _leadershipEnvelope = NoopEnvelope.Instance;
+
+	private void EndLeadership() {
+		var envelope = _leadershipEnvelope;
+		_leadershipEnvelope = NoopEnvelope.Instance;
+		envelope.ReplyWith(ElectionMessage.LeadershipEnded.Instance);
 	}
 
 	private MemberInfoLite _leader;
@@ -314,6 +326,7 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 				VNodeState.ReadOnlyLeaderless,
 				VNodeState.PreReadOnlyReplica,
 				VNodeState.ReadOnlyReplica)
+			.When<ElectionMessage.LeaderAppointed>().Do(Handle)
 			.When<ElectionMessage.ElectionsDone>().Do(Handle);
 
 		stm.InStates(
@@ -428,6 +441,27 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 				VNodeState.ResigningLeader)
 			.When<SystemMessage.NoQuorumMessage>().Ignore()
 			.When<ReplicationMessage.ReplicaSubscriptionRequest>().Ignore();
+
+		stm.InStates(
+				VNodeState.PreLeader,
+				VNodeState.Leader,
+				VNodeState.ResigningLeader,
+				VNodeState.PreReplica,
+				VNodeState.CatchingUp,
+				VNodeState.Clone,
+				VNodeState.Follower)
+			.When<SystemMessage.Freeze>().Do(Handle);
+
+		stm.InAllStatesExcept(
+				VNodeState.PreLeader,
+				VNodeState.Leader,
+				VNodeState.ResigningLeader,
+				VNodeState.PreReplica,
+				VNodeState.CatchingUp,
+				VNodeState.Clone,
+				VNodeState.Follower)
+			.When<SystemMessage.Freeze>().Do(m =>
+				m.Envelope.ReplyWith(SystemMessage.Frozen.Instance));
 
 		stm.InState(VNodeState.PreLeader)
 			.When<SystemMessage.BecomeLeader>().Do(Handle)
@@ -704,7 +738,20 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 			return;
 		}
 
-		_leader = message.Leader;
+		await OnLeaderDecided(message, message.Leader, token);
+	}
+
+	private ValueTask Handle(ElectionMessage.LeaderAppointed message, CancellationToken token) {
+		if (message.Leader.InstanceId == _nodeInfo.InstanceId) {
+			EndLeadership();
+			_leadershipEnvelope = message.Envelope;
+		}
+
+		return OnLeaderDecided(message, message.Leader, token);
+	}
+
+	private async ValueTask OnLeaderDecided(Message message, MemberInfoLite leader, CancellationToken token) {
+		_leader = leader;
 		_subscriptionId = Guid.NewGuid();
 		_stateCorrelationId = Guid.NewGuid();
 		_leaderConnectionCorrelationId = Guid.NewGuid();
@@ -1281,6 +1328,13 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 	private ValueTask Handle(SystemMessage.NoQuorumMessage message, CancellationToken token) {
 		Log.Information("=== NO QUORUM EMERGED WITHIN TIMEOUT... RETIRING...");
 		return _fsm.HandleAsync(new SystemMessage.BecomeUnknown(Guid.NewGuid()), token);
+	}
+
+	private async ValueTask Handle(SystemMessage.Freeze message, CancellationToken token) {
+		Log.Information("========== [{httpEndPoint}] IS FROZEN BY THE KONTROL PLANE. State was {State}.",
+			_nodeInfo.HttpEndPoint, State);
+		await _fsm.HandleAsync(new SystemMessage.BecomeUnknown(Guid.NewGuid()), token);
+		message.Envelope.ReplyWith(SystemMessage.Frozen.Instance);
 	}
 
 	private ValueTask Handle(SystemMessage.WaitForChaserToCatchUp message, CancellationToken token) {

--- a/src/KurrentDB.Core/Services/VNode/ClusterVNodeController.cs
+++ b/src/KurrentDB.Core/Services/VNode/ClusterVNodeController.cs
@@ -120,16 +120,22 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 	public ISubscriber MainBus => _outputBus;
 
 	private VNodeFSM CreateFSM() {
-		var stm = new VNodeFSMBuilder(new(this, in _state))
-			.InAnyState()
-			.When<SystemMessage.StateChangeMessage>()
-				.Do(m => Application.Exit(ExitCode.Error,
+		// Order of registrations is irrelevant.
+		// Most derived match wins.
+		// Duplicate registrations is an error at registration time.
+		var stm = new VNodeFSMBuilder(new(this, in _state));
+
+		stm.InAnyState()
+			.When<SystemMessage.StateChangeMessage>().Do(m =>
+				Application.Exit(
+					ExitCode.Error,
 					$"{m.GetType().Name} message was unhandled in {GetType().Name}. State: {State}"))
 			.When<AuthenticationMessage.AuthenticationProviderInitialized>().Do(Handle)
 			.When<AuthenticationMessage.AuthenticationProviderInitializationFailed>().Do(Handle)
 			.When<SystemMessage.SubSystemInitialized>().Do(Handle)
-			.When<SystemMessage.SystemCoreReady>().Do(Handle)
-			.InState(VNodeState.Initializing)
+			.When<SystemMessage.SystemCoreReady>().Do(Handle);
+
+		stm.InState(VNodeState.Initializing)
 			.When<SystemMessage.SystemInit>().Do(Handle)
 			.When<SystemMessage.SystemStart>().Do(Handle)
 			.When<SystemMessage.ServiceInitialized>().Do(Handle)
@@ -137,25 +143,55 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 			.When<SystemMessage.BecomeDiscoverLeader>().Do(Handle)
 			.When<ClientMessage.ScavengeDatabase>().Ignore()
 			.When<ClientMessage.StopDatabaseScavenge>().Ignore()
-			.WhenOther().ForwardTo(_outputBus)
-			.InStates(VNodeState.DiscoverLeader, VNodeState.Unknown, VNodeState.ReadOnlyLeaderless)
-			.WhenOther().ForwardTo(_outputBus)
-			.InStates(VNodeState.Initializing, VNodeState.DiscoverLeader, VNodeState.Leader, VNodeState.ResigningLeader, VNodeState.PreLeader,
-				VNodeState.PreReplica, VNodeState.CatchingUp, VNodeState.Clone, VNodeState.Follower)
-			.When<SystemMessage.BecomeUnknown>().Do(Handle)
-			.InAllStatesExcept(VNodeState.DiscoverLeader, VNodeState.Unknown,
-				VNodeState.PreReplica, VNodeState.CatchingUp, VNodeState.Clone, VNodeState.Follower,
+			.WhenOther().ForwardTo(_outputBus);
+
+		stm.InStates(
+				VNodeState.DiscoverLeader,
+				VNodeState.Unknown,
+				VNodeState.ReadOnlyLeaderless)
+			.WhenOther().ForwardTo(_outputBus);
+
+		stm.InStates(
+				VNodeState.Initializing,
+				VNodeState.DiscoverLeader,
+				VNodeState.Leader,
+				VNodeState.ResigningLeader,
 				VNodeState.PreLeader,
-				VNodeState.Leader, VNodeState.ResigningLeader, VNodeState.ReadOnlyLeaderless,
-				VNodeState.PreReadOnlyReplica, VNodeState.ReadOnlyReplica)
-			.When<ClientMessage.ReadRequestMessage>()
-			.Do(msg => DenyRequestBecauseNotReady(msg.Envelope, msg.CorrelationId))
-			.InAllStatesExcept(VNodeState.Leader, VNodeState.ResigningLeader,
-				VNodeState.PreReplica, VNodeState.CatchingUp, VNodeState.Clone, VNodeState.Follower,
-				VNodeState.ReadOnlyReplica, VNodeState.PreReadOnlyReplica)
-			.When<ClientMessage.WriteRequestMessage>()
-			.Do(msg => DenyRequestBecauseNotReady(msg.Envelope, msg.CorrelationId))
-			.InState(VNodeState.Leader)
+				VNodeState.PreReplica,
+				VNodeState.CatchingUp,
+				VNodeState.Clone,
+				VNodeState.Follower)
+			.When<SystemMessage.BecomeUnknown>().Do(Handle);
+
+		stm.InAllStatesExcept(
+				VNodeState.DiscoverLeader,
+				VNodeState.Unknown,
+				VNodeState.PreReplica,
+				VNodeState.CatchingUp,
+				VNodeState.Clone,
+				VNodeState.Follower,
+				VNodeState.PreLeader,
+				VNodeState.Leader,
+				VNodeState.ResigningLeader,
+				VNodeState.ReadOnlyLeaderless,
+				VNodeState.PreReadOnlyReplica,
+				VNodeState.ReadOnlyReplica)
+			.When<ClientMessage.ReadRequestMessage>().Do(msg =>
+				DenyRequestBecauseNotReady(msg.Envelope, msg.CorrelationId));
+
+		stm.InAllStatesExcept(
+				VNodeState.Leader,
+				VNodeState.ResigningLeader,
+				VNodeState.PreReplica,
+				VNodeState.CatchingUp,
+				VNodeState.Clone,
+				VNodeState.Follower,
+				VNodeState.ReadOnlyReplica,
+				VNodeState.PreReadOnlyReplica)
+			.When<ClientMessage.WriteRequestMessage>().Do(msg =>
+				DenyRequestBecauseNotReady(msg.Envelope, msg.CorrelationId));
+
+		stm.InState(VNodeState.Leader)
 			.When<ClientMessage.ReadEvent>().ForwardTo(_outputBus)
 			.When<ClientMessage.ReadStreamEventsForward>().ForwardTo(_outputBus)
 			.When<ClientMessage.ReadStreamEventsBackward>().ForwardTo(_outputBus)
@@ -177,8 +213,9 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 			.When<ClientMessage.UpdatePersistentSubscriptionToAll>().ForwardTo(_outputBus)
 			.When<ClientMessage.DeletePersistentSubscriptionToAll>().ForwardTo(_outputBus)
 			.When<SystemMessage.InitiateLeaderResignation>().Do(Handle)
-			.When<SystemMessage.BecomeResigningLeader>().Do(Handle)
-			.InState(VNodeState.ResigningLeader)
+			.When<SystemMessage.BecomeResigningLeader>().Do(Handle);
+
+		stm.InState(VNodeState.ResigningLeader)
 			.When<ClientMessage.ReadEvent>().ForwardTo(_outputBus)
 			.When<ClientMessage.ReadStreamEventsForward>().ForwardTo(_outputBus)
 			.When<ClientMessage.ReadStreamEventsBackward>().ForwardTo(_outputBus)
@@ -197,12 +234,21 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 			.When<ClientMessage.ConnectToPersistentSubscriptionToAll>().Do(HandleAsResigningLeader)
 			.When<ClientMessage.UpdatePersistentSubscriptionToAll>().Do(HandleAsResigningLeader)
 			.When<ClientMessage.DeletePersistentSubscriptionToAll>().Do(HandleAsResigningLeader)
-			.When<SystemMessage.RequestQueueDrained>().Do(Handle)
-			.InAllStatesExcept(VNodeState.ResigningLeader)
-			.When<SystemMessage.RequestQueueDrained>().Ignore()
-			.InStates(VNodeState.PreReplica, VNodeState.CatchingUp, VNodeState.Clone, VNodeState.Follower,
-				VNodeState.DiscoverLeader, VNodeState.Unknown, VNodeState.ReadOnlyLeaderless,
-				VNodeState.PreReadOnlyReplica, VNodeState.ReadOnlyReplica)
+			.When<SystemMessage.RequestQueueDrained>().Do(Handle);
+
+		stm.InAllStatesExcept(VNodeState.ResigningLeader)
+			.When<SystemMessage.RequestQueueDrained>().Ignore();
+
+		stm.InStates(
+				VNodeState.PreReplica,
+				VNodeState.CatchingUp,
+				VNodeState.Clone,
+				VNodeState.Follower,
+				VNodeState.DiscoverLeader,
+				VNodeState.Unknown,
+				VNodeState.ReadOnlyLeaderless,
+				VNodeState.PreReadOnlyReplica,
+				VNodeState.ReadOnlyReplica)
 			.When<ClientMessage.ReadEvent>().Do(HandleAsNonLeader)
 			.When<ClientMessage.ReadStreamEventsForward>().Do(HandleAsNonLeader)
 			.When<ClientMessage.ReadStreamEventsBackward>().Do(HandleAsNonLeader)
@@ -220,22 +266,32 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 			.When<ClientMessage.DeletePersistentSubscriptionToAll>().Do(HandleAsNonLeader)
 			.When<ClientMessage.ReplayParkedMessages>().Do(HandleAsNonLeader)
 			.When<ClientMessage.ReplayParkedMessage>().Do(HandleAsNonLeader)
-			.When<ClientMessage.TruncateParkedMessages>().Do(HandleAsNonLeader)
-			.InStates(VNodeState.ReadOnlyLeaderless, VNodeState.PreReadOnlyReplica, VNodeState.ReadOnlyReplica)
+			.When<ClientMessage.TruncateParkedMessages>().Do(HandleAsNonLeader);
+
+		stm.InStates(
+				VNodeState.ReadOnlyLeaderless,
+				VNodeState.PreReadOnlyReplica,
+				VNodeState.ReadOnlyReplica)
 			.When<ClientMessage.WriteEvents>().Do(HandleAsReadOnlyReplica)
 			.When<ClientMessage.TransactionStart>().Do(HandleAsReadOnlyReplica)
 			.When<ClientMessage.TransactionWrite>().Do(HandleAsReadOnlyReplica)
 			.When<ClientMessage.TransactionCommit>().Do(HandleAsReadOnlyReplica)
 			.When<ClientMessage.DeleteStream>().Do(HandleAsReadOnlyReplica)
 			.When<SystemMessage.VNodeConnectionLost>().Do(HandleAsReadOnlyReplica)
-			.When<SystemMessage.BecomePreReadOnlyReplica>().Do(Handle)
-			.InStates(VNodeState.PreReplica, VNodeState.CatchingUp, VNodeState.Clone, VNodeState.Follower)
+			.When<SystemMessage.BecomePreReadOnlyReplica>().Do(Handle);
+
+		stm.InStates(
+				VNodeState.PreReplica,
+				VNodeState.CatchingUp,
+				VNodeState.Clone,
+				VNodeState.Follower)
 			.When<ClientMessage.WriteEvents>().Do(HandleAsNonLeader)
 			.When<ClientMessage.TransactionStart>().Do(HandleAsNonLeader)
 			.When<ClientMessage.TransactionWrite>().Do(HandleAsNonLeader)
 			.When<ClientMessage.TransactionCommit>().Do(HandleAsNonLeader)
-			.When<ClientMessage.DeleteStream>().Do(HandleAsNonLeader)
-			.InAnyState()
+			.When<ClientMessage.DeleteStream>().Do(HandleAsNonLeader);
+
+		stm.InAnyState()
 			.When<ClientMessage.NotHandled>().ForwardTo(_outputBus)
 			.When<ClientMessage.ReadEventCompleted>().ForwardTo(_outputBus)
 			.When<ClientMessage.ReadStreamEventsForwardCompleted>().ForwardTo(_outputBus)
@@ -249,22 +305,47 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 			.When<ClientMessage.TransactionWriteCompleted>().ForwardTo(_outputBus)
 			.When<ClientMessage.TransactionCommitCompleted>().ForwardTo(_outputBus)
 			.When<ClientMessage.DeleteStreamCompleted>().ForwardTo(_outputBus)
-			.When<SystemMessage.BecomeShuttingDown>().Do(Handle)
-			.InAllStatesExcept(VNodeState.Initializing, VNodeState.ShuttingDown, VNodeState.Shutdown,
-			VNodeState.ReadOnlyLeaderless, VNodeState.PreReadOnlyReplica, VNodeState.ReadOnlyReplica)
-			.When<ElectionMessage.ElectionsDone>().Do(Handle)
-			.InStates(VNodeState.DiscoverLeader, VNodeState.Unknown,
-				VNodeState.PreReplica, VNodeState.CatchingUp, VNodeState.Clone, VNodeState.Follower,
-				VNodeState.PreLeader, VNodeState.Leader)
+			.When<SystemMessage.BecomeShuttingDown>().Do(Handle);
+
+		stm.InAllStatesExcept(
+				VNodeState.Initializing,
+				VNodeState.ShuttingDown,
+				VNodeState.Shutdown,
+				VNodeState.ReadOnlyLeaderless,
+				VNodeState.PreReadOnlyReplica,
+				VNodeState.ReadOnlyReplica)
+			.When<ElectionMessage.ElectionsDone>().Do(Handle);
+
+		stm.InStates(
+				VNodeState.DiscoverLeader,
+				VNodeState.Unknown,
+				VNodeState.PreReplica,
+				VNodeState.CatchingUp,
+				VNodeState.Clone,
+				VNodeState.Follower,
+				VNodeState.PreLeader,
+				VNodeState.Leader)
 			.When<SystemMessage.BecomePreReplica>().Do(Handle)
-			.When<SystemMessage.BecomePreLeader>().Do(Handle)
-			.InStates(VNodeState.PreReplica, VNodeState.CatchingUp, VNodeState.Clone, VNodeState.Follower)
+			.When<SystemMessage.BecomePreLeader>().Do(Handle);
+
+		stm.InStates(
+				VNodeState.PreReplica,
+				VNodeState.CatchingUp,
+				VNodeState.Clone,
+				VNodeState.Follower)
 			.When<GossipMessage.GossipUpdated>().Do(HandleAsNonLeader)
-			.When<SystemMessage.VNodeConnectionLost>().Do(Handle)
-			.InAllStatesExcept(VNodeState.PreReplica, VNodeState.PreLeader, VNodeState.PreReadOnlyReplica)
+			.When<SystemMessage.VNodeConnectionLost>().Do(Handle);
+
+		stm.InAllStatesExcept(
+				VNodeState.PreReplica,
+				VNodeState.PreLeader,
+				VNodeState.PreReadOnlyReplica)
 			.When<SystemMessage.WaitForChaserToCatchUp>().Ignore()
-			.When<SystemMessage.ChaserCaughtUp>().Ignore()
-			.InStates(VNodeState.PreReplica, VNodeState.PreReadOnlyReplica)
+			.When<SystemMessage.ChaserCaughtUp>().Ignore();
+
+		stm.InStates(
+				VNodeState.PreReplica,
+				VNodeState.PreReadOnlyReplica)
 			.When<SystemMessage.BecomeCatchingUp>().Do(Handle)
 			.When<SystemMessage.WaitForChaserToCatchUp>().Do(Handle)
 			.When<SystemMessage.ChaserCaughtUp>().Do(HandleAsPreReplica)
@@ -273,65 +354,99 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 			.When<ReplicationMessage.SubscribeToLeader>().Do(Handle)
 			.When<ReplicationMessage.ReplicaSubscriptionRetry>().Do(Handle)
 			.When<ReplicationMessage.ReplicaSubscribed>().Do(Handle)
-			.WhenOther().ForwardTo(_outputBus)
-			.InAllStatesExcept(VNodeState.PreReplica, VNodeState.PreReadOnlyReplica)
+			.WhenOther().ForwardTo(_outputBus);
+
+		stm.InAllStatesExcept(
+				VNodeState.PreReplica,
+				VNodeState.PreReadOnlyReplica)
 			.When<ReplicationMessage.ReconnectToLeader>().Ignore()
 			.When<ReplicationMessage.LeaderConnectionFailed>().Ignore()
 			.When<ReplicationMessage.SubscribeToLeader>().Ignore()
 			.When<ReplicationMessage.ReplicaSubscriptionRetry>().Ignore()
-			.When<ReplicationMessage.ReplicaSubscribed>().Ignore()
-			.InStates(VNodeState.CatchingUp, VNodeState.Clone, VNodeState.Follower, VNodeState.ReadOnlyReplica)
+			.When<ReplicationMessage.ReplicaSubscribed>().Ignore();
+
+		stm.InStates(
+				VNodeState.CatchingUp,
+				VNodeState.Clone,
+				VNodeState.Follower,
+				VNodeState.ReadOnlyReplica)
 			.When<ReplicationMessage.CreateChunk>().Do(ForwardReplicationMessage)
 			.When<ReplicationMessage.RawChunkBulk>().Do(ForwardReplicationMessage)
 			.When<ReplicationMessage.DataChunkBulk>().Do(ForwardReplicationMessage)
 			.When<ReplicationMessage.AckLogPosition>().ForwardTo(_outputBus)
-			.WhenOther().ForwardTo(_outputBus)
-			.InAllStatesExcept(VNodeState.CatchingUp, VNodeState.Clone, VNodeState.Follower, VNodeState.ReadOnlyReplica)
+			.WhenOther().ForwardTo(_outputBus);
+
+		stm.InAllStatesExcept(
+				VNodeState.CatchingUp,
+				VNodeState.Clone,
+				VNodeState.Follower,
+				VNodeState.ReadOnlyReplica)
 			.When<ReplicationMessage.CreateChunk>().Ignore()
 			.When<ReplicationMessage.RawChunkBulk>().Ignore()
 			.When<ReplicationMessage.DataChunkBulk>().Ignore()
-			.When<ReplicationMessage.AckLogPosition>().Ignore()
-			.InState(VNodeState.CatchingUp)
+			.When<ReplicationMessage.AckLogPosition>().Ignore();
+
+		stm.InState(VNodeState.CatchingUp)
 			.When<ReplicationMessage.CloneAssignment>().Do(Handle)
 			.When<ReplicationMessage.FollowerAssignment>().Do(Handle)
 			.When<SystemMessage.BecomeClone>().Do(Handle)
-			.When<SystemMessage.BecomeFollower>().Do(Handle)
-			.InState(VNodeState.Clone)
+			.When<SystemMessage.BecomeFollower>().Do(Handle);
+
+		stm.InState(VNodeState.Clone)
 			.When<ReplicationMessage.DropSubscription>().Do(Handle)
 			.When<ReplicationMessage.FollowerAssignment>().Do(Handle)
-			.When<SystemMessage.BecomeFollower>().Do(Handle)
-			.InState(VNodeState.Follower)
+			.When<SystemMessage.BecomeFollower>().Do(Handle);
+
+		stm.InState(VNodeState.Follower)
 			.When<ReplicationMessage.CloneAssignment>().Do(Handle)
-			.When<SystemMessage.BecomeClone>().Do(Handle)
-			.InStates(VNodeState.PreReadOnlyReplica, VNodeState.ReadOnlyReplica)
+			.When<SystemMessage.BecomeClone>().Do(Handle);
+
+		stm.InStates(
+				VNodeState.PreReadOnlyReplica,
+				VNodeState.ReadOnlyReplica)
 			.When<GossipMessage.GossipUpdated>().Do(HandleAsReadOnlyReplica)
-			.When<SystemMessage.BecomeReadOnlyLeaderless>().Do(Handle)
-			.InStates(VNodeState.ReadOnlyLeaderless)
-			.When<GossipMessage.GossipUpdated>().Do(HandleAsReadOnlyLeaderLess)
-			.InState(VNodeState.PreReadOnlyReplica)
-			.When<SystemMessage.BecomeReadOnlyReplica>().Do(Handle)
-			.InStates(VNodeState.PreLeader, VNodeState.Leader, VNodeState.ResigningLeader)
+			.When<SystemMessage.BecomeReadOnlyLeaderless>().Do(Handle);
+
+		stm.InStates(VNodeState.ReadOnlyLeaderless)
+			.When<GossipMessage.GossipUpdated>().Do(HandleAsReadOnlyLeaderLess);
+
+		stm.InState(VNodeState.PreReadOnlyReplica)
+			.When<SystemMessage.BecomeReadOnlyReplica>().Do(Handle);
+
+		stm.InStates(
+				VNodeState.PreLeader,
+				VNodeState.Leader,
+				VNodeState.ResigningLeader)
 			.When<SystemMessage.NoQuorumMessage>().Do(Handle)
 			.When<GossipMessage.GossipUpdated>().Do(HandleAsLeader)
 			.When<ReplicationMessage.ReplicaSubscriptionRequest>().ForwardTo(_outputBus)
-			.When<ReplicationMessage.ReplicaLogPositionAck>().ForwardTo(_outputBus)
-			.InAllStatesExcept(VNodeState.PreLeader, VNodeState.Leader, VNodeState.ResigningLeader)
+			.When<ReplicationMessage.ReplicaLogPositionAck>().ForwardTo(_outputBus);
+
+		stm.InAllStatesExcept(
+				VNodeState.PreLeader,
+				VNodeState.Leader,
+				VNodeState.ResigningLeader)
 			.When<SystemMessage.NoQuorumMessage>().Ignore()
-			.When<ReplicationMessage.ReplicaSubscriptionRequest>().Ignore()
-			.InState(VNodeState.PreLeader)
+			.When<ReplicationMessage.ReplicaSubscriptionRequest>().Ignore();
+
+		stm.InState(VNodeState.PreLeader)
 			.When<SystemMessage.BecomeLeader>().Do(Handle)
 			.When<SystemMessage.WaitForChaserToCatchUp>().Do(Handle)
 			.When<SystemMessage.ChaserCaughtUp>().Do(HandleAsPreLeader)
-			.WhenOther().ForwardTo(_outputBus)
-			.InStates(VNodeState.Leader, VNodeState.ResigningLeader)
+			.WhenOther().ForwardTo(_outputBus);
+
+		stm.InStates(
+				VNodeState.Leader,
+				VNodeState.ResigningLeader)
 			.When<StorageMessage.WritePrepares>().ForwardTo(_outputBus)
 			.When<StorageMessage.WriteDelete>().ForwardTo(_outputBus)
 			.When<StorageMessage.WriteTransactionStart>().ForwardTo(_outputBus)
 			.When<StorageMessage.WriteTransactionData>().ForwardTo(_outputBus)
 			.When<StorageMessage.WriteTransactionEnd>().ForwardTo(_outputBus)
 			.When<StorageMessage.WriteCommit>().ForwardTo(_outputBus)
-			.WhenOther().ForwardTo(_outputBus)
-			.InAllStatesExcept(VNodeState.Leader, VNodeState.ResigningLeader)
+			.WhenOther().ForwardTo(_outputBus);
+
+		stm.InAllStatesExcept(VNodeState.Leader, VNodeState.ResigningLeader)
 			.When<SystemMessage.InitiateLeaderResignation>().Ignore()
 			.When<SystemMessage.BecomeResigningLeader>().Ignore()
 			.When<StorageMessage.WritePrepares>().Ignore()
@@ -339,18 +454,23 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 			.When<StorageMessage.WriteTransactionStart>().Ignore()
 			.When<StorageMessage.WriteTransactionData>().Ignore()
 			.When<StorageMessage.WriteTransactionEnd>().Ignore()
-			.When<StorageMessage.WriteCommit>().Ignore()
-			.InState(VNodeState.ShuttingDown)
+			.When<StorageMessage.WriteCommit>().Ignore();
+
+		stm.InState(VNodeState.ShuttingDown)
 			.When<SystemMessage.BecomeShutdown>().Do(Handle)
-			.When<SystemMessage.ShutdownTimeout>().Do(Handle)
-			.InStates(VNodeState.ShuttingDown, VNodeState.Shutdown)
+			.When<SystemMessage.ShutdownTimeout>().Do(Handle);
+
+		stm.InStates(
+				VNodeState.ShuttingDown,
+				VNodeState.Shutdown)
 			.When<SystemMessage.ServiceShutdown>().Do(Handle)
-			.WhenOther().ForwardTo(_outputBus)
-			.InState(VNodeState.DiscoverLeader)
+			.WhenOther().ForwardTo(_outputBus);
+
+		stm.InState(VNodeState.DiscoverLeader)
 			.When<GossipMessage.GossipUpdated>().Do(HandleAsDiscoverLeader)
-			.When<LeaderDiscoveryMessage.DiscoveryTimeout>().Do(HandleAsDiscoverLeader)
-			.Build();
-		return stm;
+			.When<LeaderDiscoveryMessage.DiscoveryTimeout>().Do(HandleAsDiscoverLeader);
+
+		return stm.Build();
 	}
 
 	public void Start() => _mainQueue.Start();

--- a/src/KurrentDB.Core/Services/VNode/ClusterVNodeController.cs
+++ b/src/KurrentDB.Core/Services/VNode/ClusterVNodeController.cs
@@ -18,6 +18,7 @@ using KurrentDB.Core.Services.Storage;
 using KurrentDB.Core.Services.TimerService;
 using KurrentDB.Core.Services.UserManagement;
 using KurrentDB.Core.TransactionLog.Chunks;
+using Serilog.Events;
 using ILogger = Serilog.ILogger;
 using OperationResult = KurrentDB.Core.Messages.OperationResult;
 
@@ -1395,7 +1396,10 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 	}
 
 	private async ValueTask Handle(ReplicationMessage.ReplicaSubscriptionRetry message, CancellationToken token) {
-		if (IsLegitimateReplicationMessage(message)) {
+		// ReplicaSubscriptionRetry means the node isn't ready to replicate yet or it wasn't the node we were intending
+		// to replicate from (the leaderId on the request didn't match the instanceId of the node)
+		// Therefore it is ok if the leaderId doesn't match; we don't need to ensure it, we just skip handling the message.
+		if (IsLegitimateReplicationMessage(message, ensureLeaderIdMatch: false)) {
 			await _outputBus.DispatchAsync(message, token);
 
 			var msg = new ReplicationMessage.SubscribeToLeader(_stateCorrelationId, _leader.InstanceId,
@@ -1470,7 +1474,7 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 		return task;
 	}
 
-	private bool IsLegitimateReplicationMessage(ReplicationMessage.IReplicationMessage message) {
+	private bool IsLegitimateReplicationMessage(ReplicationMessage.IReplicationMessage message, bool ensureLeaderIdMatch = true) {
 		if (message.SubscriptionId == Guid.Empty)
 			throw new Exception("IReplicationMessage with empty SubscriptionId provided.");
 		if (message.SubscriptionId != _subscriptionId) {
@@ -1481,13 +1485,20 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 		}
 
 		if (_leader == null || _leader.InstanceId != message.LeaderId) {
-			var msg = string.Format("{0} message passed SubscriptionId check, but leader is either null or wrong. "
-									+ "Message.Leader: [{1:B}], VNode Leader: {2}.",
+			// it is ok for instanceId not to match for ReplicaSubscriptionRetry
+			Log.Write(
+				ensureLeaderIdMatch ? LogEventLevel.Fatal : LogEventLevel.Debug,
+				"{messageType} message passed SubscriptionId check, but leader is either null or wrong. " +
+				"Message.Leader: [{leaderId:B}], VNode Leader: {leaderInfo}.",
 				message.GetType().Name, message.LeaderId, _leader);
-			Log.Fatal("{messageType} message passed SubscriptionId check, but leader is either null or wrong. "
-					  + "Message.Leader: [{leaderId:B}], VNode Leader: {leaderInfo}.",
-				message.GetType().Name, message.LeaderId, _leader);
-			Application.Exit(ExitCode.Error, msg);
+
+			if (ensureLeaderIdMatch) {
+				Application.Exit(ExitCode.Error, string.Format(
+					"{0} message passed SubscriptionId check, but leader is either null or wrong. " +
+					"Message.Leader: [{1:B}], VNode Leader: {2}.",
+					message.GetType().Name, message.LeaderId, _leader));
+			}
+
 			return false;
 		}
 

--- a/src/KurrentDB.Core/Services/VNode/ClusterVNodeController.cs
+++ b/src/KurrentDB.Core/Services/VNode/ClusterVNodeController.cs
@@ -35,6 +35,7 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 	private static readonly TimeSpan LeaderSubscriptionTimeout = TimeSpan.FromMilliseconds(1000);
 	private static readonly TimeSpan LeaderDiscoveryTimeout = TimeSpan.FromMilliseconds(3000);
 
+	private readonly bool _clusterIsUsingKontrolPlane;
 	private readonly InMemoryBus _outputBus;
 	private readonly VNodeInfo _nodeInfo;
 	private readonly TFChunkDb _db;
@@ -104,6 +105,7 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 		Ensure.NotNull(forwardingProxy, "forwardingProxy");
 		Ensure.NotNull(startSubsystems, "startSubsystems");
 
+		_clusterIsUsingKontrolPlane = options.ClusterIsUsingKontrolPlane;
 		_nodeInfo = nodeInfo;
 		_db = db;
 		_node = node;
@@ -145,6 +147,7 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 					$"{m.GetType().Name} message was unhandled in {GetType().Name}. State: {State}"))
 			.When<AuthenticationMessage.AuthenticationProviderInitialized>().Do(Handle)
 			.When<AuthenticationMessage.AuthenticationProviderInitializationFailed>().Do(Handle)
+			.When<ClientMessage.ResignNode>().Do(Handle)
 			.When<SystemMessage.SubSystemInitialized>().Do(Handle)
 			.When<SystemMessage.SystemCoreReady>().Do(Handle);
 
@@ -522,7 +525,7 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 		var id = Guid.NewGuid();
 		Message msg = _nodeInfo.IsReadOnlyReplica
 			? new SystemMessage.BecomeReadOnlyLeaderless(id)
-			: _clusterSize > 1
+			: _clusterSize > 1 && !_clusterIsUsingKontrolPlane
 				? new SystemMessage.BecomeDiscoverLeader(id)
 				: new SystemMessage.BecomeUnknown(id);
 
@@ -535,10 +538,21 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 		State = VNodeState.Unknown;
 		_leader = null;
 		await _outputBus.DispatchAsync(message, token);
-		_mainQueue.Publish(new ElectionMessage.StartElections());
+
+		if (_clusterIsUsingKontrolPlane) {
+			// NoOp. KPlane will tell us what to do next.
+		} else {
+			_mainQueue.Publish(new ElectionMessage.StartElections());
+		}
 	}
 
 	private async ValueTask Handle(SystemMessage.BecomeDiscoverLeader message, CancellationToken token) {
+		if (_clusterIsUsingKontrolPlane) {
+			// Not allowed to discover leader from gossip in KPlane mode, must be told the leader by the kplane.
+			// If we discover it from gossip we may subvert the KPlane's fence on an old epoch.
+			throw new InvalidOperationException();
+		}
+
 		Log.Information("========== [{httpEndPoint}] IS ATTEMPTING TO DISCOVER EXISTING LEADER...", _nodeInfo.HttpEndPoint);
 
 		State = VNodeState.DiscoverLeader;
@@ -546,6 +560,23 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 
 		var msg = new LeaderDiscoveryMessage.DiscoveryTimeout();
 		_mainQueue.Publish(TimerMessage.Schedule.Create(LeaderDiscoveryTimeout, _publishEnvelope, msg));
+	}
+
+	private ValueTask Handle(ClientMessage.ResignNode message, CancellationToken token) {
+		if (!_clusterIsUsingKontrolPlane) {
+			return _outputBus.DispatchAsync(message, token);
+		}
+
+		if (!_state.CanReplicateToOtherNodes()) {
+			Log.Information(
+				"========== [{httpEndPoint}] IGNORING RESIGNATION: THIS NODE DOES NOT HOLD LEADERSHIP. State: {state}.",
+				_nodeInfo.HttpEndPoint, _state);
+			return ValueTask.CompletedTask;
+		}
+
+		// works in the same was as NoQuorumMessage
+		Log.Information("========== [{httpEndPoint}] IS RESIGNING LEADERSHIP...", _nodeInfo.HttpEndPoint);
+		return _fsm.HandleAsync(new SystemMessage.BecomeUnknown(Guid.NewGuid()), token);
 	}
 
 	private ValueTask Handle(SystemMessage.InitiateLeaderResignation message, CancellationToken token) {
@@ -1221,7 +1252,9 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 		if (_leader is null)
 			return ValueTask.FromException(new Exception("_leader == null"));
 
-		if (message.ClusterInfo.Members.Count(IsAliveLeader) > 1) {
+		if (_clusterIsUsingKontrolPlane) {
+			// Don't start elections, KPlane will tell us what to do.
+		} else if (message.ClusterInfo.Members.Count(IsAliveLeader) > 1) {
 			Log.Debug("There are MULTIPLE LEADERS according to gossip, need to start elections. LEADER: [{leader}]",
 				_leader);
 			Log.Debug("GOSSIP:");
@@ -1280,6 +1313,11 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 		if (_leader is null)
 			return ValueTask.FromException(new Exception("_leader == null"));
 
+		if (_clusterIsUsingKontrolPlane) {
+			// Don't start elections. KPlane will tell us what to do.
+			return _outputBus.DispatchAsync(message, token);
+		}
+
 		var leader = message.ClusterInfo.Members.FirstOrDefault(x => x.InstanceId == _leader.InstanceId);
 		if (leader is null or { IsAlive: false }) {
 			Log.Debug(
@@ -1332,7 +1370,7 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController {
 	}
 
 	private async ValueTask Handle(SystemMessage.Freeze message, CancellationToken token) {
-		Log.Information("========== [{httpEndPoint}] IS FROZEN BY THE KONTROL PLANE. State was {State}.",
+		Log.Information("========== [{httpEndPoint}] IS FREEZING. State was {State}.",
 			_nodeInfo.HttpEndPoint, State);
 		await _fsm.HandleAsync(new SystemMessage.BecomeUnknown(Guid.NewGuid()), token);
 		message.Envelope.ReplyWith(SystemMessage.Frozen.Instance);

--- a/src/KurrentDB.Core/Services/VNode/DatabaseStateHandler.cs
+++ b/src/KurrentDB.Core/Services/VNode/DatabaseStateHandler.cs
@@ -212,7 +212,7 @@ public sealed class DatabaseStateHandler :
 	}
 
 	// Tells the node who the Kontrol Plane has appointed, once it is in a state to hear it.
-	private async Task AnnounceLeaderAsync(
+	private async ValueTask AnnounceLeaderAsync(
 		DatabaseNode leaderNode,
 		int epochNumber,
 		IEnvelope<ElectionMessage.LeadershipEnded>? envelope,

--- a/src/KurrentDB.Core/Services/VNode/DatabaseStateHandler.cs
+++ b/src/KurrentDB.Core/Services/VNode/DatabaseStateHandler.cs
@@ -1,0 +1,250 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using DotNext.Threading;
+using KurrentDB.Common.Utils;
+using KurrentDB.Core.Bus;
+using KurrentDB.Core.Cluster;
+using KurrentDB.Core.Messages;
+using KurrentDB.Core.Messaging;
+using KurrentDB.Core.Services.Storage.EpochManager;
+using KurrentDB.Core.TransactionLog.Checkpoint;
+using KurrentDB.DataPlane;
+using KurrentDB.KontrolPlane;
+using ILogger = Serilog.ILogger;
+
+namespace KurrentDB.Core.Services.VNode;
+
+/// <summary>
+/// Drives this node's <see cref="VNodeFSM"/> from the leader appointments made by the Kontrol Plane.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Threading:
+///   - CurrentNode and _nodePriority are written serially but can be read concurrently.
+///   - The <see cref="IDatabaseStateHandler"/> methods are called serially.
+/// </para>
+/// </remarks>
+public sealed class DatabaseStateHandler :
+	IDatabaseStateHandler,
+	IHandle<ClientMessage.SetNodePriority>,
+	IHandle<SystemMessage.SystemStart>,
+	IHandle<SystemMessage.BecomeShuttingDown> {
+
+	private static readonly ILogger Log = Serilog.Log.ForContext<DatabaseStateHandler>();
+
+	private readonly IPublisher _mainQueue;
+	private readonly IEpochManager _epochManager;
+	private readonly IReadOnlyCheckpoint _writerCheckpoint;
+	private readonly IReadOnlyCheckpoint _chaserCheckpoint;
+	private readonly CancellationTokenSource _cts = new();
+	private readonly TaskCompletionSource _systemInitialized = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+	private int _nodePriority;
+
+	public DatabaseStateHandler(
+		IPublisher mainQueue,
+		IEpochManager epochManager,
+		IReadOnlyCheckpoint writerCheckpoint,
+		IReadOnlyCheckpoint chaserCheckpoint,
+		DatabaseNode currentNode,
+		int nodePriority) {
+
+		_mainQueue = Ensure.NotNull(mainQueue);
+		_epochManager = Ensure.NotNull(epochManager);
+		_writerCheckpoint = Ensure.NotNull(writerCheckpoint);
+		_chaserCheckpoint = Ensure.NotNull(chaserCheckpoint);
+		CurrentNode = Ensure.NotNull(currentNode);
+		_nodePriority = nodePriority;
+	}
+
+	/// <inheritdoc/>
+	public DatabaseNode CurrentNode { get; set; }
+
+	private bool IsReadOnlyReplica =>
+		CurrentNode.Role is DatabaseNodeRole.ReadOnlyReplica;
+
+	public void Handle(ClientMessage.SetNodePriority message) {
+		Log.Information("Setting Node Priority to {nodePriority}.", message.NodePriority);
+		_nodePriority = message.NodePriority;
+		_mainQueue.Publish(new GossipMessage.UpdateNodePriority(message.NodePriority));
+	}
+
+	// System has initialized, is now being told to start.
+	public void Handle(SystemMessage.SystemStart message) =>
+		_systemInitialized.TrySetResult();
+
+	public void Handle(SystemMessage.BecomeShuttingDown message) =>
+		_cts.Cancel();
+
+	/// <inheritdoc/>
+	public ValueTask<ReplicaState> GetReplicaStateAsync(CancellationToken token) {
+		if (!_systemInitialized.Task.IsCompleted) {
+			// we need epochManager to be initialized with the last epoch
+			// this should never happen in a multi-node cluster because the relevant gRPC service goes live after initialization
+			// but could happen single node, and then the kplane will retry.
+			throw new InvalidOperationException("System not yet initialized");
+		}
+
+		// when no epochs have been written LastEpochNumber is -1 but we need a ulong.
+		// bumping it to 0 is safe because writer checkpoint will also reflect that no epoch is written.
+		var epoch = (ulong)Math.Max(0, _epochManager.LastEpochNumber); 
+		return ValueTask.FromResult(new ReplicaState(
+			Epoch: epoch,
+			WriterCheckpoint: _writerCheckpoint.ReadNonFlushed(), // followers ack unflushed
+			ChaserCheckpoint: _chaserCheckpoint.ReadNonFlushed(), // chaser not important for correctness just speed of transition
+			Priority: _nodePriority,
+			InstanceId: CurrentNode.InstanceId));
+	}
+
+	/// <inheritdoc/>
+	public async Task RunReplicationAsync(Database database, DatabaseNode leaderNode, CancellationToken token) {
+		try {
+			var epochNumber = ToEpochNumber(database.Epoch);
+			Log.Information(
+				"Kontrol plane appointed [{leaderAddress}] as leader of database '{databaseId}' at epoch {epoch}.",
+				leaderNode.Address, database.Id, epochNumber);
+
+			// Notify the node of who was appointed leader. Replication begins.
+			await AnnounceLeaderAsync(leaderNode, epochNumber, envelope: null, token);
+
+			await token.WaitAsync();
+		} finally {
+			if (!IsReadOnlyReplica) {
+				await Freeze(token.IsCancellationRequested
+					? FreezeTrigger.KPlane
+					: FreezeTrigger.Unknown);
+			} else {
+				// Don't freeze RoR. No need because they don't participate in committing new data
+				// and there isn't currently  a state we can put them in where they will stay frozen.
+			}
+		}
+	}
+
+	/// <inheritdoc/>
+	public async Task RunLeadershipAsync(
+		DatabaseCluster initial,
+		IAsyncEnumerable<DatabaseCluster> changes,
+		CancellationToken token) {
+
+		var endedDueToVNodeStateTransition = false;
+		try {
+			var epochNumber = ToEpochNumber(initial.Epoch);
+			var thisNode = CurrentNode;
+			Log.Information(
+				"Kontrol plane appointed this node as leader of database '{databaseId}' at epoch {epoch}.",
+				initial.Id, epochNumber);
+
+			// This transitions the node into PreLeader. The inauguration manager takes it from there
+			// and moves us to Leader once the epoch record for this appointment has been replicated.
+			// Alternatively inauguration may fail, moving us out of a leadership related state.
+			var leadershipEnded = new TcsEnvelope<ElectionMessage.LeadershipEnded>();
+			await AnnounceLeaderAsync(thisNode, epochNumber, leadershipEnded, token);
+
+			await leadershipEnded.Task.WaitAsync(token);
+			endedDueToVNodeStateTransition = true;
+		} finally {
+			var trigger = (endedDueToVNodeStateTransition, token.IsCancellationRequested) switch {
+				(true, _) => FreezeTrigger.ClusterVNode,
+				(_, true) => FreezeTrigger.KPlane,
+				_ => FreezeTrigger.Unknown,
+			};
+			await Freeze(trigger);
+		}
+	}
+
+	enum FreezeTrigger {
+		Unknown,
+		ClusterVNode,
+		KPlane,
+	}
+
+	// Stops replication in the sense of stopping this node from participating in the commit process.
+	//
+	// With a naive selection of a leader by highest (epoch, writer checkpoint) pair, the problem is that a
+	// node might be appointed leader, then, before it actually becomes the leader, some additional data gets
+	// committed on the previous epoch which then gets truncated on this epoch.
+	//
+	// We therefore stop the leader of the previous epoch from committing any extra data before we appoint a
+	// new leader. This is called fence, which we require to be acked by the majority of the regular nodes.
+	// We don't try to fence only the leader because it might not be reachable. The fence is an instruction
+	// to the nodes to stop trying to get data committed for earlier epochs. When a node has done this it
+	// returns its epoch and writer checkpoint which are an upper bound of what that node has acked
+	// (i.e. we might have acked less, but we have not acked more).
+	//
+	// It is ok if the reported writer checkpoint is higher than what we acked, as long as we still have data
+	// up to that point if we get appointed.
+	//
+	// We use the unflushed writer checkpoint in particular, because followers ack (allowing commit) before flushing.
+	//
+	// We just need to make sure that whatever we ack doesn't exceed the reported writer checkpoint.
+	// - Previous ACKS may already be in the send queues or on the wire, but these are necessarily less than
+	//   or equal to the writer checkpoint.
+	// - At the time we read the writer checkpoint, further writes may be in the writer queue so the writer
+	//   checkpoint may continue to move and even be flushed.
+	//     - That's ok on followers because the subsequent ReplicationMessage.AckLogPosition messages are
+	//       blocked by ClusterVNodeController
+	//     - That's ok on the leader because the replication checkpoint is only advanced in Leader & Preleader
+	//       (see ReplicationTrackingService)
+	//     - ReadOnlyReplicas don't need to freeze because they never contribute to data becoming committed.
+	private async ValueTask Freeze(FreezeTrigger trigger) {
+		Debug.Assert(!IsReadOnlyReplica);
+
+		Log.Debug("Freezing. Trigger: {trigger}...", trigger);
+		var frozen = new TcsEnvelope<SystemMessage.Frozen>();
+		_mainQueue.Publish(new SystemMessage.Freeze(frozen));
+
+		try {
+			// if we are ShuttingDown then we may not get a reply to the freeze
+			// but we are already frozen (the ClusterVNodeController has already transitioned)
+			await frozen.Task.WaitAsync(_cts.Token);
+			Log.Debug("Frozen");
+		} catch (OperationCanceledException oce) when (oce.CancellationToken == _cts.Token) {
+			Log.Debug("Freeze cancelled for shutdown");
+		}
+	}
+
+	// Tells the node who the Kontrol Plane has appointed, once it is in a state to hear it.
+	private async Task AnnounceLeaderAsync(
+		DatabaseNode leaderNode,
+		int epochNumber,
+		IEnvelope<ElectionMessage.LeadershipEnded>? envelope,
+		CancellationToken token) {
+
+		if (!_systemInitialized.Task.IsCompleted) {
+			// be ready for LeaderAppointed message
+			Log.Information("Waiting for system to be initialized before announcing the appointed leader...");
+			await _systemInitialized.Task.WaitAsync(token);
+			Log.Information("System initialized, announcing the appointed leader.");
+		}
+
+		_mainQueue.Publish(new ElectionMessage.LeaderAppointed(
+			epochNumber: epochNumber,
+			leader: ToLeaderMemberInfo(leaderNode, epochNumber),
+			envelope: envelope));
+	}
+
+	// The Kontrol Plane epoch is what the appointed leader writes as the epoch number of its epoch
+	// record, so the two numbering schemes are the same one - only the widths differ.
+	private static int ToEpochNumber(ulong epoch) => epoch <= int.MaxValue
+		? (int)epoch
+		: throw new InvalidOperationException(
+			$"Kontrol Plane epoch {epoch} is larger than the largest epoch number this node can write ({int.MaxValue}).");
+
+	private static MemberInfoLite ToLeaderMemberInfo(DatabaseNode node, int epochNumber) => new() {
+		InstanceId = node.InstanceId,
+		HttpEndPoint = node.Address,
+		ReplicationEndPoint = node.ReplicationProtocolAddress,
+		ClientHttpEndPoint = node.ClientApiAddress,
+		ClientTcpPort = node.ClientTcpApiPort,
+		ClientTcpApiIsSecure = node.ClientTcpApiIsSecure,
+		EpochNumber = epochNumber,
+	};
+}

--- a/src/KurrentDB.Core/Services/VNode/InaugurationManager.cs
+++ b/src/KurrentDB.Core/Services/VNode/InaugurationManager.cs
@@ -20,6 +20,7 @@ public class InaugurationManager :
 	IHandle<SystemMessage.EpochWritten>,
 	IHandle<SystemMessage.CheckInaugurationConditions>,
 	IHandle<ElectionMessage.ElectionsDone>,
+	IHandle<ElectionMessage.LeaderAppointed>,
 	IHandle<ReplicationTrackingMessage.ReplicatedTo>,
 	IHandle<ReplicationTrackingMessage.IndexedTo> {
 
@@ -73,6 +74,11 @@ public class InaugurationManager :
 
 	public void Handle(ElectionMessage.ElectionsDone received) {
 		_currentEpochNumber = received.ProposalNumber;
+		Received(received, "currentEpochNumber {currentEpochNumber}.", _currentEpochNumber);
+	}
+
+	public void Handle(ElectionMessage.LeaderAppointed received) {
+		_currentEpochNumber = received.EpochNumber;
 		Received(received, "currentEpochNumber {currentEpochNumber}.", _currentEpochNumber);
 	}
 

--- a/src/KurrentDB.Core/Settings/ESConsts.cs
+++ b/src/KurrentDB.Core/Settings/ESConsts.cs
@@ -27,4 +27,15 @@ public static class ESConsts {
 	public const string DefaultIndexDirectoryName = "index";
 	public const string StreamExistenceFilterDirectoryName = "stream-existence";
 	public const string KontrollerDirectoryName = "kontroller";
+
+	public const int KPlaneConnectionPoolCapacity = 32;
+
+	// number of records to accumulate in wal before squash
+	public const int KPlaneSnapshotDepth = 512;
+
+	// renewal delay as a multiple of timeout
+	public const double KPlaneRenewalRate = 0.5;
+
+	// Normal HTTP timeout
+	public const int KPlaneUnaryCallTimeoutMs = 30_000;
 }

--- a/src/KurrentDB.Core/Telemetry/TelemetryService.cs
+++ b/src/KurrentDB.Core/Telemetry/TelemetryService.cs
@@ -32,6 +32,7 @@ namespace KurrentDB.Core.Telemetry;
 public sealed class TelemetryService :
 	IHandle<SystemMessage.StateChangeMessage>,
 	IHandle<ElectionMessage.ElectionsDone>,
+	IHandle<ElectionMessage.LeaderAppointed>,
 	IHandle<SystemMessage.ReplicaStateMessage>,
 	IHandle<LeaderDiscoveryMessage.LeaderFound>,
 	IAsyncDisposable {
@@ -162,6 +163,12 @@ public sealed class TelemetryService :
 		_epochNumber = message.ProposalNumber;
 		_leaderId = message.Leader.InstanceId;
 	}
+
+	public void Handle(ElectionMessage.LeaderAppointed message) {
+		_epochNumber = message.EpochNumber;
+		_leaderId = message.Leader.InstanceId;
+	}
+
 	public void Handle(SystemMessage.ReplicaStateMessage message) {
 		_epochNumber = message.Leader.EpochNumber;
 		_leaderId = message.Leader.InstanceId;

--- a/src/KurrentDB.DataPlane/DataPlane/DatabaseManager.StateMachine.cs
+++ b/src/KurrentDB.DataPlane/DataPlane/DatabaseManager.StateMachine.cs
@@ -16,6 +16,8 @@ partial class DatabaseManager : IDatabaseStateMachine {
 			advanced = _clusterInfo is null || _clusterInfo.Epoch <= newVersion.Epoch;
 			if (advanced) {
 				await ChangeStateAsync(_clusterInfo, newVersion);
+			} else {
+				_logger.Debug($"Ignoring cluster info from epoch {newVersion.Epoch} because we are on epoch {_clusterInfo?.Epoch}");
 			}
 
 			_clusterInfo = newVersion;

--- a/src/KurrentDB.DataPlane/DataPlane/DatabaseManager.StateMachine.cs
+++ b/src/KurrentDB.DataPlane/DataPlane/DatabaseManager.StateMachine.cs
@@ -98,7 +98,9 @@ partial class DatabaseManager : IDatabaseStateMachine {
 			lockTaken = true;
 
 			if (transition.IsValid(_state)) {
-				await ChangeStateAsync(new ResigningState(KontrolPlane, transition.DatabaseId, transition.CurrentEpoch));
+				var newState = new ResigningState(KontrolPlane, transition.DatabaseId, transition.CurrentEpoch);
+				await ChangeStateAsync(newState);
+				newState.TryStart();
 			}
 		} catch {
 			// we can't throw here, it's async void method

--- a/src/KurrentDB.DataPlane/DataPlane/DatabaseManager.cs
+++ b/src/KurrentDB.DataPlane/DataPlane/DatabaseManager.cs
@@ -74,7 +74,7 @@ public sealed partial class DatabaseManager : IAsyncEnumerable<DatabaseCluster> 
 	}
 
 	/// <summary>
-	/// Stops any incoming replication.
+	/// Stops any incoming & outgoing replication.
 	/// </summary>
 	/// <param name="currentEpoch">The epoch reported by the KPlane.</param>
 	/// <param name="token">The token that can be used to cancel the operation.</param>

--- a/src/KurrentDB.DataPlane/DataPlane/FollowerState.cs
+++ b/src/KurrentDB.DataPlane/DataPlane/FollowerState.cs
@@ -5,6 +5,7 @@ namespace KurrentDB.DataPlane;
 
 using KontrolPlane;
 
+// Follower (including RoR), replicating from the leader.
 internal sealed class FollowerState(IDatabaseStateHandler handler, DatabaseCluster database) : DatabaseState {
 	protected override Task RunAsync() {
 		return database.LeaderNode is { } leaderNode

--- a/src/KurrentDB.DataPlane/DataPlane/FrozenState.cs
+++ b/src/KurrentDB.DataPlane/DataPlane/FrozenState.cs
@@ -6,6 +6,8 @@ namespace KurrentDB.DataPlane;
 
 using KontrolPlane;
 
+// Data is frozen, no replication is happening to or from this node in the sense that
+// it is not contributing towards the commit process.
 internal class FrozenState : DatabaseState {
 	protected override Task RunAsync() => Task.CompletedTask;
 }

--- a/src/KurrentDB.DataPlane/DataPlane/IDatabaseStateHandler.cs
+++ b/src/KurrentDB.DataPlane/DataPlane/IDatabaseStateHandler.cs
@@ -34,7 +34,7 @@ public interface IDatabaseStateHandler {
 	/// <param name="changes">An infinite sequence of database cluster changes.</param>
 	/// <param name="token">The token that can be used to cancel the operation.</param>
 	/// <returns>The task representing asynchronous state of the operation.</returns>
-	Task RunLeadershipAsync(IAsyncEnumerable<DatabaseCluster> changes, CancellationToken token);
+	Task RunLeadershipAsync(DatabaseCluster initial, IAsyncEnumerable<DatabaseCluster> changes, CancellationToken token);
 
 	/// <summary>
 	/// Gets the replication state

--- a/src/KurrentDB.DataPlane/DataPlane/IDatabaseStateHandler.cs
+++ b/src/KurrentDB.DataPlane/DataPlane/IDatabaseStateHandler.cs
@@ -15,8 +15,9 @@ public interface IDatabaseStateHandler {
 	/// <remarks>
 	/// This method implements Follower state logic.
 	/// If method returns, it doesn't force DPlane to switch the state.
+	/// DataPlane state machine calls this for followers (including RoR) to start replication.
 	/// </remarks>
-	/// <param name="database">The database descriptor.</param>
+	/// <param name="database">The database description.</param>
 	/// <param name="leaderNode">The appointed leader.</param>
 	/// <param name="token">The token that can be used to cancel the operation.</param>
 	/// <returns>The task representing asynchronous state of the operation.</returns>
@@ -29,6 +30,7 @@ public interface IDatabaseStateHandler {
 	/// This method implements Leader state logic.
 	/// When it returns, the leadership is over and the node moves to Frozen state.
 	/// </remarks>
+	/// <param name="initial">The initial database description.</param>
 	/// <param name="changes">An infinite sequence of database cluster changes.</param>
 	/// <param name="token">The token that can be used to cancel the operation.</param>
 	/// <returns>The task representing asynchronous state of the operation.</returns>

--- a/src/KurrentDB.DataPlane/DataPlane/LeaderState.cs
+++ b/src/KurrentDB.DataPlane/DataPlane/LeaderState.cs
@@ -30,7 +30,7 @@ internal sealed class LeaderState(IDatabaseStateMachine stateMachine,
 			heartbeatTask = SendHeartbeatsAsync(linkedCts);
 			await stateMachine
 				.DatabaseHandler
-				.RunLeadershipAsync(stateMachine.DatabaseChanges, linkedCts.Token)
+				.RunLeadershipAsync(cluster, stateMachine.DatabaseChanges, linkedCts.Token)
 				.ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext
 				                | ConfigureAwaitOptions.SuppressThrowing);
 

--- a/src/KurrentDB.DataPlane/DataPlane/LeaderState.cs
+++ b/src/KurrentDB.DataPlane/DataPlane/LeaderState.cs
@@ -5,6 +5,7 @@ namespace KurrentDB.DataPlane;
 
 using KontrolPlane;
 
+// Leader, replicating to other nodes.
 internal sealed class LeaderState(IDatabaseStateMachine stateMachine,
 	DatabaseCluster cluster,
 	double renewalRate) : DatabaseState {

--- a/src/KurrentDB.DataPlane/KontrolPlane/Transport/Grpc/GrpcKontrolPlaneClient.Utils.cs
+++ b/src/KurrentDB.DataPlane/KontrolPlane/Transport/Grpc/GrpcKontrolPlaneClient.Utils.cs
@@ -4,7 +4,6 @@
 using System.Collections.Concurrent;
 using System.Net;
 using DotNext;
-using Grpc.Core;
 
 namespace KurrentDB.KontrolPlane.Transport.Grpc;
 
@@ -65,7 +64,7 @@ partial class GrpcKontrolPlaneClient {
 		ClientCacheEntry? entry;
 		do {
 			if (!_clients.TryGetValue(address, out entry)) {
-				var newEntry = CreateClient(address, UnaryCallTimeout);
+				var newEntry = CreateClient(address);
 				entry = _clients.GetOrAdd(address, newEntry);
 				if (!ReferenceEquals(entry, newEntry)) {
 					newEntry.Dispose();
@@ -76,9 +75,8 @@ partial class GrpcKontrolPlaneClient {
 		return entry;
 	}
 
-	private ClientCacheEntry CreateClient(EndPoint address, TimeSpan timeout) {
+	private ClientCacheEntry CreateClient(EndPoint address) {
 		var channel = CreateChannel(address, out var invoker);
-		invoker = new CallInvokerWithUnaryCallTimeout(invoker, timeout);
 		return new(new(invoker), channel);
 	}
 
@@ -138,42 +136,4 @@ partial class GrpcKontrolPlaneClient {
 			base.Dispose(disposing);
 		}
 	}
-}
-
-file sealed class CallInvokerWithUnaryCallTimeout(CallInvoker invoker, TimeSpan timeout) : CallInvoker {
-	public override TResponse BlockingUnaryCall<TRequest, TResponse>(Method<TRequest, TResponse> method,
-		string? host,
-		CallOptions options,
-		TRequest request)
-		=> invoker.BlockingUnaryCall(method,
-			host,
-			options.Deadline is null ? options.WithDeadline(DateTime.UtcNow + timeout) : options,
-			request);
-
-	public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(Method<TRequest, TResponse> method,
-		string? host,
-		CallOptions options,
-		TRequest request)
-		=> invoker.AsyncUnaryCall(method,
-			host,
-			options.Deadline is null ? options.WithDeadline(DateTime.UtcNow + timeout) : options,
-			request);
-
-	public override AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method,
-		string? host,
-		CallOptions options,
-		TRequest request)
-		=> invoker.AsyncServerStreamingCall(method, host, options, request);
-
-	public override AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCall<TRequest, TResponse>(
-		Method<TRequest, TResponse> method,
-		string? host,
-		CallOptions options)
-		=> invoker.AsyncClientStreamingCall(method, host, options);
-
-	public override AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TRequest, TResponse>(
-		Method<TRequest, TResponse> method,
-		string? host,
-		CallOptions options)
-		=> invoker.AsyncDuplexStreamingCall(method, host, options);
 }

--- a/src/KurrentDB.DataPlane/KontrolPlane/Transport/Grpc/GrpcKontrolPlaneClient.cs
+++ b/src/KurrentDB.DataPlane/KontrolPlane/Transport/Grpc/GrpcKontrolPlaneClient.cs
@@ -7,7 +7,6 @@ using DotNext;
 using DotNext.Diagnostics;
 using Google.Protobuf;
 using Grpc.Core;
-using static System.Threading.Timeout;
 
 namespace KurrentDB.KontrolPlane.Transport.Grpc;
 
@@ -22,16 +21,6 @@ public abstract partial class GrpcKontrolPlaneClient : Disposable, IKontrolPlane
 	public required IReadOnlySet<EndPoint> KontrolPlaneNodes {
 		init => _kontrollerNodes = value.Count > 0 ? [.. value] : throw new ArgumentOutOfRangeException(nameof(value));
 	}
-
-	/// <summary>
-	/// Gets or sets timeout for <see cref="RenewLeaderAppointmentAsync"/> or <see cref="ResignLeaderAsync"/> underlying gRPC
-	/// calls.
-	/// </summary>
-	/// <exception cref="ArgumentOutOfRangeException"><paramref name="value"/> is less than or equal to <see cref="TimeSpan.Zero"/>.</exception>
-	public TimeSpan UnaryCallTimeout {
-		get;
-		init => field = value > TimeSpan.Zero ? value : throw new ArgumentOutOfRangeException(nameof(value));
-	} = TimeSpan.FromSeconds(30);
 
 	/// <summary>
 	/// Creates gRPC communication channel.

--- a/src/KurrentDB.DataPlane/KontrolPlane/Transport/Grpc/GrpcKontrolPlaneClient.cs
+++ b/src/KurrentDB.DataPlane/KontrolPlane/Transport/Grpc/GrpcKontrolPlaneClient.cs
@@ -4,6 +4,7 @@
 using System.Net;
 using System.Runtime.CompilerServices;
 using DotNext;
+using DotNext.Diagnostics;
 using Google.Protobuf;
 using Grpc.Core;
 using static System.Threading.Timeout;
@@ -43,9 +44,11 @@ public abstract partial class GrpcKontrolPlaneClient : Disposable, IKontrolPlane
 	/// <inheritdoc cref="IKontrolPlane.AnnounceNodeAsync"/>
 	public async IAsyncEnumerable<KontrolPlane.DatabaseCluster> AnnounceNodeAsync(KontrolPlane.DatabaseNode node, [EnumeratorCancellation] CancellationToken token = default) {
 		for (var currentAddress = _kontrollerNodes[0];; token.ThrowIfCancellationRequested()) {
-			var entry = CreateClient(currentAddress, InfiniteTimeSpan);
+			var start = new Timestamp();
+			var entry = CreateClient(currentAddress);
 
 			var call = entry.Client.AnnounceDatabaseNode(new() { NodeInfo = new(node) }, cancellationToken: token);
+			var redirected = false;
 			try {
 				// Outer loop for reconnections
 				// Inner loop for enumerating database cluster changes
@@ -65,6 +68,7 @@ public abstract partial class GrpcKontrolPlaneClient : Disposable, IKontrolPlane
 					// KPlane informed us about a new KPlane leader, switch to it
 					if (!response.KontrollerLeader.IsEmpty) {
 						currentAddress = response.KontrollerLeader.ToEndPoint();
+						redirected = true;
 						break;
 					}
 
@@ -74,6 +78,11 @@ public abstract partial class GrpcKontrolPlaneClient : Disposable, IKontrolPlane
 				call.Dispose();
 				entry.Release();
 			}
+
+			// the loop normally takes at least connection timeout between iterations, but when connecting
+			// locally the OS bypasses the connection timeout so we have a small delay here as a baseline.
+			if (!redirected && start.ElapsedMilliseconds < 10)
+				await Task.Delay(50, token);
 		}
 	}
 

--- a/src/KurrentDB.KontrolPlane.ObjectModel/CallInvokerWithUnaryCallTimeout.cs
+++ b/src/KurrentDB.KontrolPlane.ObjectModel/CallInvokerWithUnaryCallTimeout.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using Grpc.Core;
+
+namespace KurrentDB;
+
+public static class CallInvokerExtensions {
+	public static CallInvoker WithUnaryTimeout(this CallInvoker self, int timeoutMs) =>
+		WithUnaryTimeout(self, TimeSpan.FromMilliseconds(timeoutMs));
+
+	public static CallInvoker WithUnaryTimeout(this CallInvoker self, TimeSpan timeout) =>
+		new CallInvokerWithUnaryCallTimeout(self, timeout);
+}
+
+file sealed class CallInvokerWithUnaryCallTimeout(CallInvoker invoker, TimeSpan timeout) : CallInvoker {
+	public override TResponse BlockingUnaryCall<TRequest, TResponse>(Method<TRequest, TResponse> method,
+		string? host,
+		CallOptions options,
+		TRequest request)
+		=> invoker.BlockingUnaryCall(method,
+			host,
+			options.Deadline is null ? options.WithDeadline(DateTime.UtcNow + timeout) : options,
+			request);
+
+	public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(Method<TRequest, TResponse> method,
+		string? host,
+		CallOptions options,
+		TRequest request)
+		=> invoker.AsyncUnaryCall(method,
+			host,
+			options.Deadline is null ? options.WithDeadline(DateTime.UtcNow + timeout) : options,
+			request);
+
+	public override AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method,
+		string? host,
+		CallOptions options,
+		TRequest request)
+		=> invoker.AsyncServerStreamingCall(method, host, options, request);
+
+	public override AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCall<TRequest, TResponse>(
+		Method<TRequest, TResponse> method,
+		string? host,
+		CallOptions options)
+		=> invoker.AsyncClientStreamingCall(method, host, options);
+
+	public override AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TRequest, TResponse>(
+		Method<TRequest, TResponse> method,
+		string? host,
+		CallOptions options)
+		=> invoker.AsyncDuplexStreamingCall(method, host, options);
+}

--- a/src/KurrentDB.KontrolPlane.Tests/CallInvokerWithUnaryTimeoutTests.cs
+++ b/src/KurrentDB.KontrolPlane.Tests/CallInvokerWithUnaryTimeoutTests.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Text;
+using Grpc.Core;
+
+namespace KurrentDB.KontrolPlane;
+
+public class CallInvokerWithUnaryTimeoutTests {
+	[Fact]
+	public void a_unary_call_is_given_the_timeout_as_its_deadline() {
+		var inner = new RecordingCallInvoker();
+		var invoker = inner.WithUnaryTimeout(TimeSpan.FromSeconds(30));
+
+		var before = DateTime.UtcNow;
+		invoker.AsyncUnaryCall(UnaryMethod, host: null, new CallOptions(), request: "");
+		var after = DateTime.UtcNow;
+
+		var deadline = Assert.NotNull(inner.LastOptions.Deadline);
+		Assert.InRange(deadline, before.AddSeconds(30), after.AddSeconds(30));
+	}
+
+	[Fact]
+	public void a_deadline_the_caller_asked_for_is_left_alone() {
+		var inner = new RecordingCallInvoker();
+		var invoker = inner.WithUnaryTimeout(TimeSpan.FromSeconds(30));
+		var callersDeadline = DateTime.UtcNow.AddHours(1);
+
+		invoker.AsyncUnaryCall(UnaryMethod, host: null, new CallOptions(deadline: callersDeadline), request: "");
+
+		Assert.Equal(callersDeadline, inner.LastOptions.Deadline);
+	}
+
+	// The announce stream is open for as long as the node is up, so a deadline on it would tear the
+	// stream down on every timeout and the node would stop hearing about its own database.
+	[Fact]
+	public void a_streaming_call_is_not_given_a_deadline() {
+		var inner = new RecordingCallInvoker();
+		var invoker = inner.WithUnaryTimeout(TimeSpan.FromSeconds(30));
+
+		invoker.AsyncServerStreamingCall(StreamingMethod, host: null, new CallOptions(), request: "");
+		Assert.Null(inner.LastOptions.Deadline);
+
+		invoker.AsyncDuplexStreamingCall(DuplexMethod, host: null, new CallOptions());
+		Assert.Null(inner.LastOptions.Deadline);
+
+		invoker.AsyncClientStreamingCall(ClientStreamingMethod, host: null, new CallOptions());
+		Assert.Null(inner.LastOptions.Deadline);
+	}
+
+	private static readonly Marshaller<string> Marshaller = Marshallers.Create(
+		Encoding.UTF8.GetBytes, Encoding.UTF8.GetString);
+
+	private static readonly Method<string, string> UnaryMethod =
+		new(MethodType.Unary, "svc", "unary", Marshaller, Marshaller);
+
+	private static readonly Method<string, string> StreamingMethod =
+		new(MethodType.ServerStreaming, "svc", "serverStreaming", Marshaller, Marshaller);
+
+	private static readonly Method<string, string> DuplexMethod =
+		new(MethodType.DuplexStreaming, "svc", "duplexStreaming", Marshaller, Marshaller);
+
+	private static readonly Method<string, string> ClientStreamingMethod =
+		new(MethodType.ClientStreaming, "svc", "clientStreaming", Marshaller, Marshaller);
+
+	private sealed class RecordingCallInvoker : CallInvoker {
+		public CallOptions LastOptions { get; private set; }
+
+		public override TResponse BlockingUnaryCall<TRequest, TResponse>(
+			Method<TRequest, TResponse> method, string? host, CallOptions options, TRequest request) {
+			LastOptions = options;
+			return default!;
+		}
+
+		public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(
+			Method<TRequest, TResponse> method, string? host, CallOptions options, TRequest request) {
+			LastOptions = options;
+			return new(Task.FromResult<TResponse>(default!), EmptyHeaders, Success, EmptyTrailers, Nothing);
+		}
+
+		public override AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(
+			Method<TRequest, TResponse> method, string? host, CallOptions options, TRequest request) {
+			LastOptions = options;
+			return new(null!, EmptyHeaders, Success, EmptyTrailers, Nothing);
+		}
+
+		public override AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCall<TRequest, TResponse>(
+			Method<TRequest, TResponse> method, string? host, CallOptions options) {
+			LastOptions = options;
+			return new(null!, Task.FromResult<TResponse>(default!), EmptyHeaders, Success, EmptyTrailers, Nothing);
+		}
+
+		public override AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TRequest, TResponse>(
+			Method<TRequest, TResponse> method, string? host, CallOptions options) {
+			LastOptions = options;
+			return new(null!, null!, EmptyHeaders, Success, EmptyTrailers, Nothing);
+		}
+
+		private static Task<Metadata> EmptyHeaders => Task.FromResult(new Metadata());
+		private static Status Success() => Status.DefaultSuccess;
+		private static Metadata EmptyTrailers() => new();
+		private static void Nothing() { }
+	}
+}

--- a/src/KurrentDB.KontrolPlane.Tests/DataPlane/TestDatabaseStateHandler.cs
+++ b/src/KurrentDB.KontrolPlane.Tests/DataPlane/TestDatabaseStateHandler.cs
@@ -32,14 +32,12 @@ internal sealed class TestDatabaseStateHandler(DatabaseNode currentNode, Replica
 		return Task.CompletedTask;
 	}
 
-	async Task IDatabaseStateHandler.RunLeadershipAsync(IAsyncEnumerable<DatabaseCluster> changes, CancellationToken token) {
+	async Task IDatabaseStateHandler.RunLeadershipAsync(DatabaseCluster initial, IAsyncEnumerable<DatabaseCluster> changes, CancellationToken token) {
 		Interlocked.Exchange(ref _leadership, null)?.TrySetResult();
-		await foreach (var snapshot in changes.WithCancellation(token)) {
-			if (snapshot.LeaderNode is { } leaderNode) {
-				_leaderNode = leaderNode;
-				_leaderNodeTracker.TryAdvance();
-				break;
-			}
+
+		if (initial.LeaderNode is { } leaderNode) {
+			_leaderNode = leaderNode;
+			_leaderNodeTracker.TryAdvance();
 		}
 
 		// simulate long-running work

--- a/src/KurrentDB.KontrolPlane/KontrolPlane/Raft/IRaftKontroller.cs
+++ b/src/KurrentDB.KontrolPlane/KontrolPlane/Raft/IRaftKontroller.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+namespace KurrentDB.KontrolPlane.Raft;
+
+/// <summary>
+/// Reporting that is specific to the Raft-based Kontroller
+/// </summary>
+public interface IRaftKontroller : IKontroller {
+	/// <summary>
+	/// Gets this Kontroller's view of the Kontrol Plane cluster, for reporting.
+	/// </summary>
+	KontrollerClusterInfo GetClusterInfo();
+}

--- a/src/KurrentDB.KontrolPlane/KontrolPlane/Raft/KontrollerClusterInfo.cs
+++ b/src/KurrentDB.KontrolPlane/KontrolPlane/Raft/KontrollerClusterInfo.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System.Net;
+using DotNext.IO.Log;
+using DotNext.Net.Cluster;
+using DotNext.Net.Cluster.Consensus.Raft;
+
+namespace KurrentDB.KontrolPlane.Raft;
+
+/// <summary>
+/// One node of the Kontrol Plane's Raft cluster.
+/// </summary>
+/// <remarks>
+/// The members mirror <see cref="IRaftClusterMember"/>, of which this is an inert snapshot.
+/// </remarks>
+public readonly record struct KontrollerNodeInfo(
+	EndPoint EndPoint,
+	bool IsLeader,
+	bool IsRemote,
+	ClusterMemberStatus Status) {
+	public KontrollerNodeInfo(IRaftClusterMember member)
+		: this(member.EndPoint, member.IsLeader, member.IsRemote, member.Status) {
+	}
+}
+
+/// <summary>
+/// One Kontroller's view of the Kontrol Plane cluster.
+/// </summary>
+public readonly record struct KontrollerClusterInfo(
+	long Term,
+	long LastEntryIndex,
+	long LastCommittedEntryIndex,
+	IReadOnlyList<KontrollerNodeInfo> Nodes) {
+	public KontrollerClusterInfo(long term, IAuditTrail log, IEnumerable<IRaftClusterMember> members)
+		: this(term,
+			log.LastEntryIndex,
+			log.LastCommittedEntryIndex,
+			[.. members.Select(static member => new KontrollerNodeInfo(member))]) {
+	}
+}

--- a/src/KurrentDB.KontrolPlane/KontrolPlane/Raft/RaftKontroller.Appointment.cs
+++ b/src/KurrentDB.KontrolPlane/KontrolPlane/Raft/RaftKontroller.Appointment.cs
@@ -178,11 +178,17 @@ partial class RaftKontroller {
 		// Appoint the leader. Use empty cancellation token because AppointLeaderAsync throws NotLeaderException
 		// if the current node is not a leader anymore
 		if (candidate.Address is not null && await _raft.AppointLeaderAsync(databaseId, currentEpoch, candidate.Address, candidate.InstanceId, CancellationToken.None)) {
-			_logger.Information($"DPlane node '{candidate.Address}' with instance id '{candidate.InstanceId}' is appointed as leader for database '{databaseId}'");
+			_logger.Information($"DPlane node '{candidate.Address}' with instance id '{candidate.InstanceId}' is appointed as leader for database '{databaseId}'. Chosen from: {Environment.NewLine}{DescribeCandidates(responses, resignedLeader)}");
 			_appointmentState[databaseId] = new(candidate.Address, currentEpoch, candidate.InstanceId);
 			_state.NotifyDatabaseChanged(databaseId);
 		}
 	}
+
+	private static string DescribeCandidates(IReadOnlyDictionary<EndPoint, ReplicaState> responses, EndPoint? resignedLeader) =>
+		string.Join(Environment.NewLine, responses.Select(pair =>
+			$"{pair.Key} epoch={pair.Value.Epoch} writer={pair.Value.WriterCheckpoint} " +
+			$"chaser={pair.Value.ChaserCheckpoint} priority={pair.Value.Priority}" +
+			(pair.Key.Equals(resignedLeader) ? " (resigned)" : "")));
 
 	private async Task<(IReadOnlyDictionary<EndPoint, ReplicaState> State, ulong MaxEpoch, ulong Epoch)> FenceDatabaseAsync(
 		string databaseId,

--- a/src/KurrentDB.KontrolPlane/KontrolPlane/Raft/RaftKontroller.Impl.cs
+++ b/src/KurrentDB.KontrolPlane/KontrolPlane/Raft/RaftKontroller.Impl.cs
@@ -257,15 +257,14 @@ partial class RaftKontroller : IRaftKontroller, IAsyncEnumerable<EndPoint> {
 		var tokenSource = _multiplexer.Combine(token, _lifecycleToken);
 		try {
 			for (;; tokenSource.Token.ThrowIfCancellationRequested()) {
-				IRaftClusterMember leader = await _raft.WaitForLeaderAsync(InfiniteTimeSpan, tokenSource.Token);
-				KontrollerMetadata metadata;
-
-				try {
-					for (var refreshMetadata = false;
-					     !TryParseMetadata(await leader.GetMetadataAsync(refreshMetadata, tokenSource.Token), out metadata);
-					     refreshMetadata = true) ;
-				} catch {
-					continue;
+				var leader = await _raft.WaitForLeaderAsync(InfiniteTimeSpan, tokenSource.Token);
+				if (!TryParseMetadata(leader, out var metadata)) {
+					try {
+						if (!TryParseMetadata(await leader.GetMetadataAsync(refresh: true, tokenSource.Token), out metadata))
+							continue;
+					} catch {
+						continue;
+					}
 				}
 
 				return GetApiEndPoint(leader.EndPoint, metadata.ApiPort);
@@ -287,14 +286,29 @@ partial class RaftKontroller : IRaftKontroller, IAsyncEnumerable<EndPoint> {
 			.SkipNulls()
 			.GetAsyncEnumerator(token);
 
-		static Task<EndPoint?> GetMemberAddressAsync(IRaftClusterMember member, CancellationToken token)
-			=> member.Status is ClusterMemberStatus.Available ? GetMemberAddressCoreAsync(member, token) : NoEndPointTask;
+		static Task<EndPoint?> GetMemberAddressAsync(RaftClusterMember member, CancellationToken token) {
+			Task<EndPoint?> task;
+			if (TryParseMetadata(member, out var metadata)) {
+				task = Task.FromResult<EndPoint?>(GetApiEndPoint(member.EndPoint, metadata.ApiPort));
+			} else if (member.Status is ClusterMemberStatus.Available) {
+				task = GetMemberAddressCoreAsync(member, token);
+			} else {
+				task = NoEndPointTask;
+			}
 
-		static async Task<EndPoint?> GetMemberAddressCoreAsync(IRaftClusterMember member, CancellationToken token)
-			=> TryParseMetadata(await member.GetMetadataAsync(refresh: false, token),
+			return task;
+		}
+
+		static async Task<EndPoint?> GetMemberAddressCoreAsync(RaftClusterMember member, CancellationToken token)
+			=> TryParseMetadata(await member.GetMetadataAsync(refresh: true, token),
 				out var metadata)
 				? GetApiEndPoint(member.EndPoint, metadata.ApiPort)
 				: null;
+	}
+
+	private static bool TryParseMetadata(RaftClusterMember member, out KontrollerMetadata result) {
+		result = default;
+		return member.TryGetMetadata() is { } metadata && TryParseMetadata(metadata, out result);
 	}
 
 	private static bool TryParseMetadata(IReadOnlyDictionary<string, string> metadata, out KontrollerMetadata result) {

--- a/src/KurrentDB.KontrolPlane/KontrolPlane/Raft/RaftKontroller.Impl.cs
+++ b/src/KurrentDB.KontrolPlane/KontrolPlane/Raft/RaftKontroller.Impl.cs
@@ -16,7 +16,7 @@ using StateMachine;
 using StateMachine.Queries;
 using static StateMachine.LogEntries.ReplicationHelpers;
 
-partial class RaftKontroller : IKontroller, IAsyncEnumerable<EndPoint> {
+partial class RaftKontroller : IRaftKontroller, IAsyncEnumerable<EndPoint> {
 	private static readonly Task<EndPoint?> NoEndPointTask = Task.FromResult<EndPoint?>(null);
 
 	IAsyncEnumerable<EndPoint> IKontroller.Nodes => this;
@@ -278,6 +278,8 @@ partial class RaftKontroller : IKontroller, IAsyncEnumerable<EndPoint> {
 			await tokenSource.DisposeAsync();
 		}
 	}
+
+	public KontrollerClusterInfo GetClusterInfo() => new(_raft.Term, _raft.AuditTrail, _raft.Members);
 
 	IAsyncEnumerator<EndPoint> IAsyncEnumerable<EndPoint>.GetAsyncEnumerator(CancellationToken token) {
 		return Task.WhenEach(_raft.Members.Select(member => GetMemberAddressAsync(member, token)))

--- a/src/KurrentDB.Plugins/Authorization/Operations.cs
+++ b/src/KurrentDB.Plugins/Authorization/Operations.cs
@@ -80,6 +80,16 @@ public static class Operations {
 			public static readonly OperationDefinition ClientRead = new($"{Resource}/client", "read");
 		}
 
+		public static class KontrolPlane {
+			const string Resource = $"{Node.Resource}/kontrolPlane";
+			public static readonly OperationDefinition Access = new(Resource, "access");
+		}
+
+		public static class DataPlane {
+			const string Resource = $"{Node.Resource}/dataPlane";
+			public static readonly OperationDefinition Access = new(Resource, "access");
+		}
+
 		public static class Transform {
 			const string Resource = "transform";
 			public static readonly OperationDefinition Set = new(Resource, "set");

--- a/src/KurrentDB.Transport.Tcp/TcpConnectionSsl.cs
+++ b/src/KurrentDB.Transport.Tcp/TcpConnectionSsl.cs
@@ -153,7 +153,6 @@ public class TcpConnectionSsl : TcpConnectionBase, ITcpConnection {
 		Func<X509Certificate2> serverCertificateSelector,
 		Func<X509Certificate2Collection> intermediatesSelector) {
 		try {
-			var enabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13;
 			var certificate = serverCertificateSelector?.Invoke();
 			var intermediates = intermediatesSelector?.Invoke();
 			Ensure.NotNull(certificate, "certificate");
@@ -162,11 +161,11 @@ public class TcpConnectionSsl : TcpConnectionBase, ITcpConnection {
 				ServerCertificateContext = SslStreamCertificateContext.Create(
 					certificate!, intermediates, offline: true),
 				ClientCertificateRequired = true,
-				EnabledSslProtocols = enabledSslProtocols,
-				CertificateRevocationCheckMode = X509RevocationMode.NoCheck,
+				EnabledSslProtocols = NodeTlsPolicy.PinnedSslProtocols,
+				CertificateRevocationCheckMode = NodeTlsPolicy.CertificateRevocationCheckMode,
 				RemoteCertificateValidationCallback = ValidateClientCertificate,
 				ApplicationProtocols = new List<SslApplicationProtocol>(),
-				AllowRenegotiation = false,
+				AllowRenegotiation = NodeTlsPolicy.AllowRenegotiation,
 			});
 
 			lock (_streamLock) {
@@ -225,9 +224,14 @@ public class TcpConnectionSsl : TcpConnectionBase, ITcpConnection {
 			}
 
 			try {
-				var enabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13;
 				var clientCertificates = clientCertificatesSelector?.Invoke();
-				_sslStream.BeginAuthenticateAsClient(targetHost, clientCertificates, enabledSslProtocols, false, OnEndAuthenticateAsClient, _sslStream);
+				_sslStream.BeginAuthenticateAsClient(
+					targetHost,
+					clientCertificates,
+					NodeTlsPolicy.PinnedSslProtocols,
+					NodeTlsPolicy.CheckCertificateRevocation,
+					OnEndAuthenticateAsClient,
+					_sslStream);
 			} catch (AuthenticationException exc) {
 				Log.Information(exc,
 					"[S{remoteEndPoint}, L{localEndPoint}]: Authentication exception on BeginAuthenticateAsClient.",
@@ -272,22 +276,18 @@ public class TcpConnectionSsl : TcpConnectionBase, ITcpConnection {
 
 	// The following method is invoked by the RemoteCertificateValidationDelegate.
 	public bool ValidateServerCertificate(object sender, X509Certificate certificate, X509Chain chain,
-		SslPolicyErrors sslPolicyErrors) {
-		var (isValid, error) = _serverCertValidator(certificate, chain, sslPolicyErrors, _otherNames);
-		if (!isValid && error != null) {
-			Log.Error("Server certificate validation error: {e}", error);
-		}
-		return isValid;
-	}
+		SslPolicyErrors sslPolicyErrors) =>
+		NodeTlsPolicy
+			.ForServerCertificate(_serverCertValidator, () => _otherNames)
+			.Invoke(sender, certificate, chain, sslPolicyErrors);
 
+	// This serves both the internal replication listener and the public TCP API, so whether a caller
+	// without a certificate is acceptable is left to the validator each of them supplied.
 	public bool ValidateClientCertificate(object sender, X509Certificate certificate, X509Chain chain,
-		SslPolicyErrors sslPolicyErrors) {
-		var (isValid, error) = _clientCertValidator(certificate, chain, sslPolicyErrors);
-		if (!isValid && error != null) {
-			Log.Error("Client certificate validation error: {e}", error);
-		}
-		return isValid;
-	}
+		SslPolicyErrors sslPolicyErrors) =>
+		NodeTlsPolicy
+			.ForClientCertificate(_clientCertValidator)
+			.Invoke(sender, certificate, chain, sslPolicyErrors);
 
 	private void DisplaySslStreamInfo(SslStream stream) {
 		Log.Information("[S{remoteEndPoint}, L{localEndPoint}]", RemoteEndPoint, LocalEndPoint);

--- a/src/KurrentDB/Components/Cluster/Cluster.razor
+++ b/src/KurrentDB/Components/Cluster/Cluster.razor
@@ -61,10 +61,59 @@
 		<MudDivider/>
 		<MudText Typo="Typo.h5" Class="pt-2 pl-2">Cluster status</MudText>
 	</MudItem>
-	@foreach (var member in _clusterInfo?.Members ?? []) {
+	@foreach (var member in SortedMembers) {
 		<MudItem @key="(member.HttpEndPointIp, member.HttpEndPointPort)" Style="flex: 0 0 500px;">
 			<ClusterMember Member="member" IsLocal="IsLocalNode(member)"/>
 		</MudItem>
+	}
+	@if (KontrolPlaneService.IsRaftKontrolPlaneNode) {
+		<MudItem xs="12">
+			<MudDivider/>
+			<MudStack Row="true" AlignItems="AlignItems.Center" Class="pl-2 pt-2">
+				<MudText Typo="Typo.h5">Kontrol Plane status</MudText>
+				@if (_kontrolPlaneInfo is { } info) {
+					<MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">Term @info.Term</MudChip>
+					@* A committed index that stops advancing while the term climbs means the leader
+					   cannot reach a quorum. Both indexes are this node's own. *@
+					<MudTooltip Text="Raft log: entries committed, of entries written.">
+						<MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">
+							Committed @info.LastCommittedEntryIndex of @info.LastEntryIndex
+						</MudChip>
+					</MudTooltip>
+				}
+			</MudStack>
+		</MudItem>
+		@if (IsKontrolPlaneLeader) {
+			// we are the leader and have the full picture. show the node cards.
+			@foreach (var node in SortedKontrolPlaneNodes) {
+				<MudItem @key="node.EndPoint" Style="flex: 0 0 500px;">
+					<KontrollerNode Node="node"/>
+				</MudItem>
+			}
+		}
+		else if (KontrolPlaneLeader is { } kontrolPlaneLeader) {
+			// not the leader but we know who is
+			<MudItem xs="12">
+				@if (KontrolPlaneLeaderUrl is { } kontrolPlaneLeaderUrl) {
+					<MudText Typo="Typo.body2" Class="pl-2">
+						See Kontrol plane
+						<MudLink Href="@kontrolPlaneLeaderUrl" Target="_blank">leader</MudLink>
+						for details.
+					</MudText>
+				} else {
+					// we know who the leader is but not how to reach its UI
+					<MudText Typo="Typo.body2" Class="pl-2">
+						Kontrol plane leader is @kontrolPlaneLeader.EndPoint.
+					</MudText>
+				}
+			</MudItem>
+		} else {
+			<MudItem xs="12">
+				<MudText Typo="Typo.body2" Class="pl-2">
+					No known leader.
+				</MudText>
+			</MudItem>
+		}
 	}
 	<MudItem xs="12">
 		<MudDivider/>

--- a/src/KurrentDB/Components/Cluster/Cluster.razor
+++ b/src/KurrentDB/Components/Cluster/Cluster.razor
@@ -91,21 +91,12 @@
 				</MudItem>
 			}
 		}
-		else if (KontrolPlaneLeader is { } kontrolPlaneLeader) {
+		else if (KontrolPlaneLeaderHost is { } kontrolPlaneLeaderHost) {
 			// not the leader but we know who is
 			<MudItem xs="12">
-				@if (KontrolPlaneLeaderUrl is { } kontrolPlaneLeaderUrl) {
-					<MudText Typo="Typo.body2" Class="pl-2">
-						See Kontrol plane
-						<MudLink Href="@kontrolPlaneLeaderUrl" Target="_blank">leader</MudLink>
-						for details.
-					</MudText>
-				} else {
-					// we know who the leader is but not how to reach its UI
-					<MudText Typo="Typo.body2" Class="pl-2">
-						Kontrol plane leader is @kontrolPlaneLeader.EndPoint.
-					</MudText>
-				}
+				<MudText Typo="Typo.body2" Class="pl-2">
+					See Kontrol plane leader <code>@kontrolPlaneLeaderHost</code> for details.
+				</MudText>
 			</MudItem>
 		} else {
 			<MudItem xs="12">

--- a/src/KurrentDB/Components/Cluster/Cluster.razor.cs
+++ b/src/KurrentDB/Components/Cluster/Cluster.razor.cs
@@ -26,7 +26,6 @@ public sealed partial class Cluster : WithLicense, IDisposable {
 	[Inject] Core.Metrics.InternalExporter InternalExporter { get; set; } = null!;
 	[Inject] ClusterOperationsService ClusterOperationsService { get; set; } = null!;
 	[Inject] KontrolPlaneService KontrolPlaneService { get; set; } = null!;
-	[Inject] NavigationManager Navigation { get; set; } = null!;
 	[Inject] IDialogService DialogService { get; set; } = null!;
 	[Inject] ISnackbar Snackbar { get; set; } = null!;
 	[Inject] IAuthorizationProvider Authorizer { get; set; } = null!;
@@ -132,31 +131,10 @@ public sealed partial class Cluster : WithLicense, IDisposable {
 	// between elections, so it cannot report their status and shows them as Unknown.
 	bool IsKontrolPlaneLeader => KontrolPlaneLeader is { IsRemote: false };
 
-	// A Kontroller is known by its Raft address, while its UI is on the node's HTTP endpoint, so the
-	// two are matched by host through gossip. Deliberately no link when the host does not identify a
-	// single member - guessing a port would send people to the wrong node.
-	string KontrolPlaneLeaderUrl {
-		get {
-			if (KontrolPlaneLeader is not { } leader)
-				return null;
-
-			var host = leader.EndPoint.GetHost();
-			ClientClusterInfo.ClientMemberInfo match = null;
-			foreach (var member in _clusterInfo?.Members ?? []) {
-				if (!string.Equals(member.HttpEndPointIp, host, StringComparison.OrdinalIgnoreCase))
-					continue;
-
-				if (match is not null)
-					return null;
-
-				match = member;
-			}
-
-			return match is null
-				? null
-				: $"{new Uri(Navigation.BaseUri).Scheme}://{match.HttpEndPointIp}:{match.HttpEndPointPort}/ui/cluster";
-		}
-	}
+	// The host only. A Kontroller is known by its Raft address, whose port says nothing about where
+	// its UI is served - and it need not even share a process with a Data Plane node.
+	string KontrolPlaneLeaderHost =>
+		KontrolPlaneLeader is { } leader ? leader.EndPoint.GetHost() : null;
 
 	readonly ChartOptions _options = new() {
 		YAxisLines = false,

--- a/src/KurrentDB/Components/Cluster/Cluster.razor.cs
+++ b/src/KurrentDB/Components/Cluster/Cluster.razor.cs
@@ -2,13 +2,16 @@
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Plugins.Authorization;
 using KurrentDB.Components.Licensed;
+using KurrentDB.Common.Utils;
 using KurrentDB.Core.Cluster;
+using KurrentDB.KontrolPlane.Raft;
 using KurrentDB.Tools;
 using KurrentDB.UI.Theme;
 using Microsoft.AspNetCore.Components;
@@ -22,6 +25,8 @@ public sealed partial class Cluster : WithLicense, IDisposable {
 	[Inject] MonitoringService MonitoringService { get; set; } = null!;
 	[Inject] Core.Metrics.InternalExporter InternalExporter { get; set; } = null!;
 	[Inject] ClusterOperationsService ClusterOperationsService { get; set; } = null!;
+	[Inject] KontrolPlaneService KontrolPlaneService { get; set; } = null!;
+	[Inject] NavigationManager Navigation { get; set; } = null!;
 	[Inject] IDialogService DialogService { get; set; } = null!;
 	[Inject] ISnackbar Snackbar { get; set; } = null!;
 	[Inject] IAuthorizationProvider Authorizer { get; set; } = null!;
@@ -29,6 +34,7 @@ public sealed partial class Cluster : WithLicense, IDisposable {
 	[CascadingParameter] Task<AuthenticationState> AuthenticationState { get; set; }
 
 	ClientClusterInfo _clusterInfo;
+	KontrollerClusterInfo? _kontrolPlaneInfo;
 	Timer _timer;
 	bool _canShutdown;
 	bool _canResign;
@@ -58,6 +64,9 @@ public sealed partial class Cluster : WithLicense, IDisposable {
 		} catch (Exception) {
 			// Gossip timed out or the node is shutting down — keep the last known cluster info.
 		}
+
+		// Local and non-blocking, so it needs no timeout of its own.
+		_kontrolPlaneInfo = KontrolPlaneService.GetClusterInfo();
 	}
 
 	void Callback(object state) {
@@ -87,6 +96,66 @@ public sealed partial class Cluster : WithLicense, IDisposable {
 				// Component/renderer torn down between timer ticks — ignore.
 			}
 		});
+	}
+
+	// Gossip and the Kontroller each report members in whatever order they happen to hold them, which
+	// is not stable between refreshes, so sort both to keep the cards in place.
+	IEnumerable<ClientClusterInfo.ClientMemberInfo> SortedMembers {
+		get {
+			ClientClusterInfo.ClientMemberInfo[] members = _clusterInfo?.Members ?? [];
+			return members
+				.OrderBy(x => x.HttpEndPointIp, StringComparer.OrdinalIgnoreCase)
+				.ThenBy(x => x.HttpEndPointPort);
+		}
+	}
+
+	IEnumerable<KontrollerNodeInfo> SortedKontrolPlaneNodes {
+		get {
+			IReadOnlyList<KontrollerNodeInfo> nodes = _kontrolPlaneInfo?.Nodes ?? [];
+			return nodes
+				.OrderBy(x => x.EndPoint.GetHost(), StringComparer.OrdinalIgnoreCase)
+				.ThenBy(x => x.EndPoint.GetPort());
+		}
+	}
+
+	KontrollerNodeInfo? KontrolPlaneLeader {
+		get {
+			foreach (var node in _kontrolPlaneInfo?.Nodes ?? [])
+				if (node.IsLeader)
+					return node;
+
+			return null;
+		}
+	}
+
+	// Only the Kontrol Plane leader has a complete picture: a follower does not contact its peers
+	// between elections, so it cannot report their status and shows them as Unknown.
+	bool IsKontrolPlaneLeader => KontrolPlaneLeader is { IsRemote: false };
+
+	// A Kontroller is known by its Raft address, while its UI is on the node's HTTP endpoint, so the
+	// two are matched by host through gossip. Deliberately no link when the host does not identify a
+	// single member - guessing a port would send people to the wrong node.
+	string KontrolPlaneLeaderUrl {
+		get {
+			if (KontrolPlaneLeader is not { } leader)
+				return null;
+
+			var host = leader.EndPoint.GetHost();
+			ClientClusterInfo.ClientMemberInfo match = null;
+			foreach (var member in _clusterInfo?.Members ?? []) {
+				if (!string.Equals(member.HttpEndPointIp, host, StringComparison.OrdinalIgnoreCase))
+					continue;
+
+				if (match is not null)
+					return null;
+
+				match = member;
+			}
+
+			return match is null
+				? null
+				: $"{new Uri(Navigation.BaseUri).Scheme}://{match.HttpEndPointIp}:{match.HttpEndPointPort}/ui/cluster";
+		}
 	}
 
 	readonly ChartOptions _options = new() {

--- a/src/KurrentDB/Components/Cluster/KontrolPlaneService.cs
+++ b/src/KurrentDB/Components/Cluster/KontrolPlaneService.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+#nullable enable
+
+using KurrentDB.KontrolPlane;
+using KurrentDB.KontrolPlane.Raft;
+
+namespace KurrentDB.Components.Cluster;
+
+public sealed class KontrolPlaneService(IKontroller? kontroller) {
+	private readonly IRaftKontroller? _raftKontroller = kontroller as IRaftKontroller;
+
+	public bool IsRaftKontrolPlaneNode => _raftKontroller is not null;
+
+	public KontrollerClusterInfo? GetClusterInfo() => _raftKontroller?.GetClusterInfo();
+}

--- a/src/KurrentDB/Components/Cluster/KontrollerNode.razor
+++ b/src/KurrentDB/Components/Cluster/KontrollerNode.razor
@@ -1,0 +1,66 @@
+@* Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements. *@
+@* Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md). *@
+
+@using DotNext.Net.Cluster
+@using KurrentDB.KontrolPlane.Raft
+
+<MudCard Class="ma-2">
+	<MudCardHeader>
+		<CardHeaderAvatar>
+			<MudAvatar Color="@StatusColor">
+				<MudIcon Icon="@StatusIcon" aria-label="@Role"/>
+			</MudAvatar>
+		</CardHeaderAvatar>
+		<CardHeaderContent>
+			<MudText Typo="Typo.h6">@Role</MudText>
+		</CardHeaderContent>
+		<CardHeaderActions>
+			@if (!Node.IsRemote) {
+				<MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="Color.Primary">This node</MudChip>
+			}
+		</CardHeaderActions>
+	</MudCardHeader>
+	<MudCardContent>
+		<MudSimpleTable Dense="true" Elevation="0" Style="background: transparent;">
+			<tbody>
+				<tr>
+					<td class="pl-0">Raft address</td>
+					<td style="text-align:right; font-family: monospace;">@Node.EndPoint</td>
+				</tr>
+				<tr>
+					<td class="pl-0">Status</td>
+					<td style="text-align:right; font-family: monospace;">@Node.Status</td>
+				</tr>
+			</tbody>
+		</MudSimpleTable>
+	</MudCardContent>
+</MudCard>
+
+@code {
+	[Parameter] public KontrollerNodeInfo Node { get; set; }
+
+	// Only a leader is identifiable: a member's own Raft state is not observable from here, so a
+	// reachable node that is not the leader we can see is called a follower without knowing whether it
+	// is in fact a follower or a candidate. A node we cannot reach is not claimed to be anything.
+	string Role => Node.IsLeader
+		? "Leader"
+		: Node.Status switch {
+			ClusterMemberStatus.Available => "Follower",
+			ClusterMemberStatus.Unavailable => "Unreachable",
+			_ => "Unknown",
+		};
+
+	Color StatusColor => Node.Status switch {
+		ClusterMemberStatus.Available => Color.Primary,
+		ClusterMemberStatus.Unavailable => Color.Error,
+		_ => Color.Warning,
+	};
+
+	string StatusIcon => Node.IsLeader
+		? Icons.Material.Filled.FileUpload
+		: Node.Status switch {
+			ClusterMemberStatus.Available => Icons.Material.Filled.FileDownload,
+			ClusterMemberStatus.Unavailable => Icons.Material.Filled.Error,
+			_ => Icons.Material.Filled.Info,
+		};
+}

--- a/src/KurrentDB/KestrelHelpers.cs
+++ b/src/KurrentDB/KestrelHelpers.cs
@@ -4,9 +4,8 @@
 using System;
 using System.IO;
 using System.Net.Security;
-using System.Security.Authentication;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
+using KurrentDB.Common.Utils;
 using KurrentDB.Core;
 using KurrentDB.Core.Services.Transport.Http;
 using Microsoft.AspNetCore.Hosting;
@@ -77,25 +76,19 @@ public static class KestrelHelpers {
 					hostedService.Node.IntermediateCertificatesSelector(),
 					offline: true),
 				ClientCertificateRequired = true, // request a client certificate but it's not necessary for the client to supply one
-				RemoteCertificateValidationCallback = (_, certificate, chain, sslPolicyErrors) => {
-					if (certificate == null) // not necessary to have a client certificate
-						return true;
+				RemoteCertificateValidationCallback = NodeTlsPolicy.ForClientCertificate((certificate, chain, sslPolicyErrors) => {
+					if (certificate is null)
+						return (true, null);
 
-					var (isValid, error) =
-						hostedService.Node.InternalClientCertificateValidator(
-							certificate,
-							chain,
-							sslPolicyErrors);
-					if (!isValid && error != null) {
-						Log.Error("Client certificate validation error: {e}", error);
-					}
-
-					return isValid;
-				},
-				CertificateRevocationCheckMode = X509RevocationMode.NoCheck,
-				EnabledSslProtocols = SslProtocols.None, // let the OS choose a secure TLS protocol
+					return hostedService.Node.InternalClientCertificateValidator(
+						certificate,
+						chain,
+						sslPolicyErrors);
+				}),
+				CertificateRevocationCheckMode = NodeTlsPolicy.CertificateRevocationCheckMode,
+				EnabledSslProtocols = NodeTlsPolicy.SystemSslProtocols,
 				ApplicationProtocols = [SslApplicationProtocol.Http2, SslApplicationProtocol.Http11],
-				AllowRenegotiation = false
+				AllowRenegotiation = NodeTlsPolicy.AllowRenegotiation
 			};
 
 			return ValueTask.FromResult(serverOptions);

--- a/src/KurrentDB/Program.cs
+++ b/src/KurrentDB/Program.cs
@@ -318,6 +318,9 @@ try {
 			builder.Services.AddSingleton<PluginsService>();
 			builder.Services.AddScoped<UserManagementService>();
 			builder.Services.AddScoped<ClusterOperationsService>();
+			// Optional resolution: IKontroller is only registered on a Kontrol Plane node.
+			builder.Services.AddScoped(sp =>
+				new KontrolPlaneService(sp.GetService<KurrentDB.KontrolPlane.IKontroller>()));
 			// Process-wide node-role tracker (subscribes to $mem-node-state); shared by all UI circuits.
 			builder.Services.AddSingleton<KurrentDB.Components.Cluster.GossipMonitor>();
 			builder.Services.AddSingleton<IHostedService>(sp =>

--- a/src/KurrentDB/logconfig.json
+++ b/src/KurrentDB/logconfig.json
@@ -3,6 +3,7 @@
 		"LogLevel": {
 			"Amazon": "Warning",
 			"Default": "Debug",
+			"DotNext.Net.Cluster": "Warning",
 			"KurrentDB.Core.Services.Transport.Enumerators": "Information",
 			"KurrentDB.Projections.Core.Services.Processing.V2": "Information",
 			"Grpc": "Critical",

--- a/src/Protos/Grpc/gossip.proto
+++ b/src/Protos/Grpc/gossip.proto
@@ -4,6 +4,8 @@ option java_package = "com.eventstore.dbclient.proto.gossip";
 
 import "shared.proto";
 
+// This is the client-facing gossip service. The gossip service for use between nodes
+// is defined in cluster.proto
 service Gossip {
 	rpc Read (event_store.client.Empty) returns (ClusterInfo);
 }


### PR DESCRIPTION
This wires up ClusterVNode with Kontrol Plane raft cluster

- In principle the Kontrol Plane nodes and Data Plane nodes can be separate processes and so they are configured separately. At the moment the KPlane runs in the same process as the DataPlane cluster nodes (not RoRs)
- When using KPlane instead of holding our own elections the KPlane appoints a leader (using the same criteria ElectionsService uses) and informs the dataplane
- Using the KPlane disables the Elections service and tweaks the semantics of some of the ClusterVNode states slightly. But Gossip, Replication, Log format, Inauguration manager, etc all stay the same.
- KPlane can be enabled and disabled again safely
- In this version enabling KPlane requires downtime while the nodes restart, in principle it seems possible to do a rolling ugprade but its a bit fiddly.