### PR TITLE
[DB-2214] Require the MULTI_NODE_CLUSTER entitlement to run in a cluster

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -79,6 +79,8 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     -  
       name: Docker Compose Smoke Test
+      env:
+        KURRENTDB__LICENSING__LICENSE_KEY: ${{ secrets.KURRENTDB_TEST_LICENSE_KEY }}
       run: |
         RUNTIME=linux-amd64 docker compose build
         docker compose up --detach

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       - KURRENTDB_CERTIFICATE_PRIVATE_KEY_FILE=/etc/kurrentdb/certs/node1/node.key
       - KURRENTDB_ADVERTISE_HOST_TO_CLIENT_AS=127.0.0.1
       - KURRENTDB_ADVERTISE_NODE_PORT_TO_CLIENT_AS=2111
+      - KURRENTDB__LICENSING__LICENSE_KEY
     ports:
       - 2111:2113
     networks:
@@ -62,6 +63,7 @@ services:
       - KURRENTDB_CERTIFICATE_PRIVATE_KEY_FILE=/etc/kurrentdb/certs/node2/node.key
       - KURRENTDB_ADVERTISE_HOST_TO_CLIENT_AS=127.0.0.1
       - KURRENTDB_ADVERTISE_NODE_PORT_TO_CLIENT_AS=2112
+      - KURRENTDB__LICENSING__LICENSE_KEY
     ports:
       - 2112:2113
     networks:
@@ -87,6 +89,7 @@ services:
       - KURRENTDB_CERTIFICATE_PRIVATE_KEY_FILE=/etc/kurrentdb/certs/node3/node.key
       - KURRENTDB_ADVERTISE_HOST_TO_CLIENT_AS=127.0.0.1
       - KURRENTDB_ADVERTISE_NODE_PORT_TO_CLIENT_AS=2113
+      - KURRENTDB__LICENSING__LICENSE_KEY
     ports:
       - 2113:2113
     networks:

--- a/src/KurrentDB.Core.Testing/Helpers/MiniClusterNode.cs
+++ b/src/KurrentDB.Core.Testing/Helpers/MiniClusterNode.cs
@@ -27,6 +27,7 @@ using KurrentDB.Core.Services.Storage.ReaderIndex;
 using KurrentDB.Core.Tests.Http;
 using KurrentDB.Core.Tests.Services.Transport.Tcp;
 using KurrentDB.Core.TransactionLog.Chunks;
+using KurrentDB.Licensing;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
@@ -199,8 +200,10 @@ public class MiniClusterNode<TLogFormat, TStreamId> {
 			[],
 			new OptionsCertificateProvider(),
 			configuration: inMemConf,
-			expiryStrategy,
-			Guid.NewGuid(), debugIndex);
+			licenseProvider: new TestLicenseProvider(MultiNodeClusterLicenseMonitor.Entitlement),
+			expiryStrategy: expiryStrategy,
+			instanceId: Guid.NewGuid(),
+			debugIndex: debugIndex);
 		Node.HttpService.SetupController(new TestController(Node.MainQueue));
 
 		var builder = WebApplication.CreateBuilder();

--- a/src/KurrentDB.Core.Testing/Helpers/TestLicenseProvider.cs
+++ b/src/KurrentDB.Core.Testing/Helpers/TestLicenseProvider.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Reactive.Subjects;
+using EventStore.Plugins.Licensing;
+using KurrentDB.Licensing;
+
+namespace KurrentDB.Core.Tests.Helpers;
+
+public class TestLicenseProvider : ILicenseProvider {
+	public TestLicenseProvider(params string[] entitlements) {
+		var summary = new LicenseSummary(
+			LicenseId: "Test License",
+			Company: "Kurrent, Inc",
+			IsTrial: false,
+			ExpiryUnixTimeSeconds: DateTimeOffset.MaxValue.ToUnixTimeSeconds(),
+			IsValid: true,
+			Notes: "Test License");
+
+		Licenses = new BehaviorSubject<License>(summary.CreateLicense(entitlements));
+	}
+
+	public IObservable<License> Licenses { get; }
+}

--- a/src/KurrentDB.Core.Tests/Configuration/ClusterNodeOptionsTests/ClusterVNodeOptionsScenarios.cs
+++ b/src/KurrentDB.Core.Tests/Configuration/ClusterNodeOptionsTests/ClusterVNodeOptionsScenarios.cs
@@ -12,8 +12,10 @@ using KurrentDB.Core.Authorization.AuthorizationPolicies;
 using KurrentDB.Core.Certificates;
 using KurrentDB.Core.LogAbstraction;
 using KurrentDB.Core.Tests;
+using KurrentDB.Core.Tests.Helpers;
 using KurrentDB.Core.Tests.Services.Transport.Tcp;
 using KurrentDB.Core.Transforms.Identity;
