### PR TITLE
[DB-2209] Bump chunk limit to 600_000

### DIFF
--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -28,7 +28,7 @@
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.452401" />
 		<PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.6" />
-		<PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.30" />
 		<PackageReference Include="DotNext" Version="5.13.0" />
 		<PackageReference Include="DotNext.IO" Version="5.13.0" />
 		<PackageReference Include="DotNext.Threading" Version="5.13.0" />

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
@@ -16,10 +16,10 @@ namespace EventStore.Core.TransactionLog.Chunks;
 public class TFChunkManager {
 	private static readonly ILogger Log = Serilog.Log.ForContext<TFChunkManager>();
 
-	// MaxChunksCount is currently capped at 400,000 since:
+	// MaxChunksCount is currently capped at 600,000 since:
 	// - the chunk file naming strategy supports only up to 6 digits for the chunk number.
 	// - this class uses a fixed size array to keep the chunk list
-	public const int MaxChunksCount = 400_000;
+	public const int MaxChunksCount = 600_000;
 
 	public int ChunksCount {
 		get { return _chunksCount; }


### PR DESCRIPTION
Changed: chunk limit from 400k to 600k