+using KurrentDB.Licensing;
 using NUnit.Framework;
 
 namespace KurrentDB.Core.XUnit.Tests.Configuration.ClusterNodeOptionsTests;
@@ -95,6 +97,7 @@ public abstract class ClusterMemberScenario<TLogFormat, TStreamId> {
 					_options.Application.AllowAnonymousEndpointAccess,
 					_options.Application.AllowAnonymousStreamAccess,
 					_options.Application.OverrideAnonymousEndpointAccessForGossip).Create(c.MainQueue)]))),
+			licenseProvider: new TestLicenseProvider(MultiNodeClusterLicenseMonitor.Entitlement),
 			certificateProvider: new OptionsCertificateProvider());
 
 		_node.Db.TransformManager.LoadTransforms([new IdentityDbTransform()]);

--- a/src/KurrentDB.Core/ClusterVNode.cs
+++ b/src/KurrentDB.Core/ClusterVNode.cs
@@ -108,6 +108,7 @@ public abstract class ClusterVNode {
 		IReadOnlyList<IPersistentSubscriptionConsumerStrategyFactory> factories = null,
 		CertificateProvider certificateProvider = null,
 		IConfiguration configuration = null,
+		ILicenseProvider licenseProvider = null,
 		Guid? instanceId = null,
 		int debugIndex = 0) {
 
@@ -121,6 +122,7 @@ public abstract class ClusterVNode {
 			factories,
 			certificateProvider,
 			configuration,
+			licenseProvider,
 			instanceId: instanceId,
 			debugIndex: debugIndex);
 	}
@@ -246,6 +248,7 @@ public class ClusterVNode<TStreamId> :
 			additionalPersistentSubscriptionConsumerStrategyFactories = null,
 		CertificateProvider certificateProvider = null,
 		IConfiguration configuration = null,
+		ILicenseProvider licenseProvider = null,
 		IExpiryStrategy expiryStrategy = null,
 		Guid? instanceId = null, int debugIndex = 0,
 		Action<IServiceCollection> configureAdditionalNodeServices = null) {
@@ -990,7 +993,7 @@ public class ClusterVNode<TStreamId> :
 		modifiedOptions = modifiedOptions.WithPlugableComponent(new LicensingPlugin(isSingleNode, ex => {
 			Log.Warning("Shutting down due to licensing error: {Message}", ex.Message);
 			MainQueue.Publish(new ClientMessage.RequestShutdown(exitProcess: true, shutdownHttp: true));
-		}));
+		}, licenseProvider));
 
 		var authorizationGateway = new AuthorizationGateway(_authorizationProvider);
 		{

--- a/src/KurrentDB.Licensing.Tests/LicensingPluginTests.cs
+++ b/src/KurrentDB.Licensing.Tests/LicensingPluginTests.cs
@@ -23,9 +23,11 @@ public sealed class LicensingPluginTests : IAsyncLifetime {
 
 	public ValueTask InitializeAsync() => ValueTask.CompletedTask;
 
+	// isSingleNode: these tests are about the /license endpoint, not the multi-node cluster
+	// entitlement check (see MultiNodeClusterLicenseMonitorTests).
 	private static LicensingPlugin CreateUnLicensedSutAsync() {
 		return new LicensingPlugin(
-			isSingleNode: false,
+			isSingleNode: true,
 			ex => { },
 			new AdHocLicenseProvider(new Exception("license is expired, say")));
 	}
@@ -33,7 +35,7 @@ public sealed class LicensingPluginTests : IAsyncLifetime {
 	private static async Task<LicensingPlugin> CreateLicensedSutAsync(Dictionary<string, object> claims) {
 		var license = await License.CreateAsync(claims);
 		return new LicensingPlugin(
-			isSingleNode: false,
+			isSingleNode: true,
 			ex => { },
 			new AdHocLicenseProvider(license));
 	}

--- a/src/KurrentDB.Licensing.Tests/MultiNodeClusterLicenseMonitorTests.cs
+++ b/src/KurrentDB.Licensing.Tests/MultiNodeClusterLicenseMonitorTests.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using System;
+using System.Collections.Generic;
+using System.Reactive.Subjects;
+using System.Threading.Tasks;
+using EventStore.Plugins.Licensing;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace KurrentDB.Licensing.Tests;
+
+// LicenseMonitor itself is covered by LicenseMonitorTests; these cover the only decision this
+// class makes, which is that a single node deployment does not need the entitlement.
+public sealed class MultiNodeClusterLicenseMonitorTests {
+	private static readonly TimeSpan RejectionTimeout = TimeSpan.FromSeconds(10);
+	private static readonly TimeSpan NoRejectionDelay = TimeSpan.FromSeconds(1);
+
+	// Returns the exception the license was rejected with, or null if it was not rejected within the timeout.
+	private static async Task<Exception?> MonitorAsync(
+		bool isSingleNode, FakeLicenseService licenseService, TimeSpan timeout) {
+
+		var sut = new MultiNodeClusterLicenseMonitor(isSingleNode);
+
+		sut.Monitor(licenseService, NullLoggerFactory.Instance);
+
+		var completed = await Task.WhenAny(licenseService.Rejected, Task.Delay(timeout));
+		return completed == licenseService.Rejected ? await licenseService.Rejected : null;
+	}
+
+	[Fact]
+	public async Task given_cluster_when_license_without_entitlement_then_rejects() {
+		Assert.NotNull(await MonitorAsync(
+			isSingleNode: false,
+			new FakeLicenseService("SOME_OTHER_ENTITLEMENT"),
+			RejectionTimeout));
+	}
+
+	[Fact]
+	public async Task given_single_node_when_license_without_entitlement_then_does_not_reject() {
+		Assert.Null(await MonitorAsync(
+			isSingleNode: true,
+			new FakeLicenseService("SOME_OTHER_ENTITLEMENT"),
+			NoRejectionDelay));
+	}
+
+	private class FakeLicenseService : ILicenseService {
+		private readonly TaskCompletionSource<Exception> _rejected = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		public FakeLicenseService(params string[] entitlements) {
+			var claims = new Dictionary<string, object>();
+			foreach (var entitlement in entitlements)
+				claims[entitlement] = "true";
+
+			var license = License.Create(claims);
+
+			SelfLicense = license;
+			CurrentLicense = license;
+			Licenses = new BehaviorSubject<License>(license);
+		}
+
+		public Task<Exception> Rejected => _rejected.Task;
+
+		public License SelfLicense { get; }
+
+		public License? CurrentLicense { get; }
+
+		public IObservable<License> Licenses { get; }
+
+		public void RejectLicense(Exception ex) => _rejected.TrySetResult(ex);
+	}
+}

--- a/src/KurrentDB.Licensing/LicensingPlugin.cs
+++ b/src/KurrentDB.Licensing/LicensingPlugin.cs
@@ -34,6 +34,10 @@ public class LicensingPlugin : Plugin {
 	public override void ConfigureApplication(IApplicationBuilder builder, IConfiguration configuration) {
 		var licenseService = builder.ApplicationServices.GetRequiredService<ILicenseService>();
 
+		new MultiNodeClusterLicenseMonitor(_isSingleNode).Monitor(
+			licenseService,
+			builder.ApplicationServices.GetRequiredService<Microsoft.Extensions.Logging.ILoggerFactory>());
+
 		License? currentLicense = null;
 		Exception? licenseError = null;
 		licenseService.Licenses.Subscribe(

--- a/src/KurrentDB.Licensing/MultiNodeClusterLicenseMonitor.cs
+++ b/src/KurrentDB.Licensing/MultiNodeClusterLicenseMonitor.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Kurrent, Inc and/or licensed to Kurrent, Inc under one or more agreements.
+// Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
+
+using EventStore.Plugins.Licensing;
+using Microsoft.Extensions.Logging;
+
+namespace KurrentDB.Licensing;
+
+public class MultiNodeClusterLicenseMonitor(bool isSingleNode) {
+	public const string FeatureName = "Multi-Node Cluster";
+	public const string Entitlement = "MULTI_NODE_CLUSTER";
+
+	public void Monitor(ILicenseService licenseService, ILoggerFactory loggerFactory) {
+		// A single node deployment does not need a license, but SingleNodeFallbackLicenseProvider only
+		// grants one when no license is available — a valid license that happens to lack this
+		// entitlement flows through untouched, so exempt single nodes here.
+		if (isSingleNode)
+			return;
+
+		_ = LicenseMonitor.MonitorAsync(
+			featureName: FeatureName,
+			requiredEntitlements: [Entitlement],
+			licenseService: licenseService,
+			onLicenseException: licenseService.RejectLicense,
+			logger: loggerFactory.CreateLogger<MultiNodeClusterLicenseMonitor>());
+	}
+}


### PR DESCRIPTION
A node configured to be part of a cluster now needs a license granting the MULTI_NODE_CLUSTER entitlement, and shuts down if it does not have one. Single node deployments are exempt: they are already licensed by SingleNodeFallbackLicenseProvider when no license is available, and a valid license that happens to lack the entitlement must keep working.

MultiNodeClusterLicenseMonitor owns the check and is driven from LicensingPlugin, which already knows whether the node is single node. ClusterVNode gains a licenseProvider parameter so that tests can run nodes configured for a cluster